### PR TITLE
feat: Installer for sns-quill

### DIFF
--- a/bin/dfx-releases-sns-quill
+++ b/bin/dfx-releases-sns-quill
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+. "$(dirname "$(realpath "$0")")/subcommand"

--- a/bin/dfx-releases-sns-quill-install
+++ b/bin/dfx-releases-sns-quill-install
@@ -13,7 +13,6 @@ source "$(optparse.build)"
 set -euo pipefail
 
 [[ "${QUILL_VERSION:-}" != "latest" ]] || QUILL_VERSION="$(dfx-releases-sns-quill-latest)"
-QUILL_VERSION="${QUILL_VERSION#v}" # change v1.2.3 to 1.2.3 to match download URLs
 
 mkdir -p "$USER_BIN"
 

--- a/bin/dfx-releases-sns-quill-install
+++ b/bin/dfx-releases-sns-quill-install
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+PATH="$SOURCE_DIR:$PATH"
+. "$SOURCE_DIR/versions.bash"
+
+# Source the optparse.bash file ---------------------------------------------------
+source "$SOURCE_DIR/optparse.bash"
+# Define options
+optparse.define short=v long=version desc="The release to install" variable=QUILL_VERSION default="latest"
+optparse.define short=b long=bin desc="Local directory for executables" variable=USER_BIN default="$HOME/.local/bin"
+# Source the output file ----------------------------------------------------------
+source "$(optparse.build)"
+set -euo pipefail
+
+[[ "${QUILL_VERSION:-}" != "latest" ]] || QUILL_VERSION="$(dfx-releases-sns-quill-latest)"
+QUILL_VERSION="${QUILL_VERSION#v}" # change v1.2.3 to 1.2.3 to match download URLs
+
+mkdir -p "$USER_BIN"
+
+OS="$(uname)"
+
+get_url() {
+  case "$OS" in
+  Darwin)
+    echo "https://github.com/dfinity/sns-quill/releases/download/${QUILL_VERSION}/sns-quill-macos-x86_64"
+    ;;
+  Linux)
+    echo "https://github.com/dfinity/sns-quill/releases/download/${QUILL_VERSION}/sns-quill-linux-x86_64"
+    ;;
+  esac
+}
+
+URL="$(get_url)"
+DESTINATION="$USER_BIN/sns-quill"
+TMP_DESTINATION="$(mktemp "$DESTINATION-XXXX")"
+echo "Downloading $URL ..."
+curl -Lf "$URL" >"$TMP_DESTINATION"
+chmod +x "$TMP_DESTINATION"
+mv "$TMP_DESTINATION" "$DESTINATION"
+echo "Installed sns-quill at: $DESTINATION"
+
+CURRENT_QUILL="$(realpath "$(command -v sns-quill 2>/dev/null || true)" || true)"
+[[ "$CURRENT_QUILL" == "$(realpath "$DESTINATION")" ]] || {
+  if test -z "${CURRENT_QUILL:-}"; then
+    echo "Please add this to your PATH: $USER_BIN"
+  else
+    echo "WARNING: You currently have a different sns-quill in your path"
+  fi
+}

--- a/bin/dfx-releases-sns-quill-latest
+++ b/bin/dfx-releases-sns-quill-latest
@@ -10,4 +10,4 @@ source "$SOURCE_DIR/optparse.bash"
 source "$(optparse.build)"
 set -euo pipefail
 
-gh release list --exclude-drafts --limit 1 --repo dfinity/sns-quill | awk '{print $1}'
+gh release list --exclude-drafts --limit 1 --repo dfinity/sns-quill | awk '{print $1}' | sed 's/:.*//g'

--- a/bin/dfx-releases-sns-quill-latest
+++ b/bin/dfx-releases-sns-quill-latest
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+PATH="$SOURCE_DIR:$PATH"
+. "$SOURCE_DIR/versions.bash"
+
+# Source the optparse.bash file ---------------------------------------------------
+source "$SOURCE_DIR/optparse.bash"
+# Define options
+# Source the output file ----------------------------------------------------------
+source "$(optparse.build)"
+set -euo pipefail
+
+gh release list --exclude-drafts --limit 1 --repo dfinity/sns-quill | awk '{print $1}'

--- a/bin/subcommand
+++ b/bin/subcommand
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+PATH="$PATH:$SOURCE_DIR"
 
 PREFIX="$(basename "$(realpath "$0")")"
 if (($# > 0)) && [[ "${1:-}" != "--help" ]] && [[ "${1:-}" != "-h" ]]; then


### PR DESCRIPTION
# Motivation
sns-quill is needed to complete a dsale on the command line.

# Changes
- Add an installer for sns-quill, following the same pattern as the quill installer.