### PR TITLE
fix: More robust check for whether an identity exists

### DIFF
--- a/bin/dfx-ledger-get-icp
+++ b/bin/dfx-ledger-get-icp
@@ -17,7 +17,7 @@ export DFX_NETWORK
 
 # Check whether ident-1 has already been imported as an identity.
 check_moneybags() {
-  dfx identity list 2>/dev/null | grep -qw ident-1
+  dfx identity get-principal --identity ident-1 >/dev/null 2>/dev/null
 }
 # Imports an identity that has a billion toy ICP on testnets.
 make_moneybags() {


### PR DESCRIPTION
# Motivation
The current check for whether an identity is installed is not robust.  In particular, `dfx identity list` does weird stuff with stdout, so that grepping for an identity is not reliable.

# Changes
- Use `dfx identity get-principal` instead to determine whether an identity exists.