### PR TITLE
fix: Add subcommand node for idl2json

### DIFF
--- a/bin/dfx-releases-idl2json
+++ b/bin/dfx-releases-idl2json
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+. "$(dirname "$(realpath "$0")")/subcommand"


### PR DESCRIPTION
# Motivation
There are subcommands for idl2json but they are missing the branch node, so all the subcommands are flattened into the net layer up.

# Changes
- Add `dfx releases idl2json` as a subcommand branch node.