### PR TITLE
fix: nargs shouldn't consume an arg

### DIFF
--- a/bin/optparse.bash
+++ b/bin/optparse.bash
@@ -92,7 +92,7 @@ function optparse.define() {
 	if [ "${nargs:-}" == "" ]; then
 		optparse_contractions="${optparse_contractions}#NL#TB#TB${long}${short:+|${short}})#NL#TB#TB#TB${variable}=\"\$1\"; shift 1;;"
 	elif [ "${nargs:-}" == "0" ]; then
-		optparse_contractions="${optparse_contractions}#NL#TB#TB${long}${short:+|${short}})#NL#TB#TB#TB${variable}=\"true\"; shift 1;;"
+		optparse_contractions="${optparse_contractions}#NL#TB#TB${long}${short:+|${short}})#NL#TB#TB#TB${variable}=\"true\";;"
 	else
 		optparse_contractions="${optparse_contractions}#NL#TB#TB${long}${short:+|${short}})#NL#TB#TB#TB${variable}=(); for ((i=0; i<nargs; i++)); do ${variable}+=( \"\$1\" ); shift 1; done;;"
 	fi
@@ -123,6 +123,8 @@ OPTIONS:
 
         -? --help  :  usage
 
+        --verbose  :  show debug info
+
 XXX
 }
 
@@ -139,6 +141,8 @@ while [ \$# -ne 0 ]; do
                 "-?"|--help)
                         usage
                         exit 0;;
+		--verbose)
+			set -x;;
 		--)
 			break ;;
                 -*)


### PR DESCRIPTION
# Motivation
If nargs is set to zero, a flag should not consume any additional args.  However it was nt so.

# Changes
- Add a `--verbose` flag to aid debugging
- Don't shift when nargs == 0