### PR TITLE
feat: Check that canisters have been imported before trying to create an SNS

### DIFF
--- a/bin/dfx-canister-did-dump
+++ b/bin/dfx-canister-did-dump
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Prints out the candid for a canister interface.
+set -euxo pipefail
+CANISTER_NAME="$1"
+export CANISTER_NAME
+DID_PATH="$(jq -r '.canisters[env.CANISTER_NAME].candid' dfx.json)"
+cat "$DID_PATH"

--- a/bin/dfx-sns-deploy
+++ b/bin/dfx-sns-deploy
@@ -14,7 +14,10 @@ export PATH
 
 export DFX_NETWORK
 
-dfx canister id nns-sns-wasm --network "$DFX_NETWORK" 2>/dev/null || {
+{ # Verifies that the canister ID and did file are known before deploying.
+  dfx canister id nns-sns-wasm --network "$DFX_NETWORK" &&
+    bin/dfx-canister-did-dump nns-sns-wasm
+} >/dev/null 2>/dev/null || {
   echo "Canister dfx-nns-wasm is not defined."
   echo "Please run:"
   echo "    dfx nns import --network-mapping $DFX_NETWORK=local"

--- a/bin/dfx-sns-deploy
+++ b/bin/dfx-sns-deploy
@@ -9,9 +9,17 @@ optparse.define short=c long=config desc="The SNS cofiguration" variable=SNS_CON
 # Source the output file ----------------------------------------------------------
 source "$(optparse.build)"
 set -euo pipefail
+PATH="$PATH:$(dfx cache show)"
+export PATH
 
 export DFX_NETWORK
 
+dfx canister id nns-sns-wasm --network "$DFX_NETWORK" 2>/dev/null || {
+  echo "Canister dfx-nns-wasm is not defined."
+  echo "Please run:"
+  echo "    dfx nns import --network-mapping $DFX_NETWORK=local"
+  exit 1
+} >&2
 set "sns" deploy --network "$DFX_NETWORK" --init-config-file "$SNS_CONFIG"
 echo "${@}"
 "${@}" | tee ,sns-init-response.idl

--- a/dfx.json
+++ b/dfx.json
@@ -5,6 +5,7 @@
       "candid": "candid/nns-cycles-minting.did",
       "remote": {
         "id": {
+          "ic": "rkp4c-7iaaa-aaaaa-aaaca-cai",
           "local": "rkp4c-7iaaa-aaaaa-aaaca-cai"
         }
       },
@@ -16,6 +17,7 @@
       "candid": "candid/nns-genesis-token.did",
       "remote": {
         "id": {
+          "ic": "renrk-eyaaa-aaaaa-aaada-cai",
           "local": "renrk-eyaaa-aaaaa-aaada-cai"
         }
       },
@@ -27,6 +29,7 @@
       "candid": "candid/nns-governance.did",
       "remote": {
         "id": {
+          "ic": "rrkah-fqaaa-aaaaa-aaaaq-cai",
           "local": "rrkah-fqaaa-aaaaa-aaaaq-cai"
         }
       },
@@ -38,6 +41,7 @@
       "candid": "candid/nns-ledger.did",
       "remote": {
         "id": {
+          "ic": "ryjl3-tyaaa-aaaaa-aaaba-cai",
           "local": "ryjl3-tyaaa-aaaaa-aaaba-cai"
         }
       },
@@ -49,6 +53,7 @@
       "candid": "candid/nns-lifeline.did",
       "remote": {
         "id": {
+          "ic": "rno2w-sqaaa-aaaaa-aaacq-cai",
           "local": "rno2w-sqaaa-aaaaa-aaacq-cai"
         }
       },
@@ -60,6 +65,7 @@
       "candid": "candid/nns-registry.did",
       "remote": {
         "id": {
+          "ic": "rwlgt-iiaaa-aaaaa-aaaaa-cai",
           "local": "rwlgt-iiaaa-aaaaa-aaaaa-cai"
         }
       },
@@ -71,6 +77,7 @@
       "candid": "candid/nns-root.did",
       "remote": {
         "id": {
+          "ic": "r7inp-6aaaa-aaaaa-aaabq-cai",
           "local": "r7inp-6aaaa-aaaaa-aaabq-cai"
         }
       },
@@ -108,57 +115,57 @@
     "sns_governance": {
       "build": "",
       "candid": "candid/sns_governance.did",
-      "type": "custom",
-      "wasm": "",
       "remote": {
         "id": {
           "local": "q3fc5-haaaa-aaaaa-aaahq-cai"
         }
-      }
+      },
+      "type": "custom",
+      "wasm": ""
     },
     "sns_index": {
       "build": "",
       "candid": "candid/sns_index.did",
-      "type": "custom",
-      "wasm": "",
       "remote": {
         "id": {
           "local": "si2b5-pyaaa-aaaaa-aaaja-cai"
         }
-      }
+      },
+      "type": "custom",
+      "wasm": ""
     },
     "sns_ledger": {
       "build": "",
       "candid": "candid/sns_ledger.did",
-      "type": "custom",
-      "wasm": "",
       "remote": {
         "id": {
           "local": "sgymv-uiaaa-aaaaa-aaaia-cai"
         }
-      }
+      },
+      "type": "custom",
+      "wasm": ""
     },
     "sns_root": {
       "build": "",
       "candid": "candid/sns_root.did",
-      "type": "custom",
-      "wasm": "",
       "remote": {
         "id": {
           "local": "q4eej-kyaaa-aaaaa-aaaha-cai"
         }
-      }
+      },
+      "type": "custom",
+      "wasm": ""
     },
     "sns_swap": {
       "build": "",
       "candid": "candid/sns_swap.did",
-      "type": "custom",
-      "wasm": "",
       "remote": {
         "id": {
           "local": "sbzkb-zqaaa-aaaaa-aaaiq-cai"
         }
-      }
+      },
+      "type": "custom",
+      "wasm": ""
     }
   },
   "defaults": {


### PR DESCRIPTION
# Motivation
It is easy to create SNS canisters without having imported the nns-sns-wasm canister, but that means that the response is cryptic and canister IDs aren't saved to dfx.json

# Changes 
Check that canisters have been imported before creating SNS canisters.