### PR TITLE
refactor: Rename ic commit

### DIFF
--- a/bin/_template
+++ b/bin/_template
@@ -7,7 +7,7 @@ PATH="$SOURCE_DIR:$PATH"
 source "$SOURCE_DIR/optparse.bash"
 # Define options
 optparse.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
-optparse.define short=c long=ic_commit desc="The IC commit of the wasms" variable=IC_COMMIT default="$IC_COMMIT"
+optparse.define short=c long=ic_commit desc="The IC commit of the wasms" variable=DFX_IC_COMMIT default="$DFX_IC_COMMIT"
 optparse.define short=x long=ic_dir desc="Directory containing the ic source code" variable=IC_REPO_DIR default="$HOME/dfn/ic"
 optparse.define short=y long=nd_dir desc="Directory containing the nns-dapp source code" variable=ND_REPO_DIR default="$HOME/dfn/nns-dapp"
 optparse.define short=i long=identity desc="The dfx identity to use" variable=DFX_IDENTITY default="$(dfx identity whoami)"

--- a/bin/demo-cli
+++ b/bin/demo-cli
@@ -8,7 +8,7 @@ export PATH
 source "$SOURCE_DIR/optparse.bash"
 # Define options
 optparse.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
-optparse.define short=c long=ic_commit desc="The IC commit to use" variable=IC_COMMIT default=""
+optparse.define short=c long=ic_commit desc="The IC commit to use" variable=DFX_IC_COMMIT default=""
 optparse.define short=x long=ic_dir desc="Directory containing the ic source code" variable=IC_REPO_DIR default="$HOME/dfn/ic"
 optparse.define short=y long=nd_dir desc="Directory containing the nns-dapp source code" variable=ND_REPO_DIR default="$HOME/dfn/nns-dapp"
 # Source the output file ----------------------------------------------------------
@@ -19,11 +19,11 @@ cd "$(dirname "$(realpath "$0")")/.."
 demo-cleanup
 
 # If ic-commit is specified, get execuables from there:
-[[ "${IC_COMMIT:-}" != "latest" ]] || IC_COMMIT="$(dfx-software ic latest)"
-[[ "${IC_COMMIT:-}" != "" ]] || IC_COMMIT="$(dfx-software ic current)"
+[[ "${DFX_IC_COMMIT:-}" != "latest" ]] || DFX_IC_COMMIT="$(dfx-software ic latest)"
+[[ "${DFX_IC_COMMIT:-}" != "" ]] || DFX_IC_COMMIT="$(dfx-software ic current)"
 rm -fr "$DEMO_BIN"
-dfx-software ic install-executable --commit "$IC_COMMIT" --bin "$DEMO_BIN" ic-admin sns
-echo "Using binaries from ic commit: $IC_COMMIT"
+dfx-software ic install-executable --commit "$DFX_IC_COMMIT" --bin "$DEMO_BIN" ic-admin sns
+echo "Using binaries from ic commit: $DFX_IC_COMMIT"
 
 ./bin/demo-system-subnet
 
@@ -48,7 +48,7 @@ bin/dfx-neuron-prolong --network "$DFX_NETWORK"
 
 ./bin/dfx-sns-whitelist-me --network "$DFX_NETWORK"
 ./bin/dfx-sns-subnet-add --network "$DFX_NETWORK"
-./bin/dfx-sns-wasm-download --commit "$IC_COMMIT"
+./bin/dfx-sns-wasm-download --commit "$DFX_IC_COMMIT"
 ./bin/dfx-sns-wasm-upload --network "$DFX_NETWORK"
 
 ./bin/demo-mksns --network "$DFX_NETWORK"

--- a/bin/dfx-network-deploy
+++ b/bin/dfx-network-deploy
@@ -6,9 +6,9 @@ PATH="$SOURCE_DIR:$PATH"
 source "$SOURCE_DIR/optparse.bash"
 # Define options
 optparse.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
-optparse.define short=c long=commit desc="The IC commit of the wasms" variable=IC_COMMIT default="$(
+optparse.define short=c long=commit desc="The IC commit of the wasms" variable=DFX_IC_COMMIT default="$(
   . "$SOURCE_DIR/versions.bash"
-  echo "$IC_COMMIT"
+  echo "$DFX_IC_COMMIT"
 )"
 optparse.define short=x long=ic_dir desc="Directory containing the ic source code" variable=IC_REPO_DIR default="$HOME/dfn/ic"
 optparse.define short=y long=nd_dir desc="Directory containing the nns-dapp source code" variable=ND_REPO_DIR default="$HOME/dfn/nns-dapp"

--- a/bin/dfx-network-deploy-config
+++ b/bin/dfx-network-deploy-config
@@ -6,9 +6,9 @@ PATH="$SOURCE_DIR:$PATH"
 source "$SOURCE_DIR/optparse.bash"
 # Define options
 optparse.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
-optparse.define short=c long=commit desc="The IC commit of the wasms" variable=IC_COMMIT default="$(
+optparse.define short=c long=commit desc="The IC commit of the wasms" variable=DFX_IC_COMMIT default="$(
   . "$SOURCE_DIR/versions.bash"
-  echo "$IC_COMMIT"
+  echo "$DFX_IC_COMMIT"
 )"
 optparse.define short=x long=ic_dir desc="Directory containing the ic source code" variable=IC_REPO_DIR default="$HOME/dfn/ic"
 optparse.define short=y long=nd_dir desc="Directory containing the nns-dapp source code" variable=ND_REPO_DIR default="$HOME/dfn/nns-dapp"

--- a/bin/dfx-network-deploy-frontends
+++ b/bin/dfx-network-deploy-frontends
@@ -6,9 +6,9 @@ PATH="$SOURCE_DIR:$PATH"
 source "$SOURCE_DIR/optparse.bash"
 # Define options
 optparse.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
-optparse.define short=c long=commit desc="The IC commit of the wasms" variable=IC_COMMIT default="$(
+optparse.define short=c long=commit desc="The IC commit of the wasms" variable=DFX_IC_COMMIT default="$(
   . "$SOURCE_DIR/versions.bash"
-  echo "$IC_COMMIT"
+  echo "$DFX_IC_COMMIT"
 )"
 optparse.define short=x long=ic_dir desc="Directory containing the ic source code" variable=IC_REPO_DIR default="$HOME/dfn/ic"
 optparse.define short=y long=nd_dir desc="Directory containing the nns-dapp source code" variable=ND_REPO_DIR default="$HOME/dfn/nns-dapp"

--- a/bin/dfx-network-deploy-testnet
+++ b/bin/dfx-network-deploy-testnet
@@ -6,9 +6,9 @@ PATH="$SOURCE_DIR:$PATH"
 source "$SOURCE_DIR/optparse.bash"
 # Define options
 optparse.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
-optparse.define short=c long=commit desc="The IC commit of the wasms" variable=IC_COMMIT default="$(
+optparse.define short=c long=commit desc="The IC commit of the wasms" variable=DFX_IC_COMMIT default="$(
   . "$SOURCE_DIR/versions.bash"
-  echo "$IC_COMMIT"
+  echo "$DFX_IC_COMMIT"
 )"
 optparse.define short=x long=ic_dir desc="Directory containing the ic source code" variable=IC_REPO_DIR default="$HOME/dfn/ic"
 optparse.define short=y long=nd_dir desc="Directory containing the nns-dapp source code" variable=ND_REPO_DIR default="$HOME/dfn/nns-dapp"
@@ -36,14 +36,14 @@ else
     set -euxo pipefail
     echo "Deploying testnet..."
     cd "$IC_REPO_DIR"
-    git checkout "$IC_COMMIT"
+    git checkout "$DFX_IC_COMMIT"
     cat <<-EOF >test-accounts.json
 			{
 			  "init_ledger_accounts":["5b315d2f6702cb3a27d826161797d7b2c2e131cd312aece51d4d5574d1247087", "2b8fbde99de881f695f279d2a892b1137bfe81a42d7694e064b1be58701e1138"]
 			}
 		EOF
 
-    ./testnet/tools/icos_deploy.sh --git-revision "$IC_COMMIT" "$TESTNET" --ansible-args "-e @$PWD/test-accounts.json" || {
+    ./testnet/tools/icos_deploy.sh --git-revision "$DFX_IC_COMMIT" "$TESTNET" --ansible-args "-e @$PWD/test-accounts.json" || {
       echo "Tesnet returned an error code but it returns errors for very minor reasons.  The deployment is probably fine."
     }
     (cd "testnet/env/$TESTNET/" && ./hosts --nns-nodes | awk '{printf "%s http://[%s]:8080\n", $1, $2}')

--- a/bin/dfx-nns-wasm-download
+++ b/bin/dfx-nns-wasm-download
@@ -2,15 +2,15 @@
 set -euo pipefail
 set -x
 
-# Notes regarding the IC_COMMIT - from the build config:
+# Notes regarding the DFX_IC_COMMIT - from the build config:
 # - We apply a patch to customise the code; if you change the hash, please check on the
 #   first run that the patch applies cleanly.  Docker SHOULD fail if it doesn't.
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 DOWNLOAD_DIR="$PWD/wasms"
 NO_CLOBBER=""
-IC_COMMIT="$(
+DFX_IC_COMMIT="$(
   . "$SOURCE_DIR/versions.bash"
-  echo "$IC_COMMIT"
+  echo "$DFX_IC_COMMIT"
 )"
 
 help_text() {
@@ -28,7 +28,7 @@ help_text() {
 		  Default: '$DOWNLOAD_DIR'
 		  The download dir is printed on stdout for use by other programs.
 
-		--commit <IC_COMMIT>
+		--commit <DFX_IC_COMMIT>
 		  Commit in the IC repo.
 		  Note: Not all commits are available as artifacts to download.
 
@@ -55,7 +55,7 @@ while (($# > 0)); do
     shift 1
     ;;
   --ic-commit)
-    IC_COMMIT="$1"
+    DFX_IC_COMMIT="$1"
     shift 1
     ;;
   --no-clobber)
@@ -87,10 +87,10 @@ get_binary() {
   OS="$(uname)"
   case "$OS" in
   Darwin)
-    curl -fL "https://download.dfinity.systems/ic/${IC_COMMIT}/nix-release/x86_64-darwin/${FILENAME}.gz" | gunzip >"$TMP_FILE"
+    curl -fL "https://download.dfinity.systems/ic/${DFX_IC_COMMIT}/nix-release/x86_64-darwin/${FILENAME}.gz" | gunzip >"$TMP_FILE"
     ;;
   Linux)
-    curl -fL "https://download.dfinity.systems/ic/${IC_COMMIT}/release/${FILENAME}.gz" | gunzip >"$TMP_FILE"
+    curl -fL "https://download.dfinity.systems/ic/${DFX_IC_COMMIT}/release/${FILENAME}.gz" | gunzip >"$TMP_FILE"
     ;;
   *)
     printf "ERROR: %s '%s'\n" \
@@ -114,7 +114,7 @@ get_wasm() {
   else
     local TMP_FILE
     TMP_FILE="$(mktemp)"
-    curl "https://download.dfinity.systems/ic/${IC_COMMIT}/canisters/${FILENAME}.gz" | gunzip >"$TMP_FILE"
+    curl "https://download.dfinity.systems/ic/${DFX_IC_COMMIT}/canisters/${FILENAME}.gz" | gunzip >"$TMP_FILE"
     install -m 644 "$TMP_FILE" "$DOWNLOAD_DIR/$FILENAME"
     rm "$TMP_FILE"
   fi

--- a/bin/dfx-sns-sale-finalize
+++ b/bin/dfx-sns-sale-finalize
@@ -7,7 +7,7 @@ PATH="$SOURCE_DIR:$PATH"
 source "$SOURCE_DIR/optparse.bash"
 # Define options
 optparse.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
-optparse.define short=c long=ic_commit desc="The IC commit of the wasms" variable=IC_COMMIT default="$IC_COMMIT"
+optparse.define short=c long=ic_commit desc="The IC commit of the wasms" variable=DFX_IC_COMMIT default="$DFX_IC_COMMIT"
 optparse.define short=x long=ic_dir desc="Directory containing the ic source code" variable=IC_REPO_DIR default="$HOME/dfn/ic"
 optparse.define short=y long=nd_dir desc="Directory containing the nns-dapp source code" variable=ND_REPO_DIR default="$HOME/dfn/nns-dapp"
 optparse.define short=i long=identity desc="The dfx identity to use" variable=DFX_IDENTITY default="$(dfx identity whoami)"

--- a/bin/dfx-sns-wasm-download
+++ b/bin/dfx-sns-wasm-download
@@ -4,17 +4,17 @@ SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 # Source the optparse.bash file ---------------------------------------------------
 source "$SOURCE_DIR/optparse.bash"
 # Define options
-optparse.define short=c long=commit desc="The IC commit of the wasms" variable=IC_COMMIT default="$(
+optparse.define short=c long=commit desc="The IC commit of the wasms" variable=DFX_IC_COMMIT default="$(
   . "$SOURCE_DIR/versions.bash"
-  echo "$IC_COMMIT"
+  echo "$DFX_IC_COMMIT"
 )"
 # Source the output file ----------------------------------------------------------
 source "$(optparse.build)"
 set -euo pipefail
 
-export IC_COMMIT
+export DFX_IC_COMMIT
 
 if [[ "${1:-wasms}" == "wasms" ]]; then
   mkdir -p wasms
-  jq <"$SOURCE_DIR/sns_dfx.json" -r '.canisters | to_entries | map({url: "https://download.dfinity.systems/ic/\(env.IC_COMMIT)/canisters/\(.value.wasm).gz", file: "wasms/\(.value.wasm)"}) | map ("curl -L --fail \(.url) | gunzip > \(.file)") | .[]' | xargs -I{} bash -xc '{}'
+  jq <"$SOURCE_DIR/sns_dfx.json" -r '.canisters | to_entries | map({url: "https://download.dfinity.systems/ic/\(env.DFX_IC_COMMIT)/canisters/\(.value.wasm).gz", file: "wasms/\(.value.wasm)"}) | map ("curl -L --fail \(.url) | gunzip > \(.file)") | .[]' | xargs -I{} bash -xc '{}'
 fi

--- a/bin/dfx-sns-wasm-upload
+++ b/bin/dfx-sns-wasm-upload
@@ -7,9 +7,9 @@ export PATH
 source "$SOURCE_DIR/optparse.bash"
 # Define options
 optparse.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
-optparse.define short=c long=commit desc="The IC commit of the wasms" variable=IC_COMMIT default="$(
+optparse.define short=c long=commit desc="The IC commit of the wasms" variable=DFX_IC_COMMIT default="$(
   . "$SOURCE_DIR/versions.bash"
-  echo "$IC_COMMIT"
+  echo "$DFX_IC_COMMIT"
 )"
 optparse.define short=i long=id desc="The wasm canister id to upload to" variable=SNS_WASM_CANISTER_ID default=''
 # Source the output file ----------------------------------------------------------

--- a/bin/dfx-software-ic-current
+++ b/bin/dfx-software-ic-current
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 . "$SOURCE_DIR/versions.bash"
-echo "$IC_COMMIT"
+echo "$DFX_IC_COMMIT"

--- a/bin/dfx-software-ic-install-executable
+++ b/bin/dfx-software-ic-install-executable
@@ -5,9 +5,9 @@ PATH="$SOURCE_DIR:$PATH"
 # Source the optparse.bash file ---------------------------------------------------
 source "$SOURCE_DIR/optparse.bash"
 # Define options
-optparse.define short=c long=commit desc="The IC commit of the binaries to install" variable=IC_COMMIT default="$(
+optparse.define short=c long=commit desc="The IC commit of the binaries to install" variable=DFX_IC_COMMIT default="$(
   . "$SOURCE_DIR/versions.bash"
-  echo "$IC_COMMIT"
+  echo "$DFX_IC_COMMIT"
 )"
 optparse.define short=b long=bin desc="Diectory in which to install the executeble" variable=USER_BIN default="$HOME/.local/bin"
 # Source the output file ----------------------------------------------------------
@@ -15,10 +15,10 @@ source "$(optparse.build)"
 set -euo pipefail
 
 install_linux() {
-  curl -fL "https://download.dfinity.systems/ic/${IC_COMMIT}/release/${EXEC_NAME}.gz" | gunzip | install -m 755 /dev/stdin "$USER_BIN/$EXEC_NAME"
+  curl -fL "https://download.dfinity.systems/ic/${DFX_IC_COMMIT}/release/${EXEC_NAME}.gz" | gunzip | install -m 755 /dev/stdin "$USER_BIN/$EXEC_NAME"
 }
 install_darwin() {
-  URL="https://download.dfinity.systems/ic/${IC_COMMIT}/nix-release/x86_64-darwin/${EXEC_NAME}.gz"
+  URL="https://download.dfinity.systems/ic/${DFX_IC_COMMIT}/nix-release/x86_64-darwin/${EXEC_NAME}.gz"
   echo "Downloading $URL"
   curl -fL "$URL" | gunzip >"$USER_BIN/$EXEC_NAME"
   chmod +x "$USER_BIN/$EXEC_NAME"
@@ -27,9 +27,9 @@ install_darwin() {
 OS="$(uname | tr '[:upper:]' '[:lower:]')"
 mkdir -p "$USER_BIN"
 
-[[ "${IC_COMMIT}" != "latest" ]] || {
+[[ "${DFX_IC_COMMIT}" != "latest" ]] || {
   echo "Finding the latest commit..."
-  IC_COMMIT="$(dfx-software ic latest)"
+  DFX_IC_COMMIT="$(dfx-software ic latest)"
 }
 
 echo "Installing $*"

--- a/bin/versions.bash
+++ b/bin/versions.bash
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2034 # VAriables are expected to be unused in this file
-IC_COMMIT=45e62436fd1fb209820459667b8b2bcecf14f07a
+DFX_IC_COMMIT=45e62436fd1fb209820459667b8b2bcecf14f07a


### PR DESCRIPTION
# Motivtion
dfx uses `DFX_IC_COMMIT` as the environment variable for the ic commit.  That is consistent with the `DFX_` prefixing and already established.  Why change?

# Changes
- Substitute `DFX_IC_COMMIT` for `IC_COMMIT`