### PR TITLE
fix: Update testnet deployment

### DIFF
--- a/bin/demo-cli
+++ b/bin/demo-cli
@@ -52,6 +52,7 @@ bin/dfx-neuron-prolong --network "$DFX_NETWORK"
 ./bin/dfx-sns-wasm-upload --network "$DFX_NETWORK"
 
 ./bin/demo-mksns --network "$DFX_NETWORK"
+dfx-sns-sale-buy --network "$DFX_NETWORK"
 ./bin/dfx-sns-sale-finalize --network "$DFX_NETWORK"
 
 : "Demo finished!  Hope you enjoyed the show."

--- a/bin/demo-mksns
+++ b/bin/demo-mksns
@@ -25,6 +25,4 @@ dfx canister id sns_swap --network "$DFX_NETWORK"
 
 dfx-sns-sale-propose --network "$DFX_NETWORK"
 
-dfx-sns-sale-buy --network "$DFX_NETWORK"
-
 : "Demo finished!  Hope you enjoyed the show."

--- a/bin/dfx-canister-set-id
+++ b/bin/dfx-canister-set-id
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+PATH="$SOURCE_DIR:$PATH"
+. "$SOURCE_DIR/versions.bash"
+
+# Source the optparse.bash file ---------------------------------------------------
+source "$SOURCE_DIR/optparse.bash"
+# Define options
+optparse.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
+optparse.define short=i long=canister_id desc="The ID of the canister" variable=DFX_CANISTER_ID
+optparse.define short=N long=canister_name desc="The name of the canister" variable=DFX_CANISTER_NAME
+# Source the output file ----------------------------------------------------------
+source "$(optparse.build)"
+set -euo pipefail
+
+export DFX_NETWORK
+export DFX_CANISTER_NAME
+export DFX_CANISTER_ID
+
+if [[ "$DFX_NETWORK" == "local" ]]; then
+  FILENAME=".dfx/local/canister_ids.json"
+else
+  FILENAME="canister_ids.json"
+fi
+
+(
+  set +euo pipefail
+  test -f "$FILENAME" && jq . "$FILENAME" | grep .
+) || {
+  echo "{}" >"$FILENAME"
+}
+
+jq '. * {(env.DFX_CANISTER_NAME): {(env.DFX_NETWORK): (env.DFX_CANISTER_ID)}}' "$FILENAME" | grep . | sponge "$FILENAME"

--- a/bin/dfx-sns-sale-buy
+++ b/bin/dfx-sns-sale-buy
@@ -21,6 +21,17 @@ export DFX_NETWORK
 # Set eth URL used by sns-quill
 IC_URL="$("$SOURCE_DIR/dfx-network-url" --network "$DFX_NETWORK")"
 
-set dfx-sns-quill swap --memo 0 --amount "$AMOUNT"
+set dfx-sns-quill --network "$DFX_NETWORK" swap --memo 0 --amount "$AMOUNT"
 echo "${@}"
-"${@}" | IC_URL="$IC_URL" sns-quill send - --yes
+MESSAGE="$("${@}")"
+test -n "${MESSAGE:-}" || {
+  echo "ERROR: Empty message"
+  exit 1
+} >&2
+
+echo "$MESSAGE" | IC_URL="$IC_URL" sns-quill send - --yes || {
+  echo "ERROR: Failed to send message."
+  echo "Message:"
+  echo "$MESSAGE"
+  exit 1
+}

--- a/bin/dfx-sns-subnet-add
+++ b/bin/dfx-sns-subnet-add
@@ -32,6 +32,7 @@ set "ic-admin" \
   --nns-url "$NNS_URL" \
   "${PEM_ARGS[@]}" \
   propose-to-update-sns-subnet-ids-in-sns-wasm \
+  --summary "Allow SNSs to be deployed to the listed subnets." \
   "${NEURON_ARGS[@]}" \
   $(ic-admin --nns-url "$NNS_URL" get-subnet-list | jq -r 'map("--sns-subnet-ids-to-add " + . + " ") | .[]')
 


### PR DESCRIPTION
# Motivation
Deploying to a different testnet showed some deployment issues.

# Changes
- Fix the way the network is set when swapping SNS tokens
- Add a utility for setting canister IDs, to make the flow the same for testnets and local
- Add a summary to one of the proposals.  this occurred only with the latest `ic_commit` so there has presumably been a change there.
- Move the SNS sale into the main demo so that open SNS's can be created easily.