### PR TITLE
feat: More tools

### DIFF
--- a/bin/dfx-canister-list
+++ b/bin/dfx-canister-list
@@ -1,0 +1,1 @@
+jq -r '.canisters | keys[]' dfx.json

--- a/bin/dfx-identity-list
+++ b/bin/dfx-identity-list
@@ -1,0 +1,5 @@
+
+
+
+# Very annoyingly, dfx identity list doesn't print a list of identities to stdout, when used in a script.
+ls "$HOME/.config/dfx/identity"

--- a/bin/dfx-identity-principal-lookup
+++ b/bin/dfx-identity-principal-lookup
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+PATH="$SOURCE_DIR:$PATH"
+. "$SOURCE_DIR/versions.bash"
+
+# Source the optparse.bash file ---------------------------------------------------
+source "$SOURCE_DIR/optparse.bash"
+# Define options
+optparse.define short=p long=principal desc="The principal to find" variable=PRINCIPAL default="."
+# Source the output file ----------------------------------------------------------
+source "$(optparse.build)"
+
+export DFX_NETWORK
+
+dfx-identity-list | while read -r name; do
+  principal="$(echo "" | dfx identity get-principal --identity "$name" 2>/dev/null)"
+  echo "${principal:-                                                               } $name"
+done | grep -E "${PRINCIPAL:-}"

--- a/bin/dfx-software-internet-identity-latest
+++ b/bin/dfx-software-internet-identity-latest
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+PATH="$SOURCE_DIR:$PATH"
+. "$SOURCE_DIR/versions.bash"
+
+# Source the optparse.bash file ---------------------------------------------------
+source "$SOURCE_DIR/optparse.bash"
+# Define options
+# Source the output file ----------------------------------------------------------
+source "$(optparse.build)"
+set -euo pipefail
+
+gh release list --exclude-drafts --limit 1 --repo dfinity/internet-identity | awk '{print $1}'


### PR DESCRIPTION
# Motivation
More commands that I found myself needing while deploying SNSs.

# Changes
- Added command to get the latest version of internet-identity.
- Added a  command to list canisters
- Added a command to find a principal in the user's identities.  "Ok, so which identity was I using when I deployed that?"