### PR TITLE
feat: Get ii version from mainnet

### DIFF
--- a/bin/dfx-software-idl2json-latest
+++ b/bin/dfx-software-idl2json-latest
@@ -10,4 +10,4 @@ source "$SOURCE_DIR/optparse.bash"
 source "$(optparse.build)"
 set -euo pipefail
 
-gh release list --exclude-drafts --limit 1 --repo dfinity/idl2json | awk '{print $1}'
+gh release list --exclude-drafts --limit 1 --repo dfinity/idl2json | awk '{print $1}' | awk -F: '{print $1}'

--- a/bin/dfx-software-internet-identity-latest
+++ b/bin/dfx-software-internet-identity-latest
@@ -1,13 +1,4 @@
 #!/usr/bin/env bash
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
-. "$SOURCE_DIR/versions.bash"
-
-# Source the optparse.bash file ---------------------------------------------------
-source "$SOURCE_DIR/optparse.bash"
-# Define options
-# Source the output file ----------------------------------------------------------
-source "$(optparse.build)"
-set -euo pipefail
-
-gh release list --exclude-drafts --limit 1 --repo dfinity/internet-identity | awk '{print $1}'
+dfx-software-internet-identity-version --latest

--- a/bin/dfx-software-internet-identity-version
+++ b/bin/dfx-software-internet-identity-version
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+PATH="$SOURCE_DIR:$PATH"
+. "$SOURCE_DIR/versions.bash"
+
+# Source the optparse.bash file ---------------------------------------------------
+source "$SOURCE_DIR/optparse.bash"
+# Define options
+optparse.define short=l long=latest desc="Get the latest version" variable=GET_LATEST nargs=0
+optparse.define short=u long=url desc="Get the version deployed at the given URL" variable=GET_URL
+optparse.define short=m long=mainnet desc="Get the version deployed in production" variable=GET_MAINNET
+optparse.define short=h long=hash desc="Get the version of a given hash" variable=GET_HASH
+# Source the output file ----------------------------------------------------------
+source "$(optparse.build)"
+set -euo pipefail
+
+STRATEGY="${STRATEGY:-${GET_LATEST:+latest}}"
+STRATEGY="${STRATEGY:-${GET_URL:+url}}"
+STRATEGY="${STRATEGY:-${GET_MAINNET:+mainnet}}"
+STRATEGY="${STRATEGY:-${GET_HASH:+hash}}"
+STRATEGY="${STRATEGY:-latest}"
+case "${STRATEGY}" in
+latest)
+  gh release list --exclude-drafts --limit 1 --repo dfinity/internet-identity | awk '{print $1}' | awk -F: '{print $1}'
+  ;;
+mainnet)
+  HASH="$(dfx canister info --network ic rdmx6-jaaaa-aaaaa-aaadq-cai | awk -F: '/Module hash/{print $2}' | tr -d '[[:whitespace:]]')"
+  dfx-software-internet-identity-version --hash "$HASH"
+  ;;
+hash)
+  HASH="$(echo "$GET_HASH" | tr A-Z a-z)"
+  HASH="${HASH#0x}"
+  gh release list --repo dfinity/internet-identity |
+    awk '{print $1}' | awk -F: '{print $1}' |
+    while read line; do
+      if gh release view "$line" --repo dfinity/internet-identity |
+        grep "${HASH}" |
+        sed -En 's,.*(https://github.com/dfinity/internet-identity/releases/download/release-[-0-9a-zA-Z]+/internet_identity[_a-zA-Z0-9]*.wasm).*,\1,g;ta;b;:a;p;q' |
+        grep . >&2; then
+        echo $line
+        break
+      fi
+    done
+  ;;
+*)
+  {
+    echo "ERROR: Unsupported strategy '${STRATEGY:-}'"
+    exit 1
+  } >&2
+  ;;
+esac

--- a/bin/dfx-software-internet-identity-version
+++ b/bin/dfx-software-internet-identity-version
@@ -24,20 +24,20 @@ latest)
   gh release list --exclude-drafts --limit 1 --repo dfinity/internet-identity | awk '{print $1}' | awk -F: '{print $1}'
   ;;
 mainnet)
-  HASH="$(dfx canister info --network ic rdmx6-jaaaa-aaaaa-aaadq-cai | awk -F: '/Module hash/{print $2}' | tr -d '[[:whitespace:]]')"
+  HASH="$(dfx canister info --network ic rdmx6-jaaaa-aaaaa-aaadq-cai | awk -F: '/Module hash/{print $2}' | tr -d '[:whitespace:]')"
   dfx-software-internet-identity-version --hash "$HASH"
   ;;
 hash)
-  HASH="$(echo "$GET_HASH" | tr A-Z a-z)"
+  HASH="$(echo "$GET_HASH" | tr '[:upper:]' '[:lower:]')"
   HASH="${HASH#0x}"
   gh release list --repo dfinity/internet-identity |
     awk '{print $1}' | awk -F: '{print $1}' |
-    while read line; do
+    while read -r line; do
       if gh release view "$line" --repo dfinity/internet-identity |
         grep "${HASH}" |
         sed -En 's,.*(https://github.com/dfinity/internet-identity/releases/download/release-[-0-9a-zA-Z]+/internet_identity[_a-zA-Z0-9]*.wasm).*,\1,g;ta;b;:a;p;q' |
         grep . >&2; then
-        echo $line
+        echo "$line"
         break
       fi
     done

--- a/bin/dfx-software-quill-latest
+++ b/bin/dfx-software-quill-latest
@@ -10,4 +10,4 @@ source "$SOURCE_DIR/optparse.bash"
 source "$(optparse.build)"
 set -euo pipefail
 
-gh release list --exclude-drafts --limit 1 --repo dfinity/quill | awk '{print $1}'
+gh release list --exclude-drafts --limit 1 --repo dfinity/quill | awk '{print $1}' | awk -F: '{print $1}'

--- a/dfx.json
+++ b/dfx.json
@@ -1,5 +1,105 @@
 {
   "canisters": {
+    "nns-cycles-minting": {
+      "build": "",
+      "candid": "candid/nns-cycles-minting.did",
+      "remote": {
+        "id": {
+          "local": "rkp4c-7iaaa-aaaaa-aaaca-cai",
+          "small12": "rkp4c-7iaaa-aaaaa-aaaca-cai"
+        }
+      },
+      "type": "custom",
+      "wasm": ""
+    },
+    "nns-genesis-token": {
+      "build": "",
+      "candid": "candid/nns-genesis-token.did",
+      "remote": {
+        "id": {
+          "local": "renrk-eyaaa-aaaaa-aaada-cai",
+          "small12": "renrk-eyaaa-aaaaa-aaada-cai"
+        }
+      },
+      "type": "custom",
+      "wasm": ""
+    },
+    "nns-governance": {
+      "build": "",
+      "candid": "candid/nns-governance.did",
+      "remote": {
+        "id": {
+          "local": "rrkah-fqaaa-aaaaa-aaaaq-cai",
+          "small12": "rrkah-fqaaa-aaaaa-aaaaq-cai"
+        }
+      },
+      "type": "custom",
+      "wasm": ""
+    },
+    "nns-ledger": {
+      "build": "",
+      "candid": "candid/nns-ledger.did",
+      "remote": {
+        "id": {
+          "local": "ryjl3-tyaaa-aaaaa-aaaba-cai",
+          "small12": "ryjl3-tyaaa-aaaaa-aaaba-cai"
+        }
+      },
+      "type": "custom",
+      "wasm": ""
+    },
+    "nns-lifeline": {
+      "build": "",
+      "candid": "candid/nns-lifeline.did",
+      "remote": {
+        "id": {
+          "local": "rno2w-sqaaa-aaaaa-aaacq-cai",
+          "small12": "rno2w-sqaaa-aaaaa-aaacq-cai"
+        }
+      },
+      "type": "custom",
+      "wasm": ""
+    },
+    "nns-registry": {
+      "build": "",
+      "candid": "candid/nns-registry.did",
+      "remote": {
+        "id": {
+          "local": "rwlgt-iiaaa-aaaaa-aaaaa-cai",
+          "small12": "rwlgt-iiaaa-aaaaa-aaaaa-cai"
+        }
+      },
+      "type": "custom",
+      "wasm": ""
+    },
+    "nns-root": {
+      "build": "",
+      "candid": "candid/nns-root.did",
+      "remote": {
+        "id": {
+          "local": "r7inp-6aaaa-aaaaa-aaabq-cai",
+          "small12": "r7inp-6aaaa-aaaaa-aaabq-cai"
+        }
+      },
+      "type": "custom",
+      "wasm": ""
+    },
+    "nns-sns-wasm": {
+      "build": "",
+      "candid": "candid/nns-sns-wasm.did",
+      "remote": {
+        "id": {
+          "local": "qaa6y-5yaaa-aaaaa-aaafa-cai",
+          "small12": "qaa6y-5yaaa-aaaaa-aaafa-cai"
+        }
+      },
+      "type": "custom",
+      "wasm": ""
+    },
+    "smiley_dapp": {
+      "main": "src/smiley_dapp/main.mo",
+      "type": "motoko"
+    },
     "smiley_dapp_assets": {
       "dependencies": [
         "smiley_dapp"
@@ -13,9 +113,35 @@
       ],
       "type": "assets"
     },
-    "smiley_dapp": {
-      "main": "src/smiley_dapp/main.mo",
-      "type": "motoko"
+    "sns_governance": {
+      "build": "",
+      "candid": "candid/sns_governance.did",
+      "type": "custom",
+      "wasm": ""
+    },
+    "sns_index": {
+      "build": "",
+      "candid": "candid/sns_index.did",
+      "type": "custom",
+      "wasm": ""
+    },
+    "sns_ledger": {
+      "build": "",
+      "candid": "candid/sns_ledger.did",
+      "type": "custom",
+      "wasm": ""
+    },
+    "sns_root": {
+      "build": "",
+      "candid": "candid/sns_root.did",
+      "type": "custom",
+      "wasm": ""
+    },
+    "sns_swap": {
+      "build": "",
+      "candid": "candid/sns_swap.did",
+      "type": "custom",
+      "wasm": ""
     }
   },
   "defaults": {

--- a/dfx.json
+++ b/dfx.json
@@ -1,105 +1,5 @@
 {
   "canisters": {
-    "nns-cycles-minting": {
-      "build": "",
-      "candid": "candid/nns-cycles-minting.did",
-      "remote": {
-        "id": {
-          "local": "rkp4c-7iaaa-aaaaa-aaaca-cai",
-          "small12": "rkp4c-7iaaa-aaaaa-aaaca-cai"
-        }
-      },
-      "type": "custom",
-      "wasm": ""
-    },
-    "nns-genesis-token": {
-      "build": "",
-      "candid": "candid/nns-genesis-token.did",
-      "remote": {
-        "id": {
-          "local": "renrk-eyaaa-aaaaa-aaada-cai",
-          "small12": "renrk-eyaaa-aaaaa-aaada-cai"
-        }
-      },
-      "type": "custom",
-      "wasm": ""
-    },
-    "nns-governance": {
-      "build": "",
-      "candid": "candid/nns-governance.did",
-      "remote": {
-        "id": {
-          "local": "rrkah-fqaaa-aaaaa-aaaaq-cai",
-          "small12": "rrkah-fqaaa-aaaaa-aaaaq-cai"
-        }
-      },
-      "type": "custom",
-      "wasm": ""
-    },
-    "nns-ledger": {
-      "build": "",
-      "candid": "candid/nns-ledger.did",
-      "remote": {
-        "id": {
-          "local": "ryjl3-tyaaa-aaaaa-aaaba-cai",
-          "small12": "ryjl3-tyaaa-aaaaa-aaaba-cai"
-        }
-      },
-      "type": "custom",
-      "wasm": ""
-    },
-    "nns-lifeline": {
-      "build": "",
-      "candid": "candid/nns-lifeline.did",
-      "remote": {
-        "id": {
-          "local": "rno2w-sqaaa-aaaaa-aaacq-cai",
-          "small12": "rno2w-sqaaa-aaaaa-aaacq-cai"
-        }
-      },
-      "type": "custom",
-      "wasm": ""
-    },
-    "nns-registry": {
-      "build": "",
-      "candid": "candid/nns-registry.did",
-      "remote": {
-        "id": {
-          "local": "rwlgt-iiaaa-aaaaa-aaaaa-cai",
-          "small12": "rwlgt-iiaaa-aaaaa-aaaaa-cai"
-        }
-      },
-      "type": "custom",
-      "wasm": ""
-    },
-    "nns-root": {
-      "build": "",
-      "candid": "candid/nns-root.did",
-      "remote": {
-        "id": {
-          "local": "r7inp-6aaaa-aaaaa-aaabq-cai",
-          "small12": "r7inp-6aaaa-aaaaa-aaabq-cai"
-        }
-      },
-      "type": "custom",
-      "wasm": ""
-    },
-    "nns-sns-wasm": {
-      "build": "",
-      "candid": "candid/nns-sns-wasm.did",
-      "remote": {
-        "id": {
-          "local": "qaa6y-5yaaa-aaaaa-aaafa-cai",
-          "small12": "qaa6y-5yaaa-aaaaa-aaafa-cai"
-        }
-      },
-      "type": "custom",
-      "wasm": ""
-    },
-    "smiley_dapp": {
-      "main": "src/smiley_dapp/main.mo",
-      "type": "motoko"
-    },
     "smiley_dapp_assets": {
       "dependencies": [
         "smiley_dapp"
@@ -113,35 +13,9 @@
       ],
       "type": "assets"
     },
-    "sns_governance": {
-      "build": "",
-      "candid": "candid/sns_governance.did",
-      "type": "custom",
-      "wasm": ""
-    },
-    "sns_index": {
-      "build": "",
-      "candid": "candid/sns_index.did",
-      "type": "custom",
-      "wasm": ""
-    },
-    "sns_ledger": {
-      "build": "",
-      "candid": "candid/sns_ledger.did",
-      "type": "custom",
-      "wasm": ""
-    },
-    "sns_root": {
-      "build": "",
-      "candid": "candid/sns_root.did",
-      "type": "custom",
-      "wasm": ""
-    },
-    "sns_swap": {
-      "build": "",
-      "candid": "candid/sns_swap.did",
-      "type": "custom",
-      "wasm": ""
+    "smiley_dapp": {
+      "main": "src/smiley_dapp/main.mo",
+      "type": "motoko"
     }
   },
   "defaults": {


### PR DESCRIPTION
# Motivation
To make testnets that resemble mainnet, it is useful to know the mainnet release version.  It may not be essetial, as it may be possible to download the wasm from mainnet, however we almost certainly want the test version of that release so that we can log in easily.

# Changes
- Make the release parsing more robust
- Scrape II release notes to find the hash released in prod.