### PR TITLE
fix: Support local for network delete

### DIFF
--- a/bin/dfx-network-delete
+++ b/bin/dfx-network-delete
@@ -15,7 +15,9 @@ DELETE_CANISTER_IDS="true"
 DELETE_WALLET="true"
 
 if [[ "$DELETE_CANISTER_IDS" == "true" ]]; then
-  if test -e canister_ids.json; then
+  if [[ "$DFX_NETWORK" == "local" ]]; then
+    rm -f .dfx/local/canister_ids.json
+  elif test -e canister_ids.json; then
     : Back up the canister_ids.json
     cp canister_ids.json "canister_ids.json.$(perl -e 'print time()')"
     echo "Deleting the entries for $DFX_NETWORK in canister_ids.json ..."


### PR DESCRIPTION
# Motivation
`dfx network delete` removes per-network state but p[reviously supported only non-local testnets.

# Changes
- Delete local canister IDs if called for the local testnet.