### PR TITLE
fix: Install jq

### DIFF
--- a/bin/dfx-sns-demo-install
+++ b/bin/dfx-sns-demo-install
@@ -16,6 +16,7 @@ source "$SOURCE_DIR/optparse.bash"
 source "$(optparse.build)"
 set -euo pipefail
 
+dfx-software-jq-install
 dfx-software-more-install
 dfx-software-dfx-install --version 0.12.1
 dfx-software-idl2json-install --version v0.8.5

--- a/bin/dfx-software-jq
+++ b/bin/dfx-software-jq
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+. "$(dirname "$(realpath "$0")")/subcommand"

--- a/bin/dfx-software-jq-install
+++ b/bin/dfx-software-jq-install
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Note: Do mot import optparse as without coreutils it won't wrk on mac.
+set -euo pipefail
+
+install_linux() {
+  sudo apt-get update
+  sudo apt-get install -yy jq
+}
+install_darwin() {
+  brew install jq
+}
+
+OS="$(uname | tr '[:upper:]' '[:lower:]')"
+
+EXEC_NAME="jq"
+if command -v "$EXEC_NAME"; then
+  echo "Nothing to do: $EXEC_NAME is already installed."
+else
+  echo "Installing '$EXEC_NAME' ..."
+  "install_${OS}"
+  echo "Installed '$EXEC_NAME'"
+fi


### PR DESCRIPTION
# Motivation
`jq` is installed by default on CI but not on some developers' M1 macs.  So the demo breaks unnecessarily for them.

# Changes
- Install `jq` as part of the demo setup.
