### PR TITLE
fix: sns-network-config-add fails

### DIFF
--- a/bin/dfx-network-config-add
+++ b/bin/dfx-network-config-add
@@ -14,7 +14,11 @@ set -euo pipefail
 
 export DFX_NETWORK
 
-DFX_NEWTORK_CONFIG_PATH="$(dfx-network-config-path)"
+DFX_NETWORK_CONFIG_PATH="$(dfx-network-config-path)"
+jq . "$DFX_NETWORK_CONFIG_PATH" >/dev/null 2>/dev/null || {
+  mkdir -p "$(dirname "$DFX_NETWORK_CONFIG_PATH")"
+  echo "{}" >"$DFX_NETWORK_CONFIG_PATH"
+}
 PROVIDERS="$(cd "$IC_REPO_DIR/testnet/env/$DFX_NETWORK/" && ./hosts --nns-nodes | awk '{printf "http://[%s]:8080\n", $2}' | jq --raw-input --slurp 'split("\n") | map(select(. != ""))')"
 NEW_ENTRY="$(mktemp)"
 cat <<EOF >"$NEW_ENTRY"
@@ -26,6 +30,6 @@ cat <<EOF >"$NEW_ENTRY"
 }
 EOF
 
-jq -s '.[0] * .[1]' "$DFX_NEWTORK_CONFIG_PATH" "$NEW_ENTRY" | sponge "$DFX_NEWTORK_CONFIG_PATH"
+jq -s '.[0] * .[1]' "$DFX_NETWORK_CONFIG_PATH" "$NEW_ENTRY" | sponge "$DFX_NETWORK_CONFIG_PATH"
 
 rm "$NEW_ENTRY"

--- a/bin/subcommand
+++ b/bin/subcommand
@@ -6,24 +6,34 @@ PATH="$PATH:$SOURCE_DIR"
 PREFIX="$(basename "$(realpath "$0")")"
 
 print_subcommands() {
-	find $(echo "$PATH" | tr ":" " ") -maxdepth 1 -type f -executable 2>/dev/null | awk -F/ '{print $(NF)}' | sort | uniq | awk -vprefix="$PREFIX" '($0 ~ "^" prefix "-"){ if ($0 ~ "^" last "-") { next } ; last=$0 ; print substr($0, length(prefix)+2) }'
+  # If the current command name is abc-de then we look for executables that start with abc-de- such as abc-de-fgh-ij and return "fgh-ij" as a subcommand.
+  # We do not, however, return sub-subcommands.  E.g. if there is also abc-de-fgh-ij-klmno we disregard it.  This is implemented by sorting and filtering out executables
+  # that look like sub-sub-commands of earlier sub-commands:
+  #
+  #   abc-de <- current executable
+  #   abc-de-fgh-ij <-- subcommand
+  #   abc-de-fgh-ij-klmno <- ignored
+  #   abc-de-fgh-ij-pq <---- ignored
+  #   abc-de-fgh-rs <-- subcommand
+  # shellcheck disable=SC2046
+  # shellcheck disable=SC2086 # we really do want to split PATH into separate arguments.
+  find $(echo "$PATH" | tr ":" " ") -maxdepth 1 -type f -executable 2>/dev/null | awk -F/ '{print $(NF)}' | sort | uniq | awk -vprefix="$PREFIX" '($0 ~ "^" prefix "-"){ if ($0 ~ "^" last "-") { next } ; last=$0 ; print substr($0, length(prefix)+2) }'
 }
 
 # Autocomplete?
 [[ "${COMP_LINE:-}" == "" ]] || [[ "${COMP_POINT:-}" == "" ]] || {
-	SUBCOMMAND_DEPTH="${SUBCOMMAND_DEPTH:-1}"
-	read -r -a COMP_WORDS <<< "$COMP_LINE"
-	# Only complete if the cursor is at the end of the line.
-	(( ${#COMP_LINE} == COMP_POINT )) || exit 0
-	# If the subcommand is incomplete, complete that, else delegate to the subcommand.
-	if (( ${#COMP_WORDS[@]} == SUBCOMMAND_DEPTH )) || ( (( ${#COMP_WORDS[@]} == SUBCOMMAND_DEPTH +1 )) && [[ ${COMP_LINE% } == ${COMP_LINE} ]] )
-	then
-		compgen -W "$(print_subcommands)" -- "${COMP_WORDS[$SUBCOMMAND_DEPTH]:-}"
-	else
-		SUBCOMMAND="${COMP_WORDS[$SUBCOMMAND_DEPTH]:-}"
-		SUBCOMMAND_DEPTH="$((SUBCOMMAND_DEPTH + 1))" "$PREFIX-$SUBCOMMAND" "${@}"
-	fi
-        exit 0
+  SUBCOMMAND_DEPTH="${SUBCOMMAND_DEPTH:-1}"
+  read -r -a COMP_WORDS <<<"$COMP_LINE"
+  # Only complete if the cursor is at the end of the line.
+  ((${#COMP_LINE} == COMP_POINT)) || exit 0
+  # If the subcommand is incomplete, complete that, else delegate to the subcommand.
+  if ((${#COMP_WORDS[@]} == SUBCOMMAND_DEPTH)) || ( ((${#COMP_WORDS[@]} == SUBCOMMAND_DEPTH + 1)) && [[ "${COMP_LINE% }" == "${COMP_LINE}" ]]); then
+    compgen -W "$(print_subcommands)" -- "${COMP_WORDS[$SUBCOMMAND_DEPTH]:-}"
+  else
+    SUBCOMMAND="${COMP_WORDS[$SUBCOMMAND_DEPTH]:-}"
+    SUBCOMMAND_DEPTH="$((SUBCOMMAND_DEPTH + 1))" "$PREFIX-$SUBCOMMAND" "${@}"
+  fi
+  exit 0
 }
 
 if (($# > 0)) && [[ "${1:-}" != "--help" ]] && [[ "${1:-}" != "-h" ]]; then
@@ -40,16 +50,5 @@ if (($# > 0)) && [[ "${1:-}" != "--help" ]] && [[ "${1:-}" != "-h" ]]; then
   fi
 else
   echo Subcommands:
-  # If the current command name is abc-de then we look for executables that start with abc-de- such as abc-de-fgh-ij and return "fgh-ij" as a subcommand.
-  # We do not, however, return sub-subcommands.  E.g. if there is also abc-de-fgh-ij-klmno we disregard it.  This is implemented by sorting and filtering out executables
-  # that look like sub-sub-commands of earlier sub-commands:
-  #
-  #   abc-de <- current executable
-  #   abc-de-fgh-ij <-- subcommand
-  #   abc-de-fgh-ij-klmno <- ignored
-  #   abc-de-fgh-ij-pq <---- ignored
-  #   abc-de-fgh-rs <-- subcommand
-  # shellcheck disable=SC2046
-  # shellcheck disable=SC2086 # we really do want to split PATH into separate arguments.
   print_subcommands
 fi


### PR DESCRIPTION
# Motivation
If run on a machine with no existing config file, the network config add command would fail.

# Changes
- If the config is missing or invalid, replace it with a blank config.
- Fix linter issues

# Tests
- This has no new features so should not require additional tests.