### PR TITLE
fix: Set default when getting icp

### DIFF
--- a/bin/dfx-ledger-get-icp
+++ b/bin/dfx-ledger-get-icp
@@ -8,7 +8,7 @@ source "$SOURCE_DIR/optparse.bash"
 #optparse.define short=a long=account desc="The dfx account requesting the funds" variable=account default="$(dfx identity whoami)"
 optparse.define short=i long=icp desc="The amount of ICP to request" variable=AMOUNT default="10"
 optparse.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
-optparse.define short=t long=to desc="Top up to the given value, if needed" variable=IF_NEEDED nargs=0
+optparse.define short=t long=to desc="Top up to the given value, if needed" variable=IF_NEEDED nargs=0 default=""
 # Source the output file ----------------------------------------------------------
 source "$(optparse.build)"
 set -euo pipefail


### PR DESCRIPTION
# Motivation
The default is not set for one of the variables.  This can cause incorrect behaviour.