### PR TITLE
Fix word in printout

### DIFF
--- a/bin/dfx-software-dfx-install
+++ b/bin/dfx-software-dfx-install
@@ -15,7 +15,7 @@ set -euo pipefail
 DFX_VERSION="${DFX_VERSION#v}"
 
 if command -v dfx && [[ "$(dfx --version | awk '{print $2}')" == "${DFX_VERSION:-}" ]]; then
-  echo "quill v$DFX_VERSION already installed.  Nothing to do."
+  echo "dfx v$DFX_VERSION already installed.  Nothing to do."
   exit 0
 fi
 


### PR DESCRIPTION
# Motivation
There is an error in one printout by the dfx installer, where quill is mentioned instead of dfx.