### PR TITLE
New static testnets are slow

### DIFF
--- a/bin/dfx-sns-demo
+++ b/bin/dfx-sns-demo
@@ -42,31 +42,49 @@ export DFX_IC_COMMIT
   exit 1
 } >&2
 
+sleep 1
 dfx-network-deploy --network "$DFX_NETWORK" --ic_dir "$IC_REPO_DIR" --nd_dir "$ND_REPO_DIR" --commit "$DFX_IC_COMMIT"
 
 # dfx nns import --network-mapping "$DFX_NETWORK=mainnet"
 # The above does NOT include nns-sns-wasm.  So import for local (which does include the canister????) and then copy to the requested network.
 # dfx nns import
 # jq '.*(.canisters | to_entries | map(select(.key | startswith("nns-")) | .value.remote.id[env.DFX_NETWORK] = .value.remote.id.local) |from_entries | {canisters:.})' dfx.json | sponge dfx.json
+sleep 1
 dfx nns import --network-mapping "$DFX_NETWORK=local"
+sleep 1
 dfx sns import
+sleep 1
 
 rm -fr "$HOME/.config/dfx/identity/snsdemo8"
+sleep 1
 dfx identity new --disable-encryption snsdemo8
+sleep 1
 dfx identity use snsdemo8
+sleep 1
 
 bin/dfx-ledger-get-icp --icp 900000000 --network "$DFX_NETWORK"
+sleep 1
 dfx ledger balance --network "$DFX_NETWORK"
+sleep 1
 bin/dfx-neuron-create --icp 500000000 --network "$DFX_NETWORK"
+sleep 1
 bin/dfx-neuron-prolong --network "$DFX_NETWORK"
+sleep 1
 
 ./bin/dfx-sns-whitelist-me --network "$DFX_NETWORK"
+sleep 1
 ./bin/dfx-sns-subnet-add --network "$DFX_NETWORK"
+sleep 1
 ./bin/dfx-sns-wasm-download --commit "$DFX_IC_COMMIT"
+sleep 1
 ./bin/dfx-sns-wasm-upload --network "$DFX_NETWORK"
+sleep 1
 
 ./bin/dfx-sns-demo-mksns --network "$DFX_NETWORK"
+sleep 1
 dfx-sns-sale-buy --network "$DFX_NETWORK"
+sleep 1
 ./bin/dfx-sns-sale-finalize --network "$DFX_NETWORK"
+sleep 1
 
 : "Demo finished!  Hope you enjoyed the show."

--- a/bin/versions.bash
+++ b/bin/versions.bash
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2034 # VAriables are expected to be unused in this file
-DFX_IC_COMMIT=14a1e25580baad292c0b714de2427e2eb9922e3c
+DFX_IC_COMMIT=b5a1a8c0e005216f2d945f538fc27163bafc3bf7


### PR DESCRIPTION
# Motivation
New static testnets are slow and give errors if run too quickly.

# Changes
Sleep between commands