### PR TITLE
feat: Bump the version of dfx to (a) 13

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -24,6 +24,6 @@
       "packtool": ""
     }
   },
-  "dfx": "0.12.1",
+  "dfx": "0.13.0-downgrade.1",
   "version": 1
 }

--- a/dfx.json.original
+++ b/dfx.json.original
@@ -24,6 +24,6 @@
       "packtool": ""
     }
   },
-  "dfx": "0.12.1",
+  "dfx": "0.13.0-downgrade.1",
   "version": 1
 }


### PR DESCRIPTION
# Motivation
dfx v 13 is needed for some use cases.  However dfx v 0.13.0 is not statically linked and breaks on development servers, so we have held back.  There is now a build that works on dev servers.  Let's use it.