### PR TITLE
Bump ic_commit to end Jan

### DIFF
--- a/bin/dfx-network-deploy
+++ b/bin/dfx-network-deploy
@@ -42,7 +42,7 @@ if [[ "$DFX_NETWORK" == "local" ]]; then
     rm "$tempfile"
   }
   : "Get the specified version of the nns-sns-wasm.wasm"
-  curl "https://download.dfinity.systems/ic/${DFX_IC_COMMIT}/canisters/sns-wasm-canister.wasm.gz" | gunzip > "${WASM_DIR}/sns-wasm-canister.wasm"
+  curl "https://download.dfinity.systems/ic/${DFX_IC_COMMIT}/canisters/sns-wasm-canister.wasm.gz" | gunzip >"${WASM_DIR}/sns-wasm-canister.wasm"
 
   dfx start --clean --background
   dfx nns install

--- a/bin/dfx-network-deploy
+++ b/bin/dfx-network-deploy
@@ -41,6 +41,8 @@ if [[ "$DFX_NETWORK" == "local" ]]; then
     cp "$tempfile" "$WASM_DIR/internet_identity_dev.wasm"
     rm "$tempfile"
   }
+  : "Get the specified version of the nns-sns-wasm.wasm"
+  curl "https://download.dfinity.systems/ic/${DFX_IC_COMMIT}/canisters/sns-wasm-canister.wasm.gz" | gunzip > "${WASM_DIR}/sns-wasm-canister.wasm"
 
   dfx start --clean --background
   dfx nns install

--- a/bin/dfx-network-deploy
+++ b/bin/dfx-network-deploy
@@ -31,11 +31,11 @@ if [[ "$DFX_NETWORK" == "local" ]]; then
   dfx-network-stop --network "$DFX_NETWORK"
   export DFX_IC_COMMIT
   WASM_DIR="$(dfx cache show)/wasms"
+  mkdir -p "$WASM_DIR"
   : "Get the specified version of II, if requested."
   : "Note: This does clobber the version in the global cache, which is not really OK but there is no other option at the moment."
   test -z "${DFX_II_RELEASE:-}" || {
     II_WASM_URL="$(dfx-software-internet-identity-ci-wasm-url --release "${DFX_II_RELEASE}")"
-    mkdir -p "$WASM_DIR"
     tempfile="$(mktemp ii-wasm-XXXXXX)"
     curl -sL --fail "$II_WASM_URL" >"$tempfile"
     cp "$tempfile" "$WASM_DIR/internet_identity_dev.wasm"

--- a/bin/dfx-network-deploy
+++ b/bin/dfx-network-deploy
@@ -31,6 +31,7 @@ if [[ "$DFX_NETWORK" == "local" ]]; then
   dfx-network-stop --network "$DFX_NETWORK"
   export DFX_IC_COMMIT
   WASM_DIR="$(dfx cache show)/wasms"
+  test -d "$(dfx cache show)" || dfx cache install
   mkdir -p "$WASM_DIR"
   : "Get the specified version of II, if requested."
   : "Note: This does clobber the version in the global cache, which is not really OK but there is no other option at the moment."

--- a/bin/versions.bash
+++ b/bin/versions.bash
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2034 # VAriables are expected to be unused in this file
-DFX_IC_COMMIT=b5a1a8c0e005216f2d945f538fc27163bafc3bf7
+DFX_IC_COMMIT=08807e6c49348791dc6cad016a565f3882ec4ad6


### PR DESCRIPTION
# Motivation
Bumping the ic_commit was held back by a parse error.  That was caused by the wasms canister needing to be updated; previously the stock version worked fine and changes were in the SNS canisters themselves.