### PR TITLE
Find first ic commit published after the given one

### DIFF
--- a/bin/dfx-software-ic-latest
+++ b/bin/dfx-software-ic-latest
@@ -44,7 +44,7 @@ function disk_image_exists() {
   else
     IC_COMMIT="$(git rev-parse origin/master)"
   fi
-  if test -n "${IC_COMMIT_AFTER}"; then
+  if test -n "${IC_COMMIT_AFTER:-}"; then
     git log --format=format:%H --reverse "${IC_COMMIT}...origin/master" | sed 1d
   else
     git log --format=format:%H "$IC_COMMIT"

--- a/bin/dfx-software-ic-latest
+++ b/bin/dfx-software-ic-latest
@@ -6,6 +6,7 @@ source "$SOURCE_DIR/optparse.bash"
 # Define options
 optparse.define short=x long=ic_dir desc="Directory containing the ic source code" variable=IC_REPO_DIR default="$HOME/dfn/ic"
 optparse.define short=b long=before desc="Latest published commit before the given one" variable=IC_COMMIT_BEFORE default=""
+optparse.define short=a long=after desc="First published commit after the given one" variable=IC_COMMIT_AFTER default=""
 # Source the output file ----------------------------------------------------------
 source "$(optparse.build)"
 set -eu # No pipefail
@@ -38,8 +39,14 @@ function disk_image_exists() {
   git fetch
   if test -n "${IC_COMMIT_BEFORE:-}"; then
     IC_COMMIT="$(git log --pretty=%P -n 1 "$IC_COMMIT_BEFORE" | awk '{print $(NF)}')"
+  elif test -n "${IC_COMMIT_AFTER:-}"; then
+    IC_COMMIT="$IC_COMMIT_AFTER"
   else
     IC_COMMIT="$(git rev-parse origin/master)"
   fi
-  git log --format=format:%H "$IC_COMMIT"
+  if test -n "${IC_COMMIT_AFTER}"; then
+    git log --format=format:%H --reverse "${IC_COMMIT}...origin/master" | sed 1d
+  else
+    git log --format=format:%H "$IC_COMMIT"
+  fi
 ) | while read -r GIT_REVISION; do disk_image_exists && echo "$GIT_REVISION" && break; done


### PR DESCRIPTION
# Motivation
Sometimes we need an IC release containing a given commit.

# Changes
* Support `dfx-software-ic-latest --after <COMMIT>`  The "latest" is a bit of a misnomer in this context but I think that's OK.  The user is explicitly choosing to search in reverse.