### PR TITLE
Update identity flag

### DIFF
--- a/bin/dfx-ledger-get-icp
+++ b/bin/dfx-ledger-get-icp
@@ -32,7 +32,7 @@ oUQDQgAEPas6Iag4TUx+Uop+3NhE6s3FlayFtbwdhRVjvOar0kPTfE/N8N6btRnd
 74ly5xXEBNSXiENyxhEuzOZrIWMCNQ==
 -----END EC PRIVATE KEY-----
 EOF
-      dfx identity import ident-1 ident-1.pem --disable-encryption
+      dfx identity import ident-1 ident-1.pem --storage-mode=plaintext
     } && check_moneybags
   )
 }

--- a/bin/dfx-sns-demo
+++ b/bin/dfx-sns-demo
@@ -45,7 +45,7 @@ export DFX_IC_COMMIT
 sleep 1
 rm -fr "$HOME/.config/dfx/identity/snsdemo8"
 sleep 1
-dfx identity new --disable-encryption snsdemo8
+dfx identity new --storage-mode=plaintext snsdemo8
 sleep 1
 dfx identity use snsdemo8
 sleep 1


### PR DESCRIPTION
# Motivation
The flag `--disable-encryption` is now deprecated and superseded by `--storage-mode=plaintext`.