### PR TITLE
Fix typos, realpath, openssl static linking

### DIFF
--- a/bin/dfx-neuron-create
+++ b/bin/dfx-neuron-create
@@ -52,7 +52,7 @@ test -n "${NEURON_TEXT:-}" || {
 } >&2
 NEURON_ID="$(echo "$NEURON_TEXT" | tr -cd '[:alnum:]')"
 test -n "${NEURON_ID:-}" || {
-  echo "Failed to get nuron ID from line: $NEURON_TEXT"
+  echo "Failed to get neuron ID from line: $NEURON_TEXT"
   exit 1
 } >&2
 

--- a/bin/dfx-sns-demo
+++ b/bin/dfx-sns-demo
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
-DEMO_BIN="$(realpath "${SOURCE_DIR}/../bin-other")"
+DEMO_BIN="$(realpath "${SOURCE_DIR}/..")/bin-other"
 PATH="$SOURCE_DIR:$DEMO_BIN:$HOME/.local/bin:$PATH:$(dfx cache show)"
 export PATH
 

--- a/bin/dfx-sns-demo-mksns
+++ b/bin/dfx-sns-demo-mksns
@@ -27,5 +27,3 @@ dfx canister id sns_swap --network "$DFX_NETWORK"
 : hand over control of the dapp. Skipped...
 
 dfx-sns-sale-propose --network "$DFX_NETWORK"
-
-: "Demo finished!  Hope you enjoyed the show."

--- a/bin/dfx-software-ic-install-executable
+++ b/bin/dfx-software-ic-install-executable
@@ -20,7 +20,7 @@ install_linux() {
   curl -fL "$URL" | gunzip | install -m 755 /dev/stdin "$USER_BIN/$EXEC_NAME"
 }
 install_darwin() {
-  URL="https://download.dfinity.systems/ic/${DFX_IC_COMMIT}/binaries/x86_64-darwin/${EXEC_NAME}.gz"
+  URL="https://download.dfinity.systems/ic/${DFX_IC_COMMIT}/openssl-static-binaries/x86_64-darwin/${EXEC_NAME}.gz"
   echo "Downloading $URL"
   curl -fL "$URL" | gunzip >"$USER_BIN/$EXEC_NAME"
   chmod +x "$USER_BIN/$EXEC_NAME"

--- a/bin/dfx-software-idl2json-install
+++ b/bin/dfx-software-idl2json-install
@@ -16,7 +16,7 @@ set -euo pipefail
 IDL2JSON_VERSION="${IDL2JSON_VERSION#v}"
 
 if command -v idl2json && [[ "$(idl2json --version | awk '($1 == "idl2json"){print $2}')" == "${IDL2JSON_VERSION:-}" ]]; then
-  echo "quill v$IDL2JSON_VERSION already installed.  Nothing to do."
+  echo "idl2json v$IDL2JSON_VERSION already installed.  Nothing to do."
   exit 0
 fi
 


### PR DESCRIPTION
Some small fixes we found while trying to make snsdemo work on an M1 Mac:

1. For downloading `ic-admin` and `sns`, use a URL for openssl-static-binaries.
2. realpath on Mac doesn't work with paths that don't exist. So for /bin-other, call realpath with the directory below it instead of the directory we want to create later.
3. Remove a "Demo finished!" message in a place where the demo isn't finished yet.
4. Fix a typo where `bin/dfx-software-idl2json-install` was claiming quill was installed, rather than idl2json.
5. Fix typo "nuron" => "neuron".
