### PR TITLE
Don't use realpath before it's installed on Mac

### DIFF
--- a/bin/dfx-sns-demo-install
+++ b/bin/dfx-sns-demo-install
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+set -euo pipefail
+
+SOURCE_DIR="$(dirname "${BASH_SOURCE[0]}")"
 PATH="$SOURCE_DIR:$PATH"
 . "$SOURCE_DIR/versions.bash"
 
@@ -9,12 +11,13 @@ print_help() {
 	EOF
 }
 
+set +e
 # Source the optparse.bash file ---------------------------------------------------
 source "$SOURCE_DIR/optparse.bash"
 # Define options
 # Source the output file ----------------------------------------------------------
 source "$(optparse.build)"
-set -euo pipefail
+set -e
 
 dfx-software-jq-install
 dfx-software-more-install


### PR DESCRIPTION
The GitHub runner for Mac does not have `realpath` installed. We install it during the workflow but until we do we shouldn't use it.

In addition I moved `set -euo pipefail` to the top of `bin/dfx-sns-demo-install`, which would have detected the failing `realpath`.
And I temporarily disable `set -e` while sourcing `optparse`.