### PR TITLE
Make lots of sns fast

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -47,8 +47,9 @@ jobs:
           ./bin/dfx-sns-sale-buy
           ./bin/dfx-sns-sale-finalize
       - name: Create lots of SNS
+        if: matrix.os != 'macos-11'
         run: |
-          ./bin/dfx-sns-demo-mksns-parallel -s 2 -m snsdemo8
+          ./bin/dfx-sns-demo-mksns-parallel -s 10 -m snsdemo8
   demo_latest:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -86,5 +87,6 @@ jobs:
           ./bin/dfx-sns-sale-buy
           ./bin/dfx-sns-sale-finalize
       - name: Create lots of SNS
+        if: matrix.os != 'macos-11'
         run: |
-          ./bin/dfx-sns-demo-mksns-parallel -s 2 -m snsdemo8
+          ./bin/dfx-sns-demo-mksns-parallel -s 10 -m snsdemo8

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -46,6 +46,9 @@ jobs:
           ./bin/dfx-sns-demo-mksns
           ./bin/dfx-sns-sale-buy
           ./bin/dfx-sns-sale-finalize
+      - name: Create lots of SNS
+        run: |
+          ./bin/dfx-sns-demo-mksns-parallel -s 2 -m snsdemo8
   demo_latest:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -82,3 +85,6 @@ jobs:
           ./bin/dfx-sns-demo-mksns
           ./bin/dfx-sns-sale-buy
           ./bin/dfx-sns-sale-finalize
+      - name: Create lots of SNS
+        run: |
+          ./bin/dfx-sns-demo-mksns-parallel -s 2 -m snsdemo8

--- a/bin/dfx-sns-demo-mksns-parallel
+++ b/bin/dfx-sns-demo-mksns-parallel
@@ -54,8 +54,8 @@ become_user() {
   export PATH="$PWD/bin:$PWD/bin-other:$PATH"
   export HOME="$PWD"
   # If the identity has been created, use it:
-  if dfx identity get-principal --identity "$DEMO_USER" 2>/dev/null ; then
-      dfx identity use "$DEMO_USER" || true
+  if dfx identity get-principal --identity "$DEMO_USER" 2>/dev/null; then
+    dfx identity use "$DEMO_USER" || true
   fi
 }
 
@@ -110,9 +110,9 @@ swap_all_sns() {
 
 # MAIN
 test -z "${DFX_PROPOSER:-}" || {
-	echo "Details of p[roposer '${DFX_PROPOSER}':"
-    dfx identity get-principal --identity "$DFX_PROPOSER"
-    echo
+  echo "Details of p[roposer '${DFX_PROPOSER}':"
+  dfx identity get-principal --identity "$DFX_PROPOSER"
+  echo
 }
 create_all_sns
 swap_all_sns

--- a/bin/dfx-sns-demo-mksns-parallel
+++ b/bin/dfx-sns-demo-mksns-parallel
@@ -14,12 +14,13 @@ optparse.define short=m long=majority desc="A user representing the majority vot
 source "$(optparse.build)"
 set -euxo pipefail
 cd "$(dirname "$(realpath "$0")")/.."
+DEMO_USER_DIR="$PWD/users"
 
 # Creates an identity with their own home directory, their own project in that home dir, a neuron and some ICP.
 make_user() {
   (
     DEMO_USER="$1"
-    DEMODIR="users/$1"
+    DEMODIR="$DEMO_USER_DIR/$1"
     rm -fr "$DEMODIR"
     mkdir -p "$DEMODIR/.config" "$DEMODIR/.local/share"
     # Share some data:
@@ -94,8 +95,8 @@ create_all_sns() {
 swap_all_sns() {
   for ((i = 0; i < NUM_SNS_TO_MAKE; i++)); do
     (
-      DEMODIR="snsdemo_$i"
-      become_user "$DEMODIR"
+      DEMO_USER="snsdemo_$i"
+      become_user "$DEMO_USER"
       dfx-sns-sale-propose --network "$DFX_NETWORK" --identity "${DFX_PROPOSER:-${DEMO_USER}}"
       sleep 1
       dfx-sns-sale-buy --network "$DFX_NETWORK"

--- a/bin/dfx-sns-demo-mksns-parallel
+++ b/bin/dfx-sns-demo-mksns-parallel
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+DEMO_BIN="$(realpath "${SOURCE_DIR}/../bin-other")"
+PATH="$DEMO_BIN:$SOURCE_DIR:$PATH:$(dfx cache show)"
+export PATH="$PATH:$HOME/.local/bin"
+
+# Source the optparse.bash file ---------------------------------------------------
+source "$SOURCE_DIR/optparse.bash"
+# Define options
+optparse.define short=s long=num_sns desc="The number of SNSs to create" variable=NUM_SNS_TO_MAKE default="1"
+optparse.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
+optparse.define short=m long=majority desc="A user representing the majority vote" variable=DFX_PROPOSER default=""
+# Source the output file ----------------------------------------------------------
+source "$(optparse.build)"
+set -euxo pipefail
+cd "$(dirname "$(realpath "$0")")/.."
+
+# Creates an identity with their own home directory, their own project in that home dir, a neuron and some ICP.
+make_user() {
+  (
+    DEMO_USER="$1"
+    DEMODIR="users/$1"
+    rm -fr "$DEMODIR"
+    mkdir -p "$DEMODIR/.config" "$DEMODIR/.local/share"
+    # Share some data:
+    ln -s "$PWD/bin" "$DEMODIR/bin"
+    ln -s "$PWD/logo.png" "$DEMODIR/logo.png"
+    ln -s "$PWD/candid" "$DEMODIR/candid"
+    ln -s "$PWD/bin-other" "$DEMODIR/bin-other"
+    ln -s "$HOME/.local/share/dfx" "$DEMODIR/.local/share/dfx"
+    # Copy dfx.json and the user config
+    cp dfx.json "$DEMODIR/"
+    cp -R "$HOME/.config/dfx" "$DEMODIR/.config/dfx"
+    cp -R .dfx "$DEMODIR/.dfx"
+    # Enter the directory
+    become_user "$DEMO_USER"
+    dfx identity remove --quiet "$DEMO_USER" --drop-wallets 2>/dev/null || true
+    dfx identity new --storage-mode=plaintext "$DEMO_USER"
+    dfx identity use "$DEMO_USER"
+    dfx wallet balance
+    bin/dfx-ledger-get-icp --icp 5000 --network "$DFX_NETWORK"
+    dfx ledger balance --network "$DFX_NETWORK"
+    bin/dfx-neuron-create --icp 10 --network "$DFX_NETWORK"
+    bin/dfx-neuron-prolong --network "$DFX_NETWORK"
+  )
+}
+
+# Enters an identity's home dir and gets them ready to interact with the replica.
+become_user() {
+  DEMO_USER="$1"
+  DEMODIR="users/$1"
+  cd "$DEMODIR"
+  export PATH="$PWD/bin:$PWD/bin-other:$PATH"
+  export HOME="$PWD"
+  # If the identity has been created, use it:
+  if dfx identity get-principal --identity "$DEMO_USER" 2>/dev/null ; then
+      dfx identity use "$DEMO_USER" || true
+  fi
+}
+
+# Create all the SNS canisters in parallel but do not open any swaps.
+create_all_sns() {
+  PROCESSES=()
+  echo "I am $$"
+  for ((i = 0; i < NUM_SNS_TO_MAKE; i++)); do
+    (
+      echo "Starting $BASHPID"
+      DEMO_USER="snsdemo_$i"
+      make_user "$DEMO_USER"
+      become_user "$DEMO_USER"
+
+      ./bin/dfx-sns-whitelist-me --network "$DFX_NETWORK" --proposer "${DFX_PROPOSER:-${DEMO_USER}}"
+
+      ./bin/dfx-sns-config-random --network "$DFX_NETWORK"
+      dfx ledger top-up --amount 4.0 --network "$DFX_NETWORK" "$(dfx identity get-wallet --network "$DFX_NETWORK")"
+      dfx wallet balance
+      ./bin/dfx-sns-deploy --network "$DFX_NETWORK"
+
+      dfx canister id sns_root --network "$DFX_NETWORK"
+      dfx canister id sns_governance --network "$DFX_NETWORK"
+      dfx canister id sns_ledger --network "$DFX_NETWORK"
+      dfx canister id sns_swap --network "$DFX_NETWORK"
+
+      : hand over control of the dapp. Skipped...
+
+      echo FIN $BASHPID
+    ) &
+    PROCESSES+=($!)
+  done
+  wait "${PROCESSES[@]}"
+}
+
+# Run all the swaps, one at a time.
+swap_all_sns() {
+  for ((i = 0; i < NUM_SNS_TO_MAKE; i++)); do
+    (
+      DEMODIR="snsdemo_$i"
+      become_user "$DEMODIR"
+      dfx-sns-sale-propose --network "$DFX_NETWORK" --identity "${DFX_PROPOSER:-${DEMO_USER}}"
+      sleep 1
+      dfx-sns-sale-buy --network "$DFX_NETWORK"
+      sleep 1
+      ./bin/dfx-sns-sale-finalize --network "$DFX_NETWORK" --identity "${DFX_PROPOSER:-${DEMO_USER}}" || true
+      sleep 1
+
+    )
+  done
+}
+
+# MAIN
+test -z "${DFX_PROPOSER:-}" || {
+	echo "Details of p[roposer '${DFX_PROPOSER}':"
+    dfx identity get-principal --identity "$DFX_PROPOSER"
+    echo
+}
+create_all_sns
+swap_all_sns
+echo FIN

--- a/bin/dfx-sns-whitelist-me
+++ b/bin/dfx-sns-whitelist-me
@@ -6,17 +6,19 @@ export PATH="$SOURCE_DIR:$PATH:$(dfx cache show)"
 source "$SOURCE_DIR/optparse.bash"
 # Define options
 optparse.define short=i long=identity desc="The dfx identity to use" variable=DFX_IDENTITY default="$(dfx identity whoami)"
+optparse.define short=i long=proposer desc="The dfx identity that creates the proposal" variable=DFX_PROPOSER default=""
 optparse.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
 # Source the output file ----------------------------------------------------------
 source "$(optparse.build)"
 set -euo pipefail
 
-export DFX_NEURON_ID="$(dfx-neuron-id --identity "$DFX_IDENTITY" --network "$DFX_NETWORK")"
-export DFX_IDENTITY_PEM="$HOME/.config/dfx/identity/$DFX_IDENTITY/identity.pem"
+DFX_PROPOSER="${DFX_PROPOSER:-$DFX_IDENTITY}"
+export DFX_NEURON_ID="$(dfx-neuron-id --identity "$DFX_PROPOSER" --network "$DFX_NETWORK")"
+export DFX_PROPOSER_PEM="$HOME/.config/dfx/identity/$DFX_PROPOSER/identity.pem"
 export NNS_URL="$(dfx-network-provider --network "$DFX_NETWORK")"
 command -v "ic-admin"
 set ic-admin \
-  --secret-key-pem "$DFX_IDENTITY_PEM" \
+  --secret-key-pem "$DFX_PROPOSER_PEM" \
   --nns-url "$NNS_URL" \
   propose-to-update-sns-deploy-whitelist \
   --added-principals "$(dfx identity get-wallet --network "$DFX_NETWORK" --identity "$DFX_IDENTITY")" \


### PR DESCRIPTION
# Motivation
For tests, it may be required to create many SNS.  Creating them sequentially is slow.

A challenge is that there may be only one open SNS at a time, so we cannot simply run the existing mksns script N times in parallel.  Canister creation is slow, that can be done in parallel, but the swaps need to be sequential.

# Changes
- Add a script that creates many SNS as many different users