### PR TITLE
Set e

### DIFF
--- a/bin/_template
+++ b/bin/_template
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
 . "$SOURCE_DIR/versions.bash"
@@ -14,6 +15,5 @@ clap.define short=i long=identity desc="The dfx identity to use" variable=DFX_ID
 clap.define short=b long=bin desc="Local directory for executables" variable=USER_BIN default="$HOME/.local/bin"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 
 export DFX_NETWORK

--- a/bin/clap.bash
+++ b/bin/clap.bash
@@ -60,7 +60,7 @@ function clap.define() {
 		elif [ "$key" = "long" ]; then
 			local longname="$value"
 			if [ ${#longname} -lt 2 ]; then
-				clap.throw_error "long name expected to be atleast one character long"
+				clap.throw_error "long name expected to be at least one character long"
 			fi
 			local long="--${longname}"
 		elif [ "$key" = "desc" ]; then
@@ -80,13 +80,13 @@ function clap.define() {
 		clap.throw_error "You must give a variable for option: ($short/$long)"
 	fi
 
-	if [ "$val" = "" ]; then
+	if [ "${val:-}" = "" ]; then
 		val="\$OPTARG"
 	fi
 
 	# build OPTIONS and help
 	clap_usage="${clap_usage}#NL#TB${short} $(printf "%-25s %s" "${long}:" "${desc}")"
-	if [ "$default" != "" ] && [ "${nargs:-}" != "0" ]; then
+	if [ "${default:-}" != "" ] && [ "${nargs:-}" != "0" ]; then
 		clap_usage="${clap_usage} [default:$default]"
 	fi
 	clap_flags="${clap_flags:-} ${long}"
@@ -97,11 +97,11 @@ function clap.define() {
 	else
 		clap_contractions="${clap_contractions}#NL#TB#TB${long}${short:+|${short}})#NL#TB#TB#TB${variable}=(); for ((i=0; i<nargs; i++)); do ${variable}+=( \"\$1\" ); shift 1; done;;"
 	fi
-	if [ "$default" != "" ]; then
+	if [ "${default:-}" != "" ]; then
 		clap_defaults="${clap_defaults}#NL${variable}=${default}"
 	fi
 	clap_arguments_string="${clap_arguments_string}${shortname}"
-	if [ "$val" = "\$OPTARG" ]; then
+	if [ "${val:-}" = "\$OPTARG" ]; then
 		clap_arguments_string="${clap_arguments_string}:"
 	fi
 }

--- a/bin/dfx-canister-set-id
+++ b/bin/dfx-canister-set-id
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
 . "$SOURCE_DIR/versions.bash"
@@ -11,7 +12,6 @@ clap.define short=i long=canister_id desc="The ID of the canister" variable=DFX_
 clap.define short=N long=canister_name desc="The name of the canister" variable=DFX_CANISTER_NAME
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 
 export DFX_NETWORK
 export DFX_CANISTER_NAME

--- a/bin/dfx-identity-pem
+++ b/bin/dfx-identity-pem
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 export PATH="$SOURCE_DIR:$PATH"
 
@@ -8,7 +9,6 @@ source "$SOURCE_DIR/clap.bash"
 clap.define short=i long=identity desc="The dfx identity to use" variable=DFX_IDENTITY default="$(dfx identity whoami)"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 
 : "Note:  Direct use of the pem file is needed for ic-admin but is generally deprecated"
 : "Note: It is not guaranteed that the pem file is present and unencrypted."

--- a/bin/dfx-ledger-get-icp
+++ b/bin/dfx-ledger-get-icp
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 
 # Source the clap.bash file ---------------------------------------------------
@@ -11,7 +12,6 @@ clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETW
 clap.define short=t long=to desc="Top up to the given value, if needed" variable=IF_NEEDED nargs=0 default=""
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 
 export DFX_NETWORK
 

--- a/bin/dfx-network-config-add
+++ b/bin/dfx-network-config-add
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
 . "$SOURCE_DIR/versions.bash"
@@ -10,7 +11,6 @@ clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETW
 clap.define short=x long=ic_dir desc="Directory containing the ic source code" variable=IC_REPO_DIR default="$HOME/dfn/ic"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 
 export DFX_NETWORK
 

--- a/bin/dfx-network-delete
+++ b/bin/dfx-network-delete
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 
 # Source the clap.bash file ---------------------------------------------------
@@ -7,7 +8,6 @@ source "$SOURCE_DIR/clap.bash"
 clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 
 export DFX_NETWORK
 

--- a/bin/dfx-network-deploy
+++ b/bin/dfx-network-deploy
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
 
@@ -16,7 +17,6 @@ clap.define short=x long=ic_dir desc="Directory containing the ic source code" v
 clap.define short=y long=nd_dir desc="Directory containing the nns-dapp source code" variable=ND_REPO_DIR default="$HOME/dfn/nns-dapp"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 
 export DFX_NETWORK
 export DFX_IC_COMMIT

--- a/bin/dfx-network-deploy-config
+++ b/bin/dfx-network-deploy-config
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
 
@@ -14,7 +15,6 @@ clap.define short=x long=ic_dir desc="Directory containing the ic source code" v
 clap.define short=y long=nd_dir desc="Directory containing the nns-dapp source code" variable=ND_REPO_DIR default="$HOME/dfn/nns-dapp"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 
 export DFX_NETWORK
 

--- a/bin/dfx-network-deploy-frontends
+++ b/bin/dfx-network-deploy-frontends
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
 
@@ -14,7 +15,6 @@ clap.define short=x long=ic_dir desc="Directory containing the ic source code" v
 clap.define short=y long=nd_dir desc="Directory containing the nns-dapp source code" variable=ND_REPO_DIR default="$HOME/dfn/nns-dapp"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 
 export DFX_NETWORK
 

--- a/bin/dfx-network-deploy-testnet
+++ b/bin/dfx-network-deploy-testnet
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
 
@@ -14,7 +15,6 @@ clap.define short=x long=ic_dir desc="Directory containing the ic source code" v
 clap.define short=y long=nd_dir desc="Directory containing the nns-dapp source code" variable=ND_REPO_DIR default="$HOME/dfn/nns-dapp"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 
 export DFX_NETWORK
 

--- a/bin/dfx-network-provider
+++ b/bin/dfx-network-provider
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 
 # Source the clap.bash file ---------------------------------------------------
@@ -8,7 +9,6 @@ clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETW
 clap.define short=f long=format desc="The format: url or ip" variable=FORMAT default="url"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 
 export DFX_NETWORK
 

--- a/bin/dfx-network-stop
+++ b/bin/dfx-network-stop
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 
 # Source the clap.bash file ---------------------------------------------------
@@ -7,7 +8,6 @@ source "$SOURCE_DIR/clap.bash"
 clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 
 export DFX_NETWORK
 

--- a/bin/dfx-network-url
+++ b/bin/dfx-network-url
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 
 # Source the clap.bash file ---------------------------------------------------
@@ -7,7 +8,6 @@ source "$SOURCE_DIR/clap.bash"
 clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 
 export DFX_NETWORK
 

--- a/bin/dfx-neuron-create
+++ b/bin/dfx-neuron-create
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 
 # Source the clap.bash file ---------------------------------------------------
@@ -10,7 +11,6 @@ clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETW
 clap.define short=V long=verbose desc="Print progress" variable=DFX_VERBOSE nargs=0
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 test -z "${DFX_VERBOSE:-}" || set -x
 
 # Create a neuron

--- a/bin/dfx-neuron-id
+++ b/bin/dfx-neuron-id
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 
 # Source the clap.bash file ---------------------------------------------------
@@ -9,6 +10,5 @@ clap.define short=i long=identity desc="The dfx identity to use" variable=DFX_ID
 clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 
 tail -n1 "$HOME/.config/dfx/identity/$DFX_IDENTITY/neurons/$DFX_NETWORK"

--- a/bin/dfx-neuron-prolong
+++ b/bin/dfx-neuron-prolong
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 
 # Source the clap.bash file ---------------------------------------------------
@@ -9,7 +10,6 @@ clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETW
 clap.define short=t long=time desc="By how long to extend the dissolve delay" variable=DISSOLVE_DELAY default="$((60 * 60 * 24 * 360))"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 
 # Create a neuron
 PEM="$HOME/.config/dfx/identity/$DFX_IDENTITY/identity.pem"

--- a/bin/dfx-nns-proposal-info
+++ b/bin/dfx-nns-proposal-info
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 export PATH="$SOURCE_DIR:$PATH"
 
@@ -9,7 +10,6 @@ clap.define short=p long=proposal desc="The proposal number" variable=PROPOSAL_N
 clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 
 PROPOSAL_NUM="${PROPOSAL_NUM:-${1:-$(
   {

--- a/bin/dfx-nns-propose-to-set-authorized-subnetworks
+++ b/bin/dfx-nns-propose-to-set-authorized-subnetworks
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 
 # Source the clap.bash file ---------------------------------------------------
@@ -7,7 +8,6 @@ source "$SOURCE_DIR/clap.bash"
 clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 
 NNS_URL="$(dfx-network-provider --network "$DFX_NETWORK")"
 PROPOSAL_TYPE="propose-to-set-authorized-subnetworks"

--- a/bin/dfx-nns-propose-xdr-icp-conversion-rate
+++ b/bin/dfx-nns-propose-xdr-icp-conversion-rate
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 
 # Source the clap.bash file ---------------------------------------------------
@@ -7,7 +8,6 @@ source "$SOURCE_DIR/clap.bash"
 clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 
 NNS_URL="$(dfx-network-provider --network "$DFX_NETWORK")"
 

--- a/bin/dfx-sns-demo
+++ b/bin/dfx-sns-demo
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euxo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 DEMO_BIN="$(realpath "${SOURCE_DIR}/..")/bin-other"
 PATH="$SOURCE_DIR:$DEMO_BIN:$HOME/.local/bin:$PATH:$(dfx cache show)"
@@ -13,7 +14,6 @@ clap.define short=x long=ic_dir desc="Directory containing the ic source code" v
 clap.define short=y long=nd_dir desc="Directory containing the nns-dapp source code" variable=ND_REPO_DIR default="$HOME/dfn/nns-dapp"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euxo pipefail
 cd "$(dirname "$(realpath "$0")")/.."
 
 demo-cleanup

--- a/bin/dfx-sns-demo-mksns
+++ b/bin/dfx-sns-demo-mksns
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euxo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 DEMO_BIN="$(realpath "${SOURCE_DIR}/../bin-other")"
 PATH="$DEMO_BIN:$SOURCE_DIR:$PATH:$(dfx cache show)"
@@ -10,7 +11,6 @@ source "$SOURCE_DIR/clap.bash"
 clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euxo pipefail
 cd "$(dirname "$(realpath "$0")")/.."
 
 ./bin/dfx-sns-whitelist-me --network "$DFX_NETWORK"

--- a/bin/dfx-sns-demo-mksns-parallel
+++ b/bin/dfx-sns-demo-mksns-parallel
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euxo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 DEMO_BIN="$(realpath "${SOURCE_DIR}/../bin-other")"
 PATH="$DEMO_BIN:$SOURCE_DIR:$PATH:$(dfx cache show)"
@@ -12,7 +13,6 @@ clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETW
 clap.define short=m long=majority desc="A user representing the majority vote" variable=DFX_PROPOSER default=""
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euxo pipefail
 cd "$(dirname "$(realpath "$0")")/.."
 DEMO_USER_DIR="$PWD/users"
 

--- a/bin/dfx-sns-deploy
+++ b/bin/dfx-sns-deploy
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 
 # Source the clap.bash file ---------------------------------------------------
@@ -8,7 +9,6 @@ clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETW
 clap.define short=c long=config desc="The SNS cofiguration" variable=SNS_CONFIG default="sns.yml"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 PATH="$PATH:$(dfx cache show)"
 export PATH
 

--- a/bin/dfx-sns-quill
+++ b/bin/dfx-sns-quill
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
 . "$SOURCE_DIR/versions.bash"
@@ -10,7 +11,6 @@ clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETW
 clap.define short=i long=identity desc="The dfx identity to use" variable=DFX_IDENTITY default="$(dfx identity whoami)"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 
 export DFX_NETWORK
 

--- a/bin/dfx-sns-quill-canister-ids
+++ b/bin/dfx-sns-quill-canister-ids
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
 . "$SOURCE_DIR/versions.bash"
@@ -10,7 +11,6 @@ clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETW
 clap.define short=r long=network desc="get the cnister IDs from the root canister" variable=USE_ROOT nargs=0
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 
 if test -n "${USE_ROOT:-}"; then
   dfx canister call sns_root list_sns_canisters '(record {})' | idl2json | jq '{ governance_canister_id: .governance[0], ledger_canister_id: .ledger[0], root_canister_id: .root[0], swap_canister_id: .swap[0], dapp_canister_id_list: .dapps }'

--- a/bin/dfx-sns-sale-buy
+++ b/bin/dfx-sns-sale-buy
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
 . "$SOURCE_DIR/versions.bash"
@@ -11,7 +12,6 @@ clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETW
 clap.define short=i long=identity desc="The dfx identity to use" variable=DFX_IDENTITY default="$(dfx identity whoami)"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 
 export DFX_NETWORK
 

--- a/bin/dfx-sns-sale-finalize
+++ b/bin/dfx-sns-sale-finalize
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
 . "$SOURCE_DIR/versions.bash"
@@ -14,7 +15,6 @@ clap.define short=i long=identity desc="The dfx identity to use" variable=DFX_ID
 clap.define short=b long=bin desc="Local directory for executables" variable=USER_BIN default="$HOME/.local/bin"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 
 dfx canister --network "$DFX_NETWORK" call sns_swap finalize_swap '(record {})' | tee ,sns-sale-finalize.idl
 

--- a/bin/dfx-sns-sale-propose
+++ b/bin/dfx-sns-sale-propose
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 export PATH="$SOURCE_DIR:$PATH"
 
@@ -10,7 +11,6 @@ clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETW
 clap.define short=N long=neuron desc="The dfx network to use" variable=DFX_NEURON_ID default=""
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 
 export DFX_NEURON_ID="${DFX_NEURON_ID:-$(dfx-neuron-id --identity "$DFX_IDENTITY" --network "$DFX_NETWORK")}"
 export DFX_IDENTITY_PEM="$(dfx-identity-pem --identity "$DFX_IDENTITY")"

--- a/bin/dfx-sns-subnet-add
+++ b/bin/dfx-sns-subnet-add
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 
 # Source the clap.bash file ---------------------------------------------------
@@ -8,7 +9,6 @@ clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETW
 clap.define short=i long=identity desc="The identity to use" variable=DFX_IDENTITY default="$(dfx identity whoami)"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 
 [[ "$DFX_NETWORK" != "local" ]] || {
   echo "Subnets are already authorized on local networks."

--- a/bin/dfx-sns-wasm-download
+++ b/bin/dfx-sns-wasm-download
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 
 # Source the clap.bash file ---------------------------------------------------
@@ -10,7 +11,6 @@ clap.define short=c long=commit desc="The IC commit of the wasms" variable=DFX_I
 )"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 
 export DFX_IC_COMMIT
 

--- a/bin/dfx-sns-wasm-upload
+++ b/bin/dfx-sns-wasm-upload
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$PATH:$(dfx cache show)"
 export PATH
@@ -14,7 +15,6 @@ clap.define short=c long=commit desc="The IC commit of the wasms" variable=DFX_I
 clap.define short=i long=id desc="The wasm canister id to upload to" variable=SNS_WASM_CANISTER_ID default=''
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 
 SNS_WASM_CANISTER_ID="${SNS_WASM_CANISTER_ID:-$(dfx canister id nns-sns-wasm --network "$DFX_NETWORK" 2>/dev/null)}"
 

--- a/bin/dfx-sns-whitelist-me
+++ b/bin/dfx-sns-whitelist-me
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 export PATH="$SOURCE_DIR:$PATH:$(dfx cache show)"
 
@@ -10,7 +11,6 @@ clap.define short=i long=proposer desc="The dfx identity that creates the propos
 clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 
 DFX_PROPOSER="${DFX_PROPOSER:-$DFX_IDENTITY}"
 export DFX_NEURON_ID="$(dfx-neuron-id --identity "$DFX_PROPOSER" --network "$DFX_NETWORK")"

--- a/bin/dfx-software-dfx-install
+++ b/bin/dfx-software-dfx-install
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
 . "$SOURCE_DIR/versions.bash"
@@ -9,7 +10,6 @@ source "$SOURCE_DIR/clap.bash"
 clap.define short=v long=version desc="The version of dfx to install" variable=DFX_VERSION default="latest"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 
 [[ "${DFX_VERSION}" != "latest" ]] || DFX_VERSION=""
 DFX_VERSION="${DFX_VERSION#v}"

--- a/bin/dfx-software-gh-install
+++ b/bin/dfx-software-gh-install
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
 . "$SOURCE_DIR/versions.bash"
@@ -8,7 +9,6 @@ source "$SOURCE_DIR/clap.bash"
 # Define options
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 
 if command -v gh; then
   echo "gh is already installed.  Nothing to do."

--- a/bin/dfx-software-ic-install-executable
+++ b/bin/dfx-software-ic-install-executable
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
 
@@ -12,7 +13,6 @@ clap.define short=c long=commit desc="The IC commit of the binaries to install" 
 clap.define short=b long=bin desc="Diectory in which to install the executeble" variable=USER_BIN default="$HOME/.local/bin"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 
 install_linux() {
   URL="https://download.dfinity.systems/ic/${DFX_IC_COMMIT}/binaries/x86_64-linux/${EXEC_NAME}.gz"

--- a/bin/dfx-software-ic-latest
+++ b/bin/dfx-software-ic-latest
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -eu # No pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 
 # Source the clap.bash file ---------------------------------------------------
@@ -9,7 +10,6 @@ clap.define short=b long=before desc="Latest published commit before the given o
 clap.define short=a long=after desc="First published commit after the given one" variable=IC_COMMIT_AFTER default=""
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -eu # No pipefail
 
 function disk_image_exists() {
   (

--- a/bin/dfx-software-idl2json-install
+++ b/bin/dfx-software-idl2json-install
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
 . "$SOURCE_DIR/versions.bash"
@@ -10,7 +11,6 @@ clap.define short=v long=version desc="The release to install" variable=IDL2JSON
 clap.define short=b long=bin desc="Local directory for executables" variable=USER_BIN default="$HOME/.local/bin"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 
 [[ "${IDL2JSON_VERSION:-}" != "latest" ]] || IDL2JSON_VERSION="$(dfx-software-idl2json-latest)"
 IDL2JSON_VERSION="${IDL2JSON_VERSION#v}"

--- a/bin/dfx-software-idl2json-latest
+++ b/bin/dfx-software-idl2json-latest
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
 . "$SOURCE_DIR/versions.bash"
@@ -8,6 +9,5 @@ source "$SOURCE_DIR/clap.bash"
 # Define options
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 
 gh release list --exclude-drafts --limit 1 --repo dfinity/idl2json | awk '{print $1}' | awk -F: '{print $1}'

--- a/bin/dfx-software-internet-identity-ci-wasm-url
+++ b/bin/dfx-software-internet-identity-ci-wasm-url
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
 . "$SOURCE_DIR/versions.bash"
@@ -9,7 +10,6 @@ source "$SOURCE_DIR/clap.bash"
 clap.define short=r long=release desc="The release name" variable=DFX_II_RELEASE default="latest"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 
 export DFX_NETWORK
 

--- a/bin/dfx-software-internet-identity-version
+++ b/bin/dfx-software-internet-identity-version
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
 . "$SOURCE_DIR/versions.bash"
@@ -15,7 +16,6 @@ clap.define short=m long=mainnet desc="Get the version deployed in production" v
 clap.define short=h long=hash desc="Get the version of a given hash" variable=GET_HASH
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 
 : "If a canister is specified, verify that a network is specified as well"
 test -z "${CANISTER:-}" || {

--- a/bin/dfx-software-nns-dapp-latest
+++ b/bin/dfx-software-nns-dapp-latest
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
 . "$SOURCE_DIR/versions.bash"
@@ -8,6 +9,5 @@ source "$SOURCE_DIR/clap.bash"
 # Define options
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 
 gh release list --exclude-drafts --limit 20 --repo dfinity/nns-dapp | grep -m1 proposal | sed -E 's/.*\<(proposal-[0-9]+).*/\1/g'

--- a/bin/dfx-software-quill-install
+++ b/bin/dfx-software-quill-install
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
 . "$SOURCE_DIR/versions.bash"
@@ -10,7 +11,6 @@ clap.define short=v long=version desc="The release to install" variable=QUILL_VE
 clap.define short=b long=bin desc="Local directory for executables" variable=USER_BIN default="$HOME/.local/bin"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 
 [[ "${QUILL_VERSION:-}" != "latest" ]] || QUILL_VERSION="$(dfx-software-quill-latest)"
 QUILL_VERSION="${QUILL_VERSION#v}"

--- a/bin/dfx-software-quill-latest
+++ b/bin/dfx-software-quill-latest
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
 . "$SOURCE_DIR/versions.bash"
@@ -8,6 +9,5 @@ source "$SOURCE_DIR/clap.bash"
 # Define options
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 
 gh release list --exclude-drafts --limit 1 --repo dfinity/quill | awk '{print $1}' | awk -F: '{print $1}'

--- a/bin/dfx-software-sns-quill-latest
+++ b/bin/dfx-software-sns-quill-latest
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
 . "$SOURCE_DIR/versions.bash"
@@ -8,6 +9,5 @@ source "$SOURCE_DIR/clap.bash"
 # Define options
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 
 gh release list --exclude-drafts --limit 1 --repo dfinity/sns-quill | awk '{print $1}' | sed 's/:.*//g'


### PR DESCRIPTION
# Motivation
Clap does not handle empty values correctly, so `set -euxo pipefail` is set later than usual.  Let's fix that.