### PR TITLE
Clap cleanup

### DIFF
--- a/bin/clap.bash
+++ b/bin/clap.bash
@@ -1,28 +1,5 @@
-# Optparse - a BASH argument parser
-# Heavily modified from an original by:
-# Optparse - a BASH wrapper for getopts <== NOTE: This doesn't use getopts any more.
-# https://github.com/nk412/clap
-# Copyright (c) 2015 Nagarjuna Kumarappan
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-# THE SOFTWARE.
-#
-# Author: Nagarjuna Kumarappan <nagarjuna.412@gmail.com>
+# clap - a BASH argument parser
+# This parser aims to have similar parsing semantics as Rust's clap parser; if it doesn't look anything like clap it's not just you.
 
 clap_usage=""
 clap_contractions=""

--- a/bin/clap.bash
+++ b/bin/clap.bash
@@ -2,7 +2,7 @@
 # This parser aims to have similar parsing semantics as Rust's clap parser; if it doesn't look anything like clap it's not just you.
 
 clap_usage=""
-clap_contractions=""
+clap_flag_match=""
 clap_defaults=""
 clap_arguments_string=""
 
@@ -68,11 +68,11 @@ function clap.define() {
 	fi
 	clap_flags="${clap_flags:-} ${long}"
 	if [ "${nargs:-}" == "" ]; then
-		clap_contractions="${clap_contractions}#NL#TB#TB${long}${short:+|${short}})#NL#TB#TB#TB${variable}=\"\$1\"; shift 1;;"
+		clap_flag_match="${clap_flag_match}#NL#TB#TB${long}${short:+|${short}})#NL#TB#TB#TB${variable}=\"\$1\"; shift 1;;"
 	elif [ "${nargs:-}" == "0" ]; then
-		clap_contractions="${clap_contractions}#NL#TB#TB${long}${short:+|${short}})#NL#TB#TB#TB${variable}=\"true\";;"
+		clap_flag_match="${clap_flag_match}#NL#TB#TB${long}${short:+|${short}})#NL#TB#TB#TB${variable}=\"true\";;"
 	else
-		clap_contractions="${clap_contractions}#NL#TB#TB${long}${short:+|${short}})#NL#TB#TB#TB${variable}=(); for ((i=0; i<nargs; i++)); do ${variable}+=( \"\$1\" ); shift 1; done;;"
+		clap_flag_match="${clap_flag_match}#NL#TB#TB${long}${short:+|${short}})#NL#TB#TB#TB${variable}=(); for ((i=0; i<nargs; i++)); do ${variable}+=( \"\$1\" ); shift 1; done;;"
 	fi
 	if [ "${default:-}" != "" ]; then
 		clap_defaults="${clap_defaults}#NL${variable}=${default}"
@@ -125,7 +125,7 @@ while [ \$# -ne 0 ]; do
         shift 1
 
         case "\$param" in
-                $clap_contractions
+                $clap_flag_match
                 "-?"|--help)
 			print_help
 			echo
@@ -159,7 +159,7 @@ EOF
 	unset clap_usage
 	unset clap_arguments_string
 	unset clap_defaults
-	unset clap_contractions
+	unset clap_flag_match
 
 	# Return file name to parent
 	echo "$build_file"

--- a/bin/dfx-sns-demo
+++ b/bin/dfx-sns-demo
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euxo pipefail
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 DEMO_BIN="$(realpath "${SOURCE_DIR}/..")/bin-other"
 PATH="$SOURCE_DIR:$DEMO_BIN:$HOME/.local/bin:$PATH:$(dfx cache show)"
@@ -14,6 +14,7 @@ clap.define short=x long=ic_dir desc="Directory containing the ic source code" v
 clap.define short=y long=nd_dir desc="Directory containing the nns-dapp source code" variable=ND_REPO_DIR default="$HOME/dfn/nns-dapp"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
+set -x
 cd "$(dirname "$(realpath "$0")")/.."
 
 demo-cleanup

--- a/bin/dfx-sns-demo-mksns
+++ b/bin/dfx-sns-demo-mksns
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euxo pipefail
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 DEMO_BIN="$(realpath "${SOURCE_DIR}/../bin-other")"
 PATH="$DEMO_BIN:$SOURCE_DIR:$PATH:$(dfx cache show)"
@@ -11,6 +11,7 @@ source "$SOURCE_DIR/clap.bash"
 clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
+set -x
 cd "$(dirname "$(realpath "$0")")/.."
 
 ./bin/dfx-sns-whitelist-me --network "$DFX_NETWORK"

--- a/bin/dfx-sns-demo-mksns-parallel
+++ b/bin/dfx-sns-demo-mksns-parallel
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euxo pipefail
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 DEMO_BIN="$(realpath "${SOURCE_DIR}/../bin-other")"
 PATH="$DEMO_BIN:$SOURCE_DIR:$PATH:$(dfx cache show)"
@@ -13,6 +13,7 @@ clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETW
 clap.define short=m long=majority desc="A user representing the majority vote" variable=DFX_PROPOSER default=""
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
+set -x
 cd "$(dirname "$(realpath "$0")")/.."
 DEMO_USER_DIR="$PWD/users"
 


### PR DESCRIPTION
# Motivation
Clean code

The code has long since given up on the strategy of contracting args to a short form and passing them to optparse.  But the code still uses terminology as if it did.  Let's stop that.

And reduce noise.