### PR TITLE
Sns demo: disburse neuron and fill faucet

### DIFF
--- a/bin/dfx-sns-demo
+++ b/bin/dfx-sns-demo
@@ -84,9 +84,12 @@ sleep 1
 
 ./bin/dfx-sns-demo-mksns --network "$DFX_NETWORK"
 sleep 1
-dfx-sns-sale-buy --network "$DFX_NETWORK"
+./bin/dfx-sns-sale-buy --network "$DFX_NETWORK"
 sleep 1
 ./bin/dfx-sns-sale-finalize --network "$DFX_NETWORK"
 sleep 1
+./bin/dfx-sns-disburse-neuron --network "$DFX_NETWORK"
+sleep 1
+./bin/dfx-sns-transfer-to-faucet --network "$DFX_NETWORK"
 
 : "Demo finished!  Hope you enjoyed the show."

--- a/bin/dfx-sns-disburse-neuron
+++ b/bin/dfx-sns-disburse-neuron
@@ -20,7 +20,7 @@ set -euo pipefail
 
 export DFX_NETWORK
 
-GOVERNANCE_CANISTER_ID="$(dfx canister call sns_root list_sns_canisters '(record {})' | idl2json | jq -r '.governance | .[]')"
+GOVERNANCE_CANISTER_ID="$(dfx canister call sns_root list_sns_canisters '(record {})' --network "$DFX_NETWORK" | idl2json | jq -r '.governance | .[]')"
 
 PRINCIPAL="$(dfx identity get-principal --network "$DFX_NETWORK")"
 

--- a/bin/dfx-sns-disburse-neuron
+++ b/bin/dfx-sns-disburse-neuron
@@ -3,6 +3,13 @@ SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
 . "$SOURCE_DIR/versions.bash"
 
+print_help() {
+  cat <<-EOF
+	
+	Disburses the 1 neuron with a dissolve delay of 0.
+	EOF
+}
+
 # Source the clap.bash file ---------------------------------------------------
 source "$SOURCE_DIR/clap.bash"
 # Define options
@@ -10,6 +17,8 @@ clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETW
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 set -euo pipefail
+
+export DFX_NETWORK
 
 GOVERNANCE_CANISTER_ID="$(dfx canister call sns_root list_sns_canisters '(record {})' | idl2json | jq -r '.governance | .[]')"
 

--- a/bin/dfx-sns-disburse-neuron
+++ b/bin/dfx-sns-disburse-neuron
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+PATH="$SOURCE_DIR:$PATH"
+. "$SOURCE_DIR/versions.bash"
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/clap.bash"
+# Define options
+clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+set -euo pipefail
+
+GOVERNANCE_CANISTER_ID="$(dfx canister call sns_root list_sns_canisters '(record {})' | idl2json | jq -r '.governance | .[]')"
+
+NEURON_ID="$(dfx canister call "$GOVERNANCE_CANISTER_ID" list_neurons '(record {limit=10})'|idl2json|jq -r '.neurons[] | select(.dissolve_state[].DissolveDelaySeconds == "0") | .id[].id | join("; ")')"
+
+dfx canister call "$GOVERNANCE_CANISTER_ID" manage_neuron "(record { subaccount = vec { ${NEURON_ID} }; command = opt (variant { Disburse = record { } }) })"

--- a/bin/dfx-sns-disburse-neuron
+++ b/bin/dfx-sns-disburse-neuron
@@ -13,6 +13,6 @@ set -euo pipefail
 
 GOVERNANCE_CANISTER_ID="$(dfx canister call sns_root list_sns_canisters '(record {})' | idl2json | jq -r '.governance | .[]')"
 
-NEURON_ID="$(dfx canister call "$GOVERNANCE_CANISTER_ID" list_neurons '(record {limit=10})'|idl2json|jq -r '.neurons[] | select(.dissolve_state[].DissolveDelaySeconds == "0") | .id[].id | join("; ")')"
+NEURON_ID="$(dfx canister call "$GOVERNANCE_CANISTER_ID" list_neurons '(record {limit=10})' | idl2json | jq -r '.neurons[] | select(.dissolve_state[].DissolveDelaySeconds == "0") | .id[].id | join("; ")')"
 
 dfx canister call "$GOVERNANCE_CANISTER_ID" manage_neuron "(record { subaccount = vec { ${NEURON_ID} }; command = opt (variant { Disburse = record { } }) })"

--- a/bin/dfx-sns-disburse-neuron
+++ b/bin/dfx-sns-disburse-neuron
@@ -22,9 +22,9 @@ export DFX_NETWORK
 
 GOVERNANCE_CANISTER_ID="$(dfx canister call sns_root list_sns_canisters '(record {})' | idl2json | jq -r '.governance | .[]')"
 
-PRINCIPAL="$(dfx identity get-principal)"
+PRINCIPAL="$(dfx identity get-principal --network "$DFX_NETWORK")"
 
 NEURON_ID="$(dfx canister call "$GOVERNANCE_CANISTER_ID" list_neurons "(record
-{of_principal=opt principal \"$PRINCIPAL\"; limit=100})" | idl2json | jq -r '.neurons[] | select(.dissolve_state[].DissolveDelaySeconds == "0") | .id[].id | join("; ")')"
+{of_principal=opt principal \"$PRINCIPAL\"; limit=100})" --network "$DFX_NETWORK" | idl2json | jq -r '.neurons[] | select(.dissolve_state[].DissolveDelaySeconds == "0") | .id[].id | join("; ")')"
 
-dfx canister call "$GOVERNANCE_CANISTER_ID" manage_neuron "(record { subaccount = vec { ${NEURON_ID} }; command = opt (variant { Disburse = record { } }) })"
+dfx canister call "$GOVERNANCE_CANISTER_ID" manage_neuron "(record { subaccount = vec { ${NEURON_ID} }; command = opt (variant { Disburse = record { } }) })" --network "$DFX_NETWORK"

--- a/bin/dfx-sns-disburse-neuron
+++ b/bin/dfx-sns-disburse-neuron
@@ -13,6 +13,9 @@ set -euo pipefail
 
 GOVERNANCE_CANISTER_ID="$(dfx canister call sns_root list_sns_canisters '(record {})' | idl2json | jq -r '.governance | .[]')"
 
-NEURON_ID="$(dfx canister call "$GOVERNANCE_CANISTER_ID" list_neurons '(record {limit=10})' | idl2json | jq -r '.neurons[] | select(.dissolve_state[].DissolveDelaySeconds == "0") | .id[].id | join("; ")')"
+PRINCIPAL="$(dfx identity get-principal)"
+
+NEURON_ID="$(dfx canister call "$GOVERNANCE_CANISTER_ID" list_neurons "(record
+{of_principal=opt principal \"$PRINCIPAL\"; limit=100})" | idl2json | jq -r '.neurons[] | select(.dissolve_state[].DissolveDelaySeconds == "0") | .id[].id | join("; ")')"
 
 dfx canister call "$GOVERNANCE_CANISTER_ID" manage_neuron "(record { subaccount = vec { ${NEURON_ID} }; command = opt (variant { Disburse = record { } }) })"

--- a/bin/dfx-sns-quill-canister-ids
+++ b/bin/dfx-sns-quill-canister-ids
@@ -8,12 +8,12 @@ PATH="$SOURCE_DIR:$PATH"
 source "$SOURCE_DIR/clap.bash"
 # Define options
 clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
-clap.define short=r long=network desc="get the cnister IDs from the root canister" variable=USE_ROOT nargs=0
+clap.define short=r long=from_root desc="Get the canister IDs from the root canister" variable=USE_ROOT nargs=0
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
 if test -n "${USE_ROOT:-}"; then
-  dfx canister call sns_root list_sns_canisters '(record {})' | idl2json | jq '{ governance_canister_id: .governance[0], ledger_canister_id: .ledger[0], root_canister_id: .root[0], swap_canister_id: .swap[0], dapp_canister_id_list: .dapps }'
+  dfx canister call sns_root list_sns_canisters '(record {})' --network "$DFX_NETWORK" | idl2json | jq '{ governance_canister_id: .governance[0], ledger_canister_id: .ledger[0], root_canister_id: .root[0], swap_canister_id: .swap[0], dapp_canister_id_list: .dapps }'
 else
   cat <<-EOF | jq .
 	{

--- a/bin/dfx-sns-sale-buy
+++ b/bin/dfx-sns-sale-buy
@@ -29,7 +29,7 @@ TICKET_RESPONSE_JSON="$(echo "$TICKET_RESPONSE" | idl2json)"
 TICKET_ID="$(echo "$TICKET_RESPONSE_JSON" | jq -r '.result[0].Ok.ticket[0].ticket_id')"
 TICKET_CREATION_TIME="$(echo "$TICKET_RESPONSE_JSON" | jq -r '.result[0].Ok.ticket[0].creation_time')"
 
-set dfx-sns-quill --network local pay --amount-icp-e8s "$AMOUNT_E8S" --ticket-id "$TICKET_ID" --ticket-creation-time "$TICKET_CREATION_TIME"
+set dfx-sns-quill --network "$DFX_NETWORK" pay --amount-icp-e8s "$AMOUNT_E8S" --ticket-id "$TICKET_ID" --ticket-creation-time "$TICKET_CREATION_TIME"
 echo "${@}"
 "${@}" || {
   echo "ERROR: Failed to participate in SNS swap."

--- a/bin/dfx-sns-transfer-to-faucet
+++ b/bin/dfx-sns-transfer-to-faucet
@@ -17,7 +17,7 @@ PRINCIPAL="$(dfx identity get-principal)"
 
 BALANCE_E8S="$(dfx canister call "$LEDGER_CANISTER_ID" icrc1_balance_of "(record { owner=principal \"$PRINCIPAL\" })" | idl2json | jq 'gsub("_"; "") | tonumber')"
 
-FEE_E8S="$(dfx canister call $LEDGER_CANISTER_ID icrc1_fee '(record
+FEE_E8S="$(dfx canister call "$LEDGER_CANISTER_ID" icrc1_fee '(record
 {})' | idl2json | jq -r 'gsub("_"; "") | tonumber')"
 
 from_e8s() {

--- a/bin/dfx-sns-transfer-to-faucet
+++ b/bin/dfx-sns-transfer-to-faucet
@@ -15,10 +15,10 @@ LEDGER_CANISTER_ID="$(dfx canister call sns_root list_sns_canisters '(record {})
 
 PRINCIPAL="$(dfx identity get-principal)"
 
-BALANCE_E8S="$(dfx canister call "$LEDGER_CANISTER_ID" icrc1_balance_of "(record { owner=principal \"$PRINCIPAL\" })"|idl2json|jq 'gsub("_"; "") | tonumber')"
+BALANCE_E8S="$(dfx canister call "$LEDGER_CANISTER_ID" icrc1_balance_of "(record { owner=principal \"$PRINCIPAL\" })" | idl2json | jq 'gsub("_"; "") | tonumber')"
 
 FEE_E8S="$(dfx canister call $LEDGER_CANISTER_ID icrc1_fee '(record
-{})'|idl2json|jq -r 'gsub("_"; "") | tonumber')"
+{})' | idl2json | jq -r 'gsub("_"; "") | tonumber')"
 
 from_e8s() {
   amount_e8s="$1"

--- a/bin/dfx-sns-transfer-to-faucet
+++ b/bin/dfx-sns-transfer-to-faucet
@@ -21,7 +21,7 @@ set -euo pipefail
 
 export DFX_NETWORK
 
-LEDGER_CANISTER_ID="$(dfx canister call sns_root list_sns_canisters '(record {})' --network "$DFX_NETWORK"| idl2json | jq -r '.ledger | .[]')"
+LEDGER_CANISTER_ID="$(dfx canister call sns_root list_sns_canisters '(record {})' --network "$DFX_NETWORK" | idl2json | jq -r '.ledger | .[]')"
 
 PRINCIPAL="$(dfx identity get-principal --network "$DFX_NETWORK")"
 

--- a/bin/dfx-sns-transfer-to-faucet
+++ b/bin/dfx-sns-transfer-to-faucet
@@ -21,14 +21,14 @@ set -euo pipefail
 
 export DFX_NETWORK
 
-LEDGER_CANISTER_ID="$(dfx canister call sns_root list_sns_canisters '(record {})' | idl2json | jq -r '.ledger | .[]')"
+LEDGER_CANISTER_ID="$(dfx canister call sns_root list_sns_canisters '(record {})' --network "$DFX_NETWORK"| idl2json | jq -r '.ledger | .[]')"
 
-PRINCIPAL="$(dfx identity get-principal)"
+PRINCIPAL="$(dfx identity get-principal --network "$DFX_NETWORK")"
 
-BALANCE_E8S="$(dfx canister call "$LEDGER_CANISTER_ID" icrc1_balance_of "(record { owner=principal \"$PRINCIPAL\" })" | idl2json | jq 'gsub("_"; "") | tonumber')"
+BALANCE_E8S="$(dfx canister call "$LEDGER_CANISTER_ID" icrc1_balance_of "(record { owner=principal \"$PRINCIPAL\" })" --network "$DFX_NETWORK" | idl2json | jq 'gsub("_"; "") | tonumber')"
 
 FEE_E8S="$(dfx canister call "$LEDGER_CANISTER_ID" icrc1_fee '(record
-{})' | idl2json | jq -r 'gsub("_"; "") | tonumber')"
+{})' --network "$DFX_NETWORK" | idl2json | jq -r 'gsub("_"; "") | tonumber')"
 
 from_e8s() {
   amount_e8s="$1"
@@ -42,4 +42,4 @@ FEE="$(from_e8s "$FEE_E8S")"
 # See https://github.com/dfinity/nns-dapp/blob/main/frontend/src/lib/api/dev.api.ts
 FAUCET_ADDRESS="jg6qm-uw64t-m6ppo-oluwn-ogr5j-dc5pm-lgy2p-eh6px-hebcd-5v73i-nqe"
 
-bin/dfx-sns-quill transfer --amount "$AMOUNT" --fee "$FEE" "$FAUCET_ADDRESS"
+bin/dfx-sns-quill --network "$DFX_NETWORK" transfer --amount "$AMOUNT" --fee "$FEE" "$FAUCET_ADDRESS"

--- a/bin/dfx-sns-transfer-to-faucet
+++ b/bin/dfx-sns-transfer-to-faucet
@@ -3,6 +3,14 @@ SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
 . "$SOURCE_DIR/versions.bash"
 
+print_help() {
+  cat <<-EOF
+
+	Transfers the full balance, less the fee, of SNS tokens to the faucet address
+  such that the "Get Tokens" button in the nns-dapp UI can be used.
+	EOF
+}
+
 # Source the clap.bash file ---------------------------------------------------
 source "$SOURCE_DIR/clap.bash"
 # Define options
@@ -10,6 +18,8 @@ clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETW
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 set -euo pipefail
+
+export DFX_NETWORK
 
 LEDGER_CANISTER_ID="$(dfx canister call sns_root list_sns_canisters '(record {})' | idl2json | jq -r '.ledger | .[]')"
 
@@ -29,6 +39,7 @@ from_e8s() {
 AMOUNT="$(from_e8s "$((BALANCE_E8S - FEE_E8S))")"
 FEE="$(from_e8s "$FEE_E8S")"
 
+# See https://github.com/dfinity/nns-dapp/blob/main/frontend/src/lib/api/dev.api.ts
 FAUCET_ADDRESS="jg6qm-uw64t-m6ppo-oluwn-ogr5j-dc5pm-lgy2p-eh6px-hebcd-5v73i-nqe"
 
 bin/dfx-sns-quill transfer --amount "$AMOUNT" --fee "$FEE" "$FAUCET_ADDRESS"

--- a/bin/dfx-sns-transfer-to-faucet
+++ b/bin/dfx-sns-transfer-to-faucet
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+PATH="$SOURCE_DIR:$PATH"
+. "$SOURCE_DIR/versions.bash"
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/clap.bash"
+# Define options
+clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+set -euo pipefail
+
+LEDGER_CANISTER_ID="$(dfx canister call sns_root list_sns_canisters '(record {})' | idl2json | jq -r '.ledger | .[]')"
+
+PRINCIPAL="$(dfx identity get-principal)"
+
+BALANCE_E8S="$(dfx canister call "$LEDGER_CANISTER_ID" icrc1_balance_of "(record { owner=principal \"$PRINCIPAL\" })"|idl2json|jq 'gsub("_"; "") | tonumber')"
+
+FEE_E8S="$(dfx canister call $LEDGER_CANISTER_ID icrc1_fee '(record
+{})'|idl2json|jq -r 'gsub("_"; "") | tonumber')"
+
+from_e8s() {
+  amount_e8s="$1"
+  amount="$(awk "BEGIN {printf \"%.8f\", $amount_e8s * 0.00000001}")"
+  echo "$amount"
+}
+
+AMOUNT="$(from_e8s "$((BALANCE_E8S - FEE_E8S))")"
+FEE="$(from_e8s "$FEE_E8S")"
+
+FAUCET_ADDRESS="jg6qm-uw64t-m6ppo-oluwn-ogr5j-dc5pm-lgy2p-eh6px-hebcd-5v73i-nqe"
+
+bin/dfx-sns-quill transfer --amount "$AMOUNT" --fee "$FEE" "$FAUCET_ADDRESS"


### PR DESCRIPTION
# Motivation

To do manual and end-to-end testing the user needs access to SNS tokens.
The easiest way to get tokens is through the "Get Tokens" button, which sends tokens from a special address.

# Changes

1. Add a script to disburse the non-locked neuron after a sale is finalized.
2. Add a script to transfer tokens to the faucet (Get Tokens) address.
3. Call the scripts to fill the faucet from the sns demo.

# Testing

Ran the demo and verified that "Get Tokens" works in the UI.