### PR TITLE
Clap should cope when there are no options to handle

### DIFF
--- a/bin/clap.bash
+++ b/bin/clap.bash
@@ -95,7 +95,7 @@ cat << XXX
 usage: \$(basename "\$0") [OPTIONS]
 
 OPTIONS:
-        $clap_usage
+        ${clap_usage:-}
 
         -? --help  :  usage
 
@@ -109,8 +109,8 @@ XXX
 [[ "\${COMP_LINE:-}" == "" ]] || [[ "\${COMP_POINT:-}" == "" ]] || {
 	COMP_CURRENT="${1:-}"
 	case "\$COMP_CURRENT" in
-	"")	compgen -W "$clap_flags" -- "\$COMP_CURRENT" ;;
-	-*)	compgen -W "$clap_flags" -- "\$COMP_CURRENT" ;;
+	"")	compgen -W "${clap_flags:-}" -- "\$COMP_CURRENT" ;;
+	-*)	compgen -W "${clap_flags:-}" -- "\$COMP_CURRENT" ;;
 	*)	compgen -f -- "\$COMP_CURRENT" ;;
 	esac
 	exit 0


### PR DESCRIPTION
# Motivation
`clap.bash` is an argument parser, however it should still cope if no custom arguments are defined and the only arguments it has to handle are `--help` and `--verbose`.  Yet now it fails due to the use of an unset var.

# Changes
- Handle the case where no custom flags are defined.