### PR TITLE
Handle no help

### DIFF
--- a/bin/clap.bash
+++ b/bin/clap.bash
@@ -127,7 +127,7 @@ while [ \$# -ne 0 ]; do
         case "\$param" in
                 $clap_flag_match
                 "-?"|--help)
-			print_help
+			[[ "$(type -t print_help)" != function ]] || print_help
 			echo
                         usage
                         exit 0;;

--- a/bin/dfx-canister-set-id
+++ b/bin/dfx-canister-set-id
@@ -4,6 +4,18 @@ SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
 . "$SOURCE_DIR/versions.bash"
 
+print_help() {
+	cat <<-EOF
+
+	Records the ID of a canister in the dfx state.
+
+	After this command has completed, this will return the specified ID:
+
+	dfx canister id <CANISTER_NAME> --network <DFX_NETWORK>
+
+	EOF
+}
+
 # Source the clap.bash file ---------------------------------------------------
 source "$SOURCE_DIR/clap.bash"
 # Define options

--- a/bin/dfx-canister-set-id
+++ b/bin/dfx-canister-set-id
@@ -5,7 +5,7 @@ PATH="$SOURCE_DIR:$PATH"
 . "$SOURCE_DIR/versions.bash"
 
 print_help() {
-	cat <<-EOF
+  cat <<-EOF
 
 	Records the ID of a canister in the dfx state.
 

--- a/bin/dfx-identity-pem
+++ b/bin/dfx-identity-pem
@@ -3,6 +3,18 @@ set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 export PATH="$SOURCE_DIR:$PATH"
 
+print_help() {
+	cat <<-EOF
+
+	Returns the path to the PEM file for a dfx identity.
+
+	Note: At a given time, a given identity may not have a PEM file.
+	      This command will return the path to where the PEM would
+	      be even if it does not exist.
+
+	EOF
+}
+
 # Source the clap.bash file ---------------------------------------------------
 source "$SOURCE_DIR/clap.bash"
 # Define options

--- a/bin/dfx-identity-pem
+++ b/bin/dfx-identity-pem
@@ -4,7 +4,7 @@ SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 export PATH="$SOURCE_DIR:$PATH"
 
 print_help() {
-	cat <<-EOF
+  cat <<-EOF
 
 	Returns the path to the PEM file for a dfx identity.
 

--- a/bin/dfx-identity-principal-lookup
+++ b/bin/dfx-identity-principal-lookup
@@ -3,6 +3,20 @@ SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
 . "$SOURCE_DIR/versions.bash"
 
+print_help() {
+	cat <<-EOF
+
+	Prints a list of the principals of all the DFX identities.
+
+	Note: This is useful for users with multiple identities
+	      who struggle to remember which identity they used
+	      to create a given canister.  They  can get the
+	      canister controller and then look it up in their
+	      list of principals.
+
+	EOF
+}
+
 # Source the clap.bash file ---------------------------------------------------
 source "$SOURCE_DIR/clap.bash"
 # Define options

--- a/bin/dfx-identity-principal-lookup
+++ b/bin/dfx-identity-principal-lookup
@@ -4,7 +4,7 @@ PATH="$SOURCE_DIR:$PATH"
 . "$SOURCE_DIR/versions.bash"
 
 print_help() {
-	cat <<-EOF
+  cat <<-EOF
 
 	Prints a list of the principals of all the DFX identities.
 

--- a/bin/dfx-ledger-get-icp
+++ b/bin/dfx-ledger-get-icp
@@ -3,7 +3,7 @@ set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 
 print_help() {
-	cat <<-EOF
+  cat <<-EOF
 
 	Gives a user toy ICP, taken from an affluent friar
 	deployed with every local testnet.

--- a/bin/dfx-ledger-get-icp
+++ b/bin/dfx-ledger-get-icp
@@ -29,6 +29,8 @@ check_moneybags() {
   dfx identity get-principal --identity ident-1 >/dev/null 2>/dev/null
 }
 # Imports an identity that has a billion toy ICP on testnets.
+# The key is as specified in the `dfx nns` documentation: https://internetcomputer.org/docs/current/references/cli-reference/dfx-nns#_dfx_nns_install
+# and implemented in the sdk repo: https://github.com/dfinity/sdk/search?q=ident-1
 make_moneybags() {
   (
     set -euo pipefail

--- a/bin/dfx-ledger-get-icp
+++ b/bin/dfx-ledger-get-icp
@@ -2,6 +2,15 @@
 set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 
+print_help() {
+	cat <<-EOF
+
+	Gives a user toy ICP, taken from an affluent friar
+	deployed with every local testnet.
+
+	EOF
+}
+
 # Source the clap.bash file ---------------------------------------------------
 source "$SOURCE_DIR/clap.bash"
 # Define options

--- a/bin/dfx-network-config-add
+++ b/bin/dfx-network-config-add
@@ -4,6 +4,18 @@ SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
 . "$SOURCE_DIR/versions.bash"
 
+print_help() {
+	cat <<-EOF
+
+	Adds a static testnet to the local network config.
+
+	Note: Static testnets are defined in the IC repo.
+	      The user must have the ic repo checked out
+	      locally.
+
+	EOF
+}
+
 # Source the clap.bash file ---------------------------------------------------
 source "$SOURCE_DIR/clap.bash"
 # Define options

--- a/bin/dfx-network-config-add
+++ b/bin/dfx-network-config-add
@@ -5,7 +5,7 @@ PATH="$SOURCE_DIR:$PATH"
 . "$SOURCE_DIR/versions.bash"
 
 print_help() {
-	cat <<-EOF
+  cat <<-EOF
 
 	Adds a static testnet to the local network config.
 

--- a/bin/dfx-network-delete
+++ b/bin/dfx-network-delete
@@ -3,7 +3,7 @@ set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 
 print_help() {
-	cat <<-EOF
+  cat <<-EOF
 
 	Deletes a network from the local dfx state, including:
 	* Canister IDs

--- a/bin/dfx-network-delete
+++ b/bin/dfx-network-delete
@@ -2,6 +2,16 @@
 set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 
+print_help() {
+	cat <<-EOF
+
+	Deletes a network from the local dfx state, including:
+	* Canister IDs
+	* Wallet IDs.
+
+	EOF
+}
+
 # Source the clap.bash file ---------------------------------------------------
 source "$SOURCE_DIR/clap.bash"
 # Define options

--- a/bin/dfx-network-deploy
+++ b/bin/dfx-network-deploy
@@ -4,7 +4,7 @@ SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
 
 print_help() {
-	cat <<-EOF
+  cat <<-EOF
 
 	Deploys a testnet with:
 	* NNS canisters

--- a/bin/dfx-network-deploy
+++ b/bin/dfx-network-deploy
@@ -3,6 +3,16 @@ set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
 
+print_help() {
+	cat <<-EOF
+
+	Deploys a testnet with:
+	* NNS canisters
+	* An empty placeholder for the sns_aggregator canister.
+
+	EOF
+}
+
 # Source the clap.bash file ---------------------------------------------------
 source "$SOURCE_DIR/clap.bash"
 # Define options


### PR DESCRIPTION
# Motivation
Many scripts do not yet have a help description.

# Changes
- Populate some of the help texts.  There are more to do when there is time.
- If no help text is defined, do not print an error message.