### PR TITLE
Put the state in the global cache

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -52,7 +52,7 @@ jobs:
           ./bin/dfx-sns-demo-mksns-parallel -s 10 -m snsdemo8
       - name: Save state
         if: matrix.os != 'macos-11'
-        run: bin/dfx-state-save --verbose
+        run: bin/dfx-state-save --verbose --state state.zip
       - name: Upload state
         if: matrix.os != 'macos-11'
         uses: actions/upload-artifact@v3

--- a/bin/dfx-state-install
+++ b/bin/dfx-state-install
@@ -17,7 +17,7 @@ help_text() {
 # Source the clap.bash file ---------------------------------------------------
 source "$SOURCE_DIR/clap.bash"
 # Define options
-clap.define short=f long=state desc="The state file to save to" variable=DFX_STATE_FILE default="state.zip"
+clap.define short=f long=state desc="The state file to save to" variable=DFX_STATE_FILE default="$(dfx cache show)/state.zip"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 

--- a/bin/dfx-state-save
+++ b/bin/dfx-state-save
@@ -13,7 +13,7 @@ print_help() {
 # Source the clap.bash file ---------------------------------------------------
 source "$SOURCE_DIR/clap.bash"
 # Define options
-clap.define short=s long=state desc="The state file to save to" variable=DFX_STATE_FILE default="state.zip"
+clap.define short=s long=state desc="The state file to save to" variable=DFX_STATE_FILE default="$(dfx cache show)/state.zip"
 clap.define short=i long=identities desc="The identities to save" variable=DFX_IDENTITIES default="snsdemo8,ident-1"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"


### PR DESCRIPTION
# Motivation
Stat snapshots are quite large.  The state snapshot used to spin up a test environment does not normally vary by where it is used.  So, by default, a common location can be used.

# Changes
- By default, store snapshots in the global dfx cache.