### PR TITLE
Get provider local port

### DIFF
--- a/bin/dfx-network-provider
+++ b/bin/dfx-network-provider
@@ -23,7 +23,7 @@ export DFX_NETWORK
 case "${FORMAT}" in
 url)
   if [[ "$DFX_NETWORK" == "local" ]]; then
-    echo "http://localhost:$(dfx info replica-port)"
+    echo "http://localhost:$(cd "$(realpath "/proc/$(pgrep icx-proxy | head -n1)/cwd")" && dfx info replica-port)"
   elif [[ "${DFX_NETWORK:-}" =~ mainnet|ic ]]; then
     echo "https://ic0.app"
   else

--- a/bin/dfx-network-provider
+++ b/bin/dfx-network-provider
@@ -23,7 +23,12 @@ export DFX_NETWORK
 case "${FORMAT}" in
 url)
   if [[ "$DFX_NETWORK" == "local" ]]; then
-    echo "http://localhost:$(cd "$(realpath "/proc/$(pgrep icx-proxy | head -n1)/cwd")" && dfx info replica-port)"
+    REPLICA_PORT="$(dfx info replica-port 2>/dev/null || true)"
+    [[ "${REPLICA_PORT:-}" != "" ]] || {
+      # The above command can fail if not run in the same directory as the replica working directory.
+      REPLICA_PORT="$(cd "$(realpath "/proc/$(pgrep icx-proxy | head -n1)/cwd")" && dfx info replica-port)"
+    }
+    echo "http://localhost:$REPLICA_PORT"
   elif [[ "${DFX_NETWORK:-}" =~ mainnet|ic ]]; then
     echo "https://ic0.app"
   else


### PR DESCRIPTION
# Motivation
Getting the local dfx replica port can fail if not run in the same directory as the replica.

# Changes
Try changing directory.