### PR TITLE
Get replica state from a different directory on Mac

### DIFF
--- a/bin/dfx-state-save
+++ b/bin/dfx-state-save
@@ -18,6 +18,21 @@ clap.define short=i long=identities desc="The identities to save" variable=DFX_I
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
+case "$(uname)" in
+Linux)
+  REPLICA_STATE_DIR=".local/share/dfx"
+  ;;
+Darwin)
+  REPLICA_STATE_DIR="Library/Application Support/org.dfinity.dfx/network/local"
+  ;;
+*)
+  {
+    echo "ERROR: Unsupported OS: $(uname)"
+    exit 1
+  }
+  ;;
+esac
+
 # Get the absolute path to the output file and make sure that teh containing dir exists.
 DFX_STATE_DIR="$(dirname "$DFX_STATE_FILE")"
 mkdir -p "$DFX_STATE_DIR"
@@ -28,7 +43,7 @@ IFS=', ' read -r -a DFX_IDENTITIES <<<"$DFX_IDENTITIES"
 
 # Get global state
 pushd "$HOME"
-zip -r "$DFX_STATE_FILE" .local/share/dfx .config/dfx/networks.json
+zip -r "$DFX_STATE_FILE" "$REPLICA_STATE_DIR" .config/dfx/networks.json
 for id in "${DFX_IDENTITIES[@]}"; do
   zip -r "$DFX_STATE_FILE" ".config/dfx/identity/${id}"
 done

--- a/bin/dfx-state-save
+++ b/bin/dfx-state-save
@@ -20,10 +20,10 @@ source "$(clap.build)"
 
 case "$(uname)" in
 Linux)
-  REPLICA_STATE_DIR=".local/share/dfx"
+  DFX_DATA_DIR=".local/share/dfx"
   ;;
 Darwin)
-  REPLICA_STATE_DIR="Library/Application Support/org.dfinity.dfx/network/local"
+  DFX_DATA_DIR="Library/Application Support/org.dfinity.dfx/network/local"
   ;;
 *)
   {
@@ -43,7 +43,7 @@ IFS=', ' read -r -a DFX_IDENTITIES <<<"$DFX_IDENTITIES"
 
 # Get global state
 pushd "$HOME"
-zip -r "$DFX_STATE_FILE" "$REPLICA_STATE_DIR" .config/dfx/networks.json
+zip -r "$DFX_STATE_FILE" "$DFX_DATA_DIR" .config/dfx/networks.json
 for id in "${DFX_IDENTITIES[@]}"; do
   zip -r "$DFX_STATE_FILE" ".config/dfx/identity/${id}"
 done


### PR DESCRIPTION
# Motivation

Being able to save an snsdemo state once and use it multiple times is useful for Mac users as well.

# Changes

In `bin/dfx-state-save` check `uname` and use a different path to include in the state.zip depending on the OS.

# Testing

I have my own version of the `dfx-state-install` script which saves a user's existing state before replacing it with the saved state and I used that to test installing the state created by `bin/dfx-state-save`.