### PR TITLE
Stop before saving state

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -65,6 +65,7 @@ jobs:
           ./bin/dfx-network-stop
           sleep 1
           echo "Saving state"
+          bin/dfx-state-save --verbose --state state.zip
       - name: Upload state
         if: matrix.os != 'macos-11'
         uses: actions/upload-artifact@v3

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -52,7 +52,19 @@ jobs:
           ./bin/dfx-sns-demo-mksns-parallel -s 10 -m snsdemo8
       - name: Save state
         if: matrix.os != 'macos-11'
-        run: bin/dfx-state-save --verbose
+        run: |
+          # How can you tell that I don't trust dfx stop
+          dfx stop
+          echo "Waiting for replica to stop"
+          for (( i=100; i>0; i-- )); do
+              echo "$i"
+              pgrep replica || break
+              sleep 1
+          done
+          echo "Making sure the replica is dead"
+          ./bin/dfx-network-stop
+          sleep 1
+          echo "Saving state"
       - name: Upload state
         if: matrix.os != 'macos-11'
         uses: actions/upload-artifact@v3

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Save state
         if: matrix.os != 'macos-11'
         run: |
-          # How can you tell that I don't trust dfx stop
+          # Stop the replica to let it persist all its state before we save the state.
           dfx stop
           echo "Waiting for replica to stop"
           for (( i=100; i>0; i-- )); do


### PR DESCRIPTION
# Motivation
Saving the data from a stopped replica is less likely to go wrong