### PR TITLE
Use the term 'snapshot'

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -65,7 +65,7 @@ jobs:
           ./bin/dfx-network-stop
           sleep 1
           echo "Saving state"
-          bin/dfx-state-save --verbose --state state.zip
+          bin/dfx-state-save --verbose --snapshot state.zip
       - name: Upload state
         if: matrix.os != 'macos-11'
         uses: actions/upload-artifact@v3

--- a/bin/dfx-state-install
+++ b/bin/dfx-state-install
@@ -17,15 +17,15 @@ help_text() {
 # Source the clap.bash file ---------------------------------------------------
 source "$SOURCE_DIR/clap.bash"
 # Define options
-clap.define short=f long=state desc="The state file to save to" variable=DFX_STATE_FILE default="state.zip"
+clap.define short=s long=snapshot desc="The file to save to" variable=DFX_SNAPSHOT_FILE default="state.zip"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
-DFX_STATE_FILE="$(realpath "$DFX_STATE_FILE")"
+DFX_SNAPSHOT_FILE="$(realpath "$DFX_SNAPSHOT_FILE")"
 
 pushd "$HOME"
 rm -fr .local/share/dfx
-unzip -q "$DFX_STATE_FILE"
+unzip -q "$DFX_SNAPSHOT_FILE"
 # Note: dfx start works here but not in the project dir.
 dfx start --background
 num_canisters="$(curl -s "http://localhost:$(dfx info replica-port)/_/dashboard" | grep -c '<h3>Execution state</h3>')"

--- a/bin/dfx-state-save
+++ b/bin/dfx-state-save
@@ -13,7 +13,7 @@ print_help() {
 # Source the clap.bash file ---------------------------------------------------
 source "$SOURCE_DIR/clap.bash"
 # Define options
-clap.define short=s long=state desc="The state file to save to" variable=DFX_STATE_FILE default="state.zip"
+clap.define short=s long=snapshot desc="The file to save to" variable=DFX_SNAPSHOT_FILE default="state.zip"
 clap.define short=i long=identities desc="The identities to save" variable=DFX_IDENTITIES default="snsdemo8,ident-1"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
@@ -34,22 +34,22 @@ Darwin)
 esac
 
 # Get the absolute path to the output file and make sure that teh containing dir exists.
-DFX_STATE_DIR="$(dirname "$DFX_STATE_FILE")"
+DFX_STATE_DIR="$(dirname "$DFX_SNAPSHOT_FILE")"
 mkdir -p "$DFX_STATE_DIR"
-DFX_STATE_FILE="$(realpath "$DFX_STATE_DIR")/$(basename "$DFX_STATE_FILE")"
+DFX_SNAPSHOT_FILE="$(realpath "$DFX_STATE_DIR")/$(basename "$DFX_SNAPSHOT_FILE")"
 
 # Put the identities to save into an array
 IFS=', ' read -r -a DFX_IDENTITIES <<<"$DFX_IDENTITIES"
 
 # Get global state
 pushd "$HOME"
-zip -r "$DFX_STATE_FILE" "$DFX_DATA_DIR" .config/dfx/networks.json
+zip -r "$DFX_SNAPSHOT_FILE" "$DFX_DATA_DIR" .config/dfx/networks.json
 for id in "${DFX_IDENTITIES[@]}"; do
-  zip -r "$DFX_STATE_FILE" ".config/dfx/identity/${id}"
+  zip -r "$DFX_SNAPSHOT_FILE" ".config/dfx/identity/${id}"
 done
 
 # Get local project state
 popd
 if test -d .dfx; then
-  zip -r "$DFX_STATE_FILE" .dfx
+  zip -r "$DFX_SNAPSHOT_FILE" .dfx
 fi

--- a/bin/dfx-state-save
+++ b/bin/dfx-state-save
@@ -33,10 +33,10 @@ Darwin)
   ;;
 esac
 
-# Get the absolute path to the output file and make sure that teh containing dir exists.
-DFX_STATE_DIR="$(dirname "$DFX_SNAPSHOT_FILE")"
-mkdir -p "$DFX_STATE_DIR"
-DFX_SNAPSHOT_FILE="$(realpath "$DFX_STATE_DIR")/$(basename "$DFX_SNAPSHOT_FILE")"
+# Get the absolute path to the output file and make sure that the containing dir exists.
+DFX_SNAPSHOT_DIR="$(dirname "$DFX_SNAPSHOT_FILE")"
+mkdir -p "$DFX_SNAPSHOT_DIR"
+DFX_SNAPSHOT_FILE="$(realpath "$DFX_SNAPSHOT_DIR")/$(basename "$DFX_SNAPSHOT_FILE")"
 
 # Put the identities to save into an array
 IFS=', ' read -r -a DFX_IDENTITIES <<<"$DFX_IDENTITIES"


### PR DESCRIPTION
# Motivation
We have had a rash of different directories all being called the state dir. Some clearer, less ambiguous names would be helpful.  In particular, the replica state captured in a file can be called a snapshot.