### PR TITLE
Escape default

### DIFF
--- a/bin/clap.bash
+++ b/bin/clap.bash
@@ -75,7 +75,7 @@ function clap.define() {
 		clap_flag_match="${clap_flag_match}#NL#TB#TB${long}${short:+|${short}})#NL#TB#TB#TB${variable}=(); for ((i=0; i<nargs; i++)); do ${variable}+=( \"\$1\" ); shift 1; done;;"
 	fi
 	if [ "${default:-}" != "" ]; then
-		clap_defaults="${clap_defaults}#NL${variable}=${default}"
+		clap_defaults="${clap_defaults}#NL${variable}=${default@Q}"
 	fi
 	clap_arguments_string="${clap_arguments_string}${shortname:-}"
 	if [ "${val:-}" = "\$OPTARG" ]; then

--- a/bin/clap.test
+++ b/bin/clap.test
@@ -4,6 +4,7 @@ set -euo pipefail
 (
   set -euo pipefail
   echo "Testing with all features"
+  WHACKY_DEFAULT="<booby 'trap'!>"
   script() {
     set -euo pipefail
     # Script header:
@@ -17,6 +18,7 @@ set -euo pipefail
     clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
     clap.define short=p long=prodlike desc="Make it like prod (experimental)" variable=DFX_PRODLIKE nargs=0 default="false"
     clap.define short=I long=ii_release desc="The release of II to use" variable=DFX_II_RELEASE default=""
+    clap.define long=whacky-defgault desc="Value with fun characters in the default" variable=WHACKY default="${WHACKY_DEFAULT}"
     clap.define long=just_long desc="An option without a short flag" variable=DFX_LONG_OPTION default=""
     clap.define short=c long=commit desc="The IC commit of the wasms" variable=DFX_IC_COMMIT default="$(
       . "$SOURCE_DIR/versions.bash"
@@ -84,6 +86,15 @@ set -euo pipefail
     EXPECTED="true"
     [[ "${DFX_PRODLIKE:-}" == "$EXPECTED" ]] || {
       echo "ERROR: DFX_PRODLIKE not set to expected value '$EXPECTED': '${DFX_PRODLIKE:-}'"
+      exit 1
+    }
+  )
+
+  (
+    echo "Default variables are handled safely"
+    script
+    [[ "$WHACKY" == "$WHACKY_DEFAULT" ]] || {
+      echo "ERROR: WHACKY not set to expected default value '$WHACKY_DEFAULT': '${WHACKY:-}'"
       exit 1
     }
   )


### PR DESCRIPTION
# Motivation
By the way, it seems like clap doesn't allow \< or \> or even spaces in default values.

Context, I wanted the default to be "dfx-state-backeup-\<generated timestamp\>". I was then going to check if the default was changed or not and if not, I would generate a new value. I thought it would look good in --help like that.

# Changes
* Escape the default variable

# Tests
* A test has been added that exercises a default value with `< >` and similar characters.  It fails without the fix, works with the fix.