### PR TITLE
Use different replica data dir when saving a snapshot on Mac

### DIFF
--- a/bin/dfx-nns-import
+++ b/bin/dfx-nns-import
@@ -26,7 +26,7 @@ EOF
 ) >dfx.new
 mv dfx.new dfx.json
 
-mkdir declarations
+mkdir -p declarations
 
 cat <<'EOF' >declarations/internet_identity.did
 type UserNumber = nat64;

--- a/bin/dfx-snapshot-save
+++ b/bin/dfx-snapshot-save
@@ -20,10 +20,10 @@ source "$(clap.build)"
 
 case "$(uname)" in
 Linux)
-  DFX_SNAPSHOT_DIR=".local/share/dfx"
+  LOCAL_REPLICA_DATA_DIR=".local/share/dfx"
   ;;
 Darwin)
-  DFX_SNAPSHOT_DIR="Library/Application Support/org.dfinity.dfx/network/local"
+  LOCAL_REPLICA_DATA_DIR="Library/Application Support/org.dfinity.dfx/network/local"
   ;;
 *)
   {
@@ -45,7 +45,7 @@ IFS=', ' read -r -a DFX_IDENTITIES <<<"$DFX_IDENTITIES"
 
 # Get global state
 pushd "$HOME"
-tar --create --file "$DFX_SNAPSHOT_TEMP_FILE" .local/share/dfx .config/dfx/networks.json
+tar --create --file "$DFX_SNAPSHOT_TEMP_FILE" "$LOCAL_REPLICA_DATA_DIR" .config/dfx/networks.json
 for id in "${DFX_IDENTITIES[@]}"; do
   tar --append --file "$DFX_SNAPSHOT_TEMP_FILE" ".config/dfx/identity/${id}"
 done


### PR DESCRIPTION
# Motivation

`bin/dfx-snapshot-save` checks the OS to determine the local replica data dir, but then doesn't do anything with it.

# Changes

1. Actually use the local replica data dir when archiving the snapshot
2. Small unrelated fix: Don't fail in `dfx-nns-import` if the `declarations` directory already exists.

# Tested

Created a snapshot on Mac and used it to run locally with changes from https://github.com/dfinity/nns-dapp/pull/2252