### PR TITLE
Fix bin/dfx-network-provider on Mac

### DIFF
--- a/bin/dfx-network-provider
+++ b/bin/dfx-network-provider
@@ -20,6 +20,9 @@ source "$(clap.build)"
 
 export DFX_NETWORK
 
+# Work-around required to be able to run `dfx info`.
+# A proper fix is in dfx 0.14.0.
+# TODO: Remove this once we use dfx 0.14.0.
 get_home() {
   eval echo "~$USER"
 }

--- a/bin/dfx-network-provider
+++ b/bin/dfx-network-provider
@@ -20,13 +20,19 @@ source "$(clap.build)"
 
 export DFX_NETWORK
 
+get_home() {
+  eval echo "~$USER"
+}
+
 case "${FORMAT}" in
 url)
   if [[ "$DFX_NETWORK" == "local" ]]; then
     REPLICA_PORT="$(dfx info replica-port 2>/dev/null || true)"
     [[ "${REPLICA_PORT:-}" != "" ]] || {
       # The above command can fail if not run in the same directory as the replica working directory.
-      REPLICA_PORT="$(cd "$(realpath "/proc/$(pgrep icx-proxy | head -n1)/cwd")" && dfx info replica-port)"
+      DFX_EXEC_DIR="$(lsof -p $(pgrep icx-proxy) | grep cwd | awk '{print $NF}')"
+      cd "$DFX_EXEC_DIR"
+      REPLICA_PORT="$(HOME="$(get_home)" dfx info replica-port)"
     }
     echo "http://localhost:$REPLICA_PORT"
   elif [[ "${DFX_NETWORK:-}" =~ mainnet|ic ]]; then


### PR DESCRIPTION
# Motivation

Being able to create the same state on local development machine as on CI.

# Changes

1. Use `lsof` instead of `/proc` to determine in which directory a process was started.
2. Set `HOME` to the user's home directory before running `dfx info replica-port`. (It is set to something else in `become_user()` in `bin/dfx-sns-demo-mksns-parallel`

# Testing

1. Ran `bin/dfx-sns-demo-mksns-parallel` on my M1 mac.
2. Tested `lsof` and `eval echo "~$USER"` separately on my personal Ubuntu laptop.