### PR TITLE
snsdemo: Init Internet Identity Salt

### DIFF
--- a/bin/dfx-ii-init-salt
+++ b/bin/dfx-ii-init-salt
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+
+print_help() {
+  cat <<-EOF
+
+  Initialize the randomness in Internet Identity.
+  Otherwise this will be done the first time a user registers and this will fail
+  if done multiple times simultaneously.
+	EOF
+}
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/clap.bash"
+# Define options
+clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+
+echo "Initializing Internet Identity Salt"
+dfx canister call internet_identity init_salt --network "$DFX_NETWORK"

--- a/bin/dfx-ii-init-salt
+++ b/bin/dfx-ii-init-salt
@@ -6,10 +6,10 @@ SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 
 print_help() {
   cat <<-EOF
-
-  Initialize the randomness in Internet Identity.
-  Otherwise this will be done the first time a user signs in and this will fail
-  if done multiple times simultaneously.
+	
+	Initialize the randomness in Internet Identity.
+	Otherwise this will be done the first time a user signs in and this will fail
+	if done multiple times simultaneously.
 	EOF
 }
 

--- a/bin/dfx-ii-init-salt
+++ b/bin/dfx-ii-init-salt
@@ -8,7 +8,7 @@ print_help() {
   cat <<-EOF
 
   Initialize the randomness in Internet Identity.
-  Otherwise this will be done the first time a user registers and this will fail
+  Otherwise this will be done the first time a user signs in and this will fail
   if done multiple times simultaneously.
 	EOF
 }

--- a/bin/dfx-sns-demo
+++ b/bin/dfx-sns-demo
@@ -95,5 +95,7 @@ sleep 1
 ./bin/dfx-sns-transfer-to-faucet --network "$DFX_NETWORK"
 sleep 1
 ./bin/dfx-ii-create-dummy-anchor --network "$DFX_NETWORK"
+sleep 1
+./bin/dfx-ii-init-salt --network "$DFX_NETWORK"
 
 : "Demo finished!  Hope you enjoyed the show."


### PR DESCRIPTION
# Motivation

Internet-identity needs to do some initiailization to access randomness.
By default this is done the first time a user signs in.
But this breaks if it's done multiple times simultaneously.
We want to run end-to-end tests on CI in parallel but that would currently fail for this reason.

# Changes

1. Add a script to initialize the internet-identity salt.
2. Call the script from `bin/dfx-sns-demo`

# Tested

Ran e2e tests in parallel from a clean state with and without initializing the salt and noticed that it fails without and passes with.