### PR TITLE
snsdemo: Install internet-identity when deploying local

### DIFF
--- a/bin/dfx-network-deploy
+++ b/bin/dfx-network-deploy
@@ -59,6 +59,10 @@ if [[ "$DFX_NETWORK" == "local" ]]; then
   dfx nns install
   dfx-canister-set-id --canister_name nns-dapp --canister_id qsgjb-riaaa-aaaaa-aaaga-cai
   dfx-canister-set-id --canister_name internet_identity --canister_id qhbym-qaaaa-aaaaa-aaafq-cai
+
+  II_WASM_URL="$(dfx-software-internet-identity-ci-wasm-url --release "${DFX_II_RELEASE:-latest}" --flavor "dev")"
+  curl --retry 5 --fail -sSL "${II_WASM_URL}" -o internet_identity_dev.wasm
+  dfx canister install internet_identity --wasm internet_identity_dev.wasm --upgrade-unchanged --mode reinstall --yes
 else
   # Run remotely with one of the predefined configurations.
   # Note: This is still relatively slow and error prone.  Points of friction need to be ironed

--- a/bin/dfx-software-internet-identity-ci-wasm-url
+++ b/bin/dfx-software-internet-identity-ci-wasm-url
@@ -8,6 +8,8 @@ PATH="$SOURCE_DIR:$PATH"
 source "$SOURCE_DIR/clap.bash"
 # Define options
 clap.define short=r long=release desc="The release name" variable=DFX_II_RELEASE default="latest"
+# See https://github.com/dfinity/internet-identity#flavors
+clap.define short=f long=flavor desc="production, test, or dev" variable=DFX_II_FLAVOR default="test"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
@@ -17,4 +19,4 @@ RELEASE_NAME="$(dfx-software-internet-identity-version --verbose "${DFX_II_RELEA
 test -n "${RELEASE_NAME:-}" || {
   echo "ERROR: Could not find release '${DFX_II_RELEASE}'"
 } >&2
-echo "https://github.com/dfinity/internet-identity/releases/download/${RELEASE_NAME}/internet_identity_test.wasm"
+echo "https://github.com/dfinity/internet-identity/releases/download/${RELEASE_NAME}/internet_identity_${DFX_II_FLAVOR}.wasm"


### PR DESCRIPTION
# Motivation

On NNS dapp we currently install internet-identity on CI.
We want as much as possible to be in the snapshot we take from snsdemo.
If we install internet-identity in snsdemo, we can remove the installation step from CI in nns-dapp

# Changes

1. Allow specifying the "flavor" of internet-identity wasm to `bin/dfx-software-internet-identity-ci-wasm-url`
2. Install the dev wasm of internet-identity in `bin/dfx-network-deploy` when deploying to network `local`

# Tested

Ran `bin/dfx-sns-demo` and verified that I could navigate to `http://qhbym-qaaaa-aaaaa-aaafq-cai.localhost:8080/` and get version `release-2023-04-12`