### PR TITLE
Retry curl in dfx-software-dfx-install

### DIFF
--- a/bin/dfx-software-dfx-install
+++ b/bin/dfx-software-dfx-install
@@ -30,4 +30,4 @@ if command -v dfx >/dev/null; then
 fi
 
 export DFX_VERSION
-sh -ci "$(curl -fsSL https://internetcomputer.org/install.sh)"
+sh -ci "$(curl --retry 5 -fsSL https://internetcomputer.org/install.sh)"


### PR DESCRIPTION
# Motivation

Installing dfx often fails with a 500 error.

# Changes

Pass `--retry 5` to curl when installing dfx.

# Tests

CI