### PR TITLE
Mv stock state creation to a separate script

### DIFF
--- a/bin/dfx-ckbtc-deploy
+++ b/bin/dfx-ckbtc-deploy
@@ -103,7 +103,7 @@ deploy_ckbtc() {
 check_ckbtc_deployment() {
   for canister in "${LOCAL_PREFIX}ledger" "${LOCAL_PREFIX}minter"; do
     : "Verify that the deployed canister matches the local wasm"
-    dfx-canister-check-wasm-hash --canister "$canister"
+    dfx-canister-check-wasm-hash --canister "$canister" --network "$DFX_NETWORK"
   done
 }
 

--- a/bin/dfx-snapshot-stock-make
+++ b/bin/dfx-snapshot-stock-make
@@ -17,12 +17,8 @@ clap.define short=s long=snapshot desc="The file to save to" variable=DFX_SNAPSH
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
-: Set up SNS state and create one finalized SNS
-dfx-sns-demo
-
-: Set up ckbtc canisters
-dfx-ckbtc-import --prefix ckbtc_
-dfx-ckbtc-deploy --prefix ckbtc_ --yes
+: Create stock state
+dfx-stock-deploy
 
 : "Wait for a checkpoint"
 dfx-network-wait-for-checkpoint --timeout 600

--- a/bin/dfx-stock-deploy
+++ b/bin/dfx-stock-deploy
@@ -8,7 +8,7 @@ export PATH
 print_help() {
   cat <<-EOF
 
-	Deploy s astock set of canisters and state:
+	Deploys a stock set of canisters and state:
 	 - NNS canisters including root, governance, ledger and others.
 	 - SNS canisters and applies the configuration required to make additional canisters.
 	 - CKBTC canisters (incomplete)
@@ -20,8 +20,8 @@ source "$SOURCE_DIR/clap.bash"
 # Define options
 clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
 clap.define short=c long=ic_commit desc="The IC commit to use" variable=DFX_IC_COMMIT default="$(dfx-software ic current)"
-clap.define short=x long=ic_dir desc="Directory containing the ic source code" variable=IC_REPO_DIR default="$HOME/dfn/ic"
-clap.define short=y long=nd_dir desc="Directory containing the nns-dapp source code" variable=ND_REPO_DIR default="$HOME/dfn/nns-dapp"
+clap.define short=x long=ic_dir desc="Directory containing the ic source code; needed for deployments to static testnets" variable=IC_REPO_DIR default="$HOME/dfn/ic"
+clap.define short=y long=nd_dir desc="Directory containing the nns-dapp source code; needed for deployments to static testnets" variable=ND_REPO_DIR default="$HOME/dfn/nns-dapp"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 set -x

--- a/bin/dfx-stock-deploy
+++ b/bin/dfx-stock-deploy
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+DEMO_BIN="$(realpath "${SOURCE_DIR}/..")/bin-other"
+PATH="$SOURCE_DIR:$DEMO_BIN:$HOME/.local/bin:$PATH:$(dfx cache show)"
+export PATH
+
+print_help() {
+  cat <<-EOF
+
+	Deploy s astock set of canisters and state:
+	 - NNS canisters including root, governance, ledger and others.
+	 - SNS canisters and applies the configuration required to make additional canisters.
+	 - CKBTC canisters (incomplete)
+	EOF
+}
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/clap.bash"
+# Define options
+clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
+clap.define short=c long=ic_commit desc="The IC commit to use" variable=DFX_IC_COMMIT default=""
+clap.define short=x long=ic_dir desc="Directory containing the ic source code" variable=IC_REPO_DIR default="$HOME/dfn/ic"
+clap.define short=y long=nd_dir desc="Directory containing the nns-dapp source code" variable=ND_REPO_DIR default="$HOME/dfn/nns-dapp"
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+set -x
+cd "$(dirname "$(realpath "$0")")/.."
+
+: Set up SNS state and create one finalized SNS
+dfx-sns-demo --network "$DFX_NETWORK" --ic_commit "$DFX_IC_COMMIT" --ic_dir "$IC_REPO_DIR" --nd_dir "$ND_REPO_DIR"
+
+: Set up ckbtc canisters
+dfx-ckbtc-import --prefix ckbtc_
+dfx-ckbtc-deploy --prefix ckbtc_ --network "$DFX_NETWORK" --yes

--- a/bin/dfx-stock-deploy
+++ b/bin/dfx-stock-deploy
@@ -19,7 +19,7 @@ print_help() {
 source "$SOURCE_DIR/clap.bash"
 # Define options
 clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
-clap.define short=c long=ic_commit desc="The IC commit to use" variable=DFX_IC_COMMIT default=""
+clap.define short=c long=ic_commit desc="The IC commit to use" variable=DFX_IC_COMMIT default="$(dfx-software ic current)"
 clap.define short=x long=ic_dir desc="Directory containing the ic source code" variable=IC_REPO_DIR default="$HOME/dfn/ic"
 clap.define short=y long=nd_dir desc="Directory containing the nns-dapp source code" variable=ND_REPO_DIR default="$HOME/dfn/nns-dapp"
 # Source the output file ----------------------------------------------------------


### PR DESCRIPTION
# Motivation
It would be nice to be able to deploy testnets with the stock state.

# Changes
- Move the stock state creation into a separate script
- Fix a missing `--network` flag.

# Tests
- Local deployments - See CI
- Testnet deployments: Deployed to small09