### PR TITLE
Flag to disable latest tests

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -6,7 +6,6 @@ on:
   pull_request:
 env:
   GH_TOKEN: ${{ github.token }}
-  LATEST_WORKS: false # Claim that snsdemo works with the latest IC repo commit (true) or acknowledge that it doesn't (false).
 jobs:
   #  readme:
   #    runs-on: ${{ matrix.os }}
@@ -75,7 +74,7 @@ jobs:
           path: state.tar.xz
           retention-days: 3
   demo_latest:
-    if: env.LATEST_WORKS == 'true'
+    if: false # Claim that snsdemo works with the latest IC repo commit (true) or acknowledge that it doesn't (false).
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -75,7 +75,7 @@ jobs:
           path: state.tar.xz
           retention-days: 3
   demo_latest:
-    if: ${{ env.LATEST_WORKS }}
+    if: env.LATEST_WORKS == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
 env:
   GH_TOKEN: ${{ github.token }}
+  LATEST_WORKS: false # Claim that snsdemo works with the latest IC repo commit (true) or acknowledge that it doesn't (false).
 jobs:
   #  readme:
   #    runs-on: ${{ matrix.os }}
@@ -74,6 +75,7 @@ jobs:
           path: state.tar.xz
           retention-days: 3
   demo_latest:
+    if: ${{ env.LATEST_WORKS }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
# Motivation
Form time to time, as now, the latest IC repo is no longer compatible with the snsdemo.  When that happens, the "latest" canary test goes red.  Good, it has done its job.  But once the canary has died there is no point in killing many more canaries until the gas has been cleared from the mine.

# Changes
- Disable the latest test with an "if" so that it is visible in CI that the latest check has been skipped.

# Tests
- See CI. You should see a grayed out "latest" test.  And no failed tests.