### PR TITLE
More reliable dfx-stop

### DIFF
--- a/bin/dfx-network-stop
+++ b/bin/dfx-network-stop
@@ -14,6 +14,8 @@ export DFX_NETWORK
 if [[ "$DFX_NETWORK" == "local" ]]; then
   : "Ask for a clean shutdown"
   dfx stop || true
+  : "Also send the equivalent of ctrl-c, which _should_ be equivalent, as dfx stop often fails"
+  pgrep --full '^dfx\>.*\<start\>' | xargs --no-run-if-empty kill
   echo "Waiting for replica to stop..."
   for ((i = 100; i > 0; i--)); do
     printf '\r % 4d' "$i"

--- a/bin/dfx-network-stop
+++ b/bin/dfx-network-stop
@@ -12,10 +12,8 @@ source "$(clap.build)"
 export DFX_NETWORK
 
 if [[ "$DFX_NETWORK" == "local" ]]; then
-  : "Ask for a clean shutdown"
-  dfx stop || true
-  : "Also send the equivalent of ctrl-c, which _should_ be equivalent, as dfx stop often fails"
-  pgrep --full '^dfx\>.*\<start\>' | xargs --no-run-if-empty kill
+  : "Send the equivalent of ctrl-c"
+  pgrep --full '\<dfx\>.*\<start\>' | xargs --no-run-if-empty kill
   echo "Waiting for replica to stop..."
   for ((i = 100; i > 0; i--)); do
     printf '\r % 4d' "$i"

--- a/bin/dfx-network-stop
+++ b/bin/dfx-network-stop
@@ -13,7 +13,7 @@ export DFX_NETWORK
 
 if [[ "$DFX_NETWORK" == "local" ]]; then
   : "Send the equivalent of ctrl-c"
-  pgrep --full '\<dfx\>.*\<start\>' | xargs --no-run-if-empty kill
+  pgrep --full '\<dfx\>.*\<start\>' | xargs --no-run-if-empty kill || true
   echo "Waiting for replica to stop..."
   for ((i = 100; i > 0; i--)); do
     printf '\r % 4d' "$i"


### PR DESCRIPTION
# Motivation
`dfx stop` _should_ send the `dfx start` process a `SIGTERM` signal.  But sometimes it doesn't.

# Changes
- Use pgrep to find `dfx start` (ar `dfx --some-flags start`) and send the signal.