### PR TITLE
snsdemo: Add an open swap to the stock snapshot.

### DIFF
--- a/bin/dfx-snapshot-stock-make
+++ b/bin/dfx-snapshot-stock-make
@@ -20,6 +20,12 @@ source "$(clap.build)"
 : Set up SNS state and create one finalized SNS
 dfx-sns-demo
 
+: Add 10 more finalized SNS projects.
+dfx-sns-demo-mksns-parallel -s 10 -m snsdemo8
+
+: Add 1 open SNS project.
+dfx-sns-demo-mksns
+
 : Set up ckbtc canisters
 dfx-ckbtc-import --prefix ckbtc_
 dfx-ckbtc-deploy --prefix ckbtc_ --yes
@@ -32,3 +38,5 @@ dfx-network-stop
 
 echo "Saving state"
 dfx-snapshot-save --snapshot "$DFX_SNAPSHOT_FILE"
+
+echo "Snapshot saved to $DFX_SNAPSHOT_FILE"

--- a/bin/dfx-sns-sale-propose
+++ b/bin/dfx-sns-sale-propose
@@ -16,8 +16,8 @@ export DFX_NEURON_ID="${DFX_NEURON_ID:-$(dfx-neuron-id --identity "$DFX_IDENTITY
 export DFX_IDENTITY_PEM="$(dfx-identity-pem --identity "$DFX_IDENTITY")"
 export DFX_NNS_URL="$(dfx-network-provider --network "$DFX_NETWORK")"
 
-# The due date of the sale must be greater than 1 day at thetime of NNS proposal execution
-SWAP_DUE_TIMESTAMP="$(perl -e 'print time() + 14 * 24 * 3600')"
+# The due date of the sale must be greater than 1 day at the time of NNS proposal execution
+SWAP_DUE_TIMESTAMP="$(perl -e 'print time() + 90 * 24 * 3600')"
 SNS_SWAP="$(dfx canister id sns_swap --network "$DFX_NETWORK")"
 SNS_TOKENS_E8s=314100000000
 TOKEN_SYMBOL="$(awk '/token_symbol:/{print $2}' sns.yml || echo SOMETHING)"


### PR DESCRIPTION
# Motivation

We want to test swap participation in nns-dapp.
For that we need an open swap to participate in.

# Changes

1. Create a sns project that is not finalized.
2. Increase the swap duration to 90 days to make the stock snapshot usable for as long as possible.
3. Add 10 more sns'es because nns-dapp CI currently expects 12 SNS projects.

# Tested

Created and loaded the snapshot locally and checked that it had 11 closed and 1 open swap.