### PR TITLE
Fix error detection in dfx-sns-sale-finalize

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -74,6 +74,7 @@ jobs:
           path: state.tar.xz
           retention-days: 3
   demo_latest:
+    if: false # Claim that snsdemo works with the latest IC repo commit (true) or acknowledge that it doesn't (false).
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/bin/dfx-sns-sale-finalize
+++ b/bin/dfx-sns-sale-finalize
@@ -18,7 +18,9 @@ source "$(clap.build)"
 
 dfx canister --network "$DFX_NETWORK" call sns_swap finalize_swap '(record {})' | tee ,sns-sale-finalize.idl
 
-if idl2json <,sns-sale-finalize.idl | jq 'to_entries | map({key: .key, value: {failure: .value[0].failure}} | select((.value.failure != 0) and (.value.failure != null)))| from_entries | select (. != {})' | grep .; then
+ERROR_MESSAGE="$(idl2json < ,sns-sale-finalize.idl | jq -r '.error_message')"
+
+if [ "${ERROR_MESSAGE}" != "null" ]; then
   {
     echo "There were errors in the finalization."
     exit 1

--- a/bin/dfx-sns-sale-finalize
+++ b/bin/dfx-sns-sale-finalize
@@ -18,7 +18,7 @@ source "$(clap.build)"
 
 dfx canister --network "$DFX_NETWORK" call sns_swap finalize_swap '(record {})' | tee ,sns-sale-finalize.idl
 
-ERROR_MESSAGE="$(idl2json < ,sns-sale-finalize.idl | jq -r '.error_message')"
+ERROR_MESSAGE="$(idl2json <,sns-sale-finalize.idl | jq -r '.error_message')"
 
 if [ "${ERROR_MESSAGE}" != "null" ]; then
   {


### PR DESCRIPTION
# Motivation

The response format of finalize_swap has apparently changed since this code was written.

Here is an recent example error response:
```
(
  record {
    set_dapp_controllers_call_result = null;
    settle_community_fund_participation_result = null;
    error_message = opt "The Sale can only be finalized in the COMMITTED or ABORTED states. Current state is Open";
    set_mode_call_result = null;
    sweep_icp_result = null;
    claim_neuron_result = null;
    sweep_sns_result = null;
  },
)
```

Also, the previous code would search for the error message and assume that the request was successful if finding the error message failed. This meant it also assumed success if finding the error message failed because the code for finding the error message is wrong.

# Changes

1. Read the error from the `.error_message` field instead of `.failure`.
2. Don't assume success if there is an error in the code to find the error message.

# Testing

Try to finalize a sale which isn't committed and check that the script returns an error code.