### PR TITLE
Handle existing ticket or panic in dfx-sns-sale-buy

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -74,6 +74,7 @@ jobs:
           path: state.tar.xz
           retention-days: 3
   demo_latest:
+    if: false # Claim that snsdemo works with the latest IC repo commit (true) or acknowledge that it doesn't (false).
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/bin/dfx-sns-sale-buy
+++ b/bin/dfx-sns-sale-buy
@@ -29,9 +29,27 @@ TICKET_RESPONSE_JSON="$(echo "$TICKET_RESPONSE" | idl2json)"
 TICKET_ID="$(echo "$TICKET_RESPONSE_JSON" | jq -r '.result[0].Ok.ticket[0].ticket_id')"
 TICKET_CREATION_TIME="$(echo "$TICKET_RESPONSE_JSON" | jq -r '.result[0].Ok.ticket[0].creation_time')"
 
+if [ "$TICKET_ID" = "null" ]; then
+  echo "Didn't get a new ticket ID. Checking the response for an existing ticket ID."
+  TICKET_ID="$(echo "$TICKET_RESPONSE_JSON" | jq -r '.result[0].Err.existing_ticket[0].ticket_id')"
+  TICKET_CREATION_TIME="$(echo "$TICKET_RESPONSE_JSON" | jq -r '.result[0].Err.existing_ticket[0].creation_time')"
+fi
+
+echo "TICKET_ID: $TICKET_ID"
+
 set dfx-sns-quill --network "$DFX_NETWORK" pay --amount-icp-e8s "$AMOUNT_E8S" --ticket-id "$TICKET_ID" --ticket-creation-time "$TICKET_CREATION_TIME"
 echo "${@}"
-"${@}" || {
+FAILED=false
+
+if !("${@}" | tee ,sns-sale-buy.idl); then
+  FAILED=true
+fi
+
+if grep --quiet 'Panicked' ,sns-sale-buy.idl; then
+  FAILED=true
+fi
+
+if [ "$FAILED" = "true" ]; then
   echo "ERROR: Failed to participate in SNS swap."
   echo "Ticket response:"
   echo "$TICKET_RESPONSE"
@@ -42,4 +60,4 @@ echo "${@}"
   echo "Ticket creation time:"
   echo "$TICKET_CREATION_TIME"
   exit 1
-}
+fi

--- a/bin/dfx-sns-sale-buy
+++ b/bin/dfx-sns-sale-buy
@@ -49,7 +49,7 @@ if grep --quiet 'Panicked' ,sns-sale-buy.idl; then
   FAILED=true
 fi
 
-if [ "$FAILED" = "true" ]; then
+[[ "$FAILED" == "false" ]] || {
   echo "ERROR: Failed to participate in SNS swap."
   echo "Ticket response:"
   echo "$TICKET_RESPONSE"
@@ -60,4 +60,4 @@ if [ "$FAILED" = "true" ]; then
   echo "Ticket creation time:"
   echo "$TICKET_CREATION_TIME"
   exit 1
-fi
+} >&2

--- a/bin/dfx-sns-sale-buy
+++ b/bin/dfx-sns-sale-buy
@@ -41,7 +41,7 @@ set dfx-sns-quill --network "$DFX_NETWORK" pay --amount-icp-e8s "$AMOUNT_E8S" --
 echo "${@}"
 FAILED=false
 
-if !("${@}" | tee ,sns-sale-buy.idl); then
+if ! ("${@}" | tee ,sns-sale-buy.idl); then
   FAILED=true
 fi
 


### PR DESCRIPTION
# Motivation

When using an identity without ICP funds, `dfx-sns-sale-buy` (and `quill` itself) could fail to participate in the swap without returning a non-zero exit code. In that case the output looks something like this:

```
Sending message with

  Call type:   update
  Sender:      5dmmb-3lsl6-4trwn-kf5s7-zezll-xk2xc-ryx2k-7dkwu-ol2xf-lo47i-2qe
  Canister id: ryjl3-tyaaa-aaaaa-aaaba-cai
  Method name: send_dfx
  Arguments:   (
  record {
    to = "080b0f73b47b43c71fd09295c208cedb3e9c5a79b4a85e7aae3f464008ae9f16";
    fee = record { e8s = 10_000 : nat64 };
    memo = 0 : nat64;
    from_subaccount = null;
    created_at_time = opt record {
      timestamp_nanos = 1_682_065_237_249_362_000 : nat64;
    };
    amount = record { e8s = 314_100_000_000 : nat64 };
  },
)
Request ID: 0xc372c04b4eebf2783c4ebba2a660f67b9fbb0743ec4e746a241a5e4f6b64fefc
The request is being processed...
The request is being processed...
The request is being processed...
The Replica returned an error: code 5, message: "Canister ryjl3-tyaaa-aaaaa-aaaba-cai trapped explicitly: Panicked at 'called `Result::unwrap()` on an `Err` value: InsufficientFunds { balance: Tokens { e8s: 0 } }', rs/rosetta-api/icp_ledger/ledger/src/main.rs:704:39"

Sending message with

  Call type:   update
  Sender:      5dmmb-3lsl6-4trwn-kf5s7-zezll-xk2xc-ryx2k-7dkwu-ol2xf-lo47i-2qe
  Canister id: st75y-vaaaa-aaaaa-aaalq-cai
  Method name: refresh_buyer_tokens
  Arguments:   (
  record {
    buyer = "5dmmb-3lsl6-4trwn-kf5s7-zezll-xk2xc-ryx2k-7dkwu-ol2xf-lo47i-2qe";
  },
)
Request ID: 0xc9a57ccf7b162f98dc54a84f046b56b76f461affbda11f0aee83764774499c79
The request is being processed...
The request is being processed...
The request is being processed...
The Replica returned an error: code 5, message: "Canister st75y-vaaaa-aaaaa-aaalq-cai trapped explicitly: Panicked at 'Amount transferred: 0; minimum required to participate: 10000000', rs/sns/swap/canister/canister.rs:178:21"
```

If you try again, the script will fail to get a new ticket because one principal can only have 1 open ticket.

# Changes

1. When failing to get a new ticket, check if the response includes an existing ticket and use that.
2. When the output contains "Panicked" consider the call failed, even if there is no non-zero exist code.

# Testing

Tried calling `./bin/dfx-sns-sale-buy` with an identity without funds and with an identity with funds.