### PR TITLE
Add command to vote

### DIFF
--- a/bin/dfx-neuron-vote
+++ b/bin/dfx-neuron-vote
@@ -16,7 +16,7 @@ clap.define short=N long=neuron desc="The neuron ID" variable=DFX_NEURON_ID
 clap.define short=i long=DFX_IDENTITY desc="The dfx identity to use.  The identity principal must control the neuron." variable=DFX_IDENTITY default="$(dfx identity whoami)"
 clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
 clap.define short=p long=proposal desc="Proposal number" variable=DFX_PROPOSAL
-clap.define short=v long=vote desc="Vote yes/n" variable=DFX_VOTE default=yes
+clap.define short=v long=vote desc="Vote yes/no" variable=DFX_VOTE default=yes
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 test -z "${DFX_VERBOSE:-}" || set -x

--- a/bin/dfx-neuron-vote
+++ b/bin/dfx-neuron-vote
@@ -13,7 +13,7 @@ print_help() {
 source "$SOURCE_DIR/clap.bash"
 # Define options
 clap.define short=N long=neuron desc="The neuron ID" variable=DFX_NEURON_ID
-clap.define short=i long=DFX_IDENTITY desc="The dfx identity to use.  The identity principal must control the neuron." variable=DFX_IDENTITY default="$(dfx identity whoami)"
+clap.define short=i long=identity desc="The dfx identity to use.  The identity principal must control the neuron." variable=DFX_IDENTITY default="$(dfx identity whoami)"
 clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
 clap.define short=p long=proposal desc="Proposal number" variable=DFX_PROPOSAL
 clap.define short=v long=vote desc="Vote yes/no" variable=DFX_VOTE default=yes

--- a/bin/dfx-neuron-vote
+++ b/bin/dfx-neuron-vote
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+
+print_help() {
+  cat <<-EOF
+	
+	Casts a vote on a proposal.
+	EOF
+}
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/clap.bash"
+# Define options
+clap.define short=N long=neuron desc="The neuron ID" variable=DFX_NEURON_ID
+clap.define short=i long=DFX_IDENTITY desc="The dfx identity to use.  The identity principal must control the neuron." variable=DFX_IDENTITY default="$(dfx identity whoami)"
+clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
+clap.define short=p long=proposal desc="Proposal number" variable=DFX_PROPOSAL
+clap.define short=v long=vote desc="Vote yes/n" variable=DFX_VOTE default=yes
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+test -z "${DFX_VERBOSE:-}" || set -x
+
+case "${DFX_VOTE:-}" in
+yes | YES) DFX_VOTE_NUM=1 ;;
+no | NO) DFX_VOTE_NUM=0 ;;
+*) {
+  echo "ERROR: Please vote either yes or no."
+  exit 1
+} >&2 ;;
+esac
+
+[ "${DFX_NEURON_ID:-}" != "" ] || {
+  DFX_NEURON_ID="$(dfx-neuron-id --network "$DFX_NETWORK" 2>/dev/null)"
+}
+[ "${DFX_NEURON_ID:-}" != "" ] || {
+  echo "Please provide a neuron ID"
+  exit 1
+}
+
+dfx --identity "$DFX_IDENTITY" canister --network="$DFX_NETWORK" call nns-governance manage_neuron --type=idl '(record {id=opt record {id='"$DFX_NEURON_ID"'}; command=opt variant {RegisterVote=record {vote='"$DFX_VOTE_NUM"'; proposal=opt record {id='"$DFX_PROPOSAL"'}}}})'
+
+#(record { command = opt variant { RegisterVote = record {} } })


### PR DESCRIPTION
# Motivation
Here is the command to vote with the snsdemo majority neuron:

```
dfx --identity hsm canister --network=small09 call governance manage_neuron --type=idl '(record {id=opt record {id=9_014_191_754_770_650_971}; command=opt variant {RegisterVote=record {vote=1; proposal=opt record {id=56239}}}})'
```
(neuronid, vote and proposalid will vary)

It's fine but not memorable.  And existing alternatives such as quill are no better.

# Changes

Add a dfx neuron vote script:
```
dfx-neuron-vote --proposal 56239 --vote yes --network small09
```

More options:
```
max@sinkpad:~/dfn/snsdemo/branches/neuron-vote (8:17)$ ./bin/dfx-neuron-vote --help

Casts a vote on a proposal.

usage: dfx-neuron-vote [OPTIONS]

OPTIONS:
        
	-N --neuron:                 The neuron ID
	-i --identity:               The dfx identity to use. The identity principal must control the neuron. [default:snsdemo8]
	-n --network:                The dfx network to use [default:local]
	-p --proposal:               Proposal number
	-v --vote:                   Vote yes/no [default:yes]

        -? --help  :  usage

        --verbose  :  show debug info

max@sinkpad:~/dfn/snsdemo/branches/neuron-vote (8:21)$ 
```