### PR TITLE
Create the open swap among the first 10.

### DIFF
--- a/bin/dfx-stock-deploy
+++ b/bin/dfx-stock-deploy
@@ -30,11 +30,11 @@ cd "$(dirname "$(realpath "$0")")/.."
 : Set up SNS state and create one finalized SNS
 dfx-sns-demo --network "$DFX_NETWORK" --ic_commit "$DFX_IC_COMMIT" --ic_dir "$IC_REPO_DIR" --nd_dir "$ND_REPO_DIR"
 
-: Add 10 more finalized SNS projects.
-dfx-sns-demo-mksns-parallel --network "$DFX_NETWORK" --num_sns 10 --majority snsdemo8
-
 : Add 1 open SNS project.
 dfx-sns-demo-mksns --network "$DFX_NETWORK"
+
+: Add 10 more finalized SNS projects.
+dfx-sns-demo-mksns-parallel --network "$DFX_NETWORK" --num_sns 10 --majority snsdemo8
 
 : Set up ckbtc canisters
 dfx-ckbtc-import --prefix ckbtc_


### PR DESCRIPTION
# Motivation

nns-dapp currently reads only the first page from the sns_aggregator.
It used to be the last page but we need a project which has tokens in the faucet and currently only the first project (created by `bin/dfx-sns-demo`) has tokens in the faucet so we changed it to reading the first page.
I'm adding an e2e test which requires an open swap.
So for nns-dapp to be able to see the open swap (while using the sns_aggregator), it needs to be among the first 10 projects.

# Changes

Create the open swap before creating the 10 additional projects.

# Testing

1. Install sns_aggregator locally to reproduce the problem.
2. Created a new stock snapshot with this change.
3. Used the stock snapshot with the sns_aggregator running to see that an open swap is now available.