### PR TITLE
Support --latest in network deployments

### DIFF
--- a/bin/dfx-network-deploy-testnet
+++ b/bin/dfx-network-deploy-testnet
@@ -17,6 +17,7 @@ clap.define short=y long=nd_dir desc="Directory containing the nns-dapp source c
 source "$(clap.build)"
 
 export DFX_NETWORK
+[[ "${DFX_IC_COMMIT:-}" != "latest" ]] || DFX_IC_COMMIT="$(dfx-software ic latest --ic_dir "$IC_REPO_DIR")"
 
 if [[ "$DFX_NETWORK" == "local" ]]; then
   echo NOT APPLICABLE


### PR DESCRIPTION
# Motivation
`dfx-network-deploy-testnet` doesn't support `--commit latest`.  A small thing but annoying when deploying many times.

# Changes
-  Copy in the standard code for switching latest to the latest commit.

# Checks
- Deployment to small09 did indeed check out the latest commit during deployment.