### PR TITLE
Try hard to find the sns binary

### DIFF
--- a/bin/dfx-sns-wasm-upload
+++ b/bin/dfx-sns-wasm-upload
@@ -18,18 +18,9 @@ source "$(clap.build)"
 
 SNS_WASM_CANISTER_ID="${SNS_WASM_CANISTER_ID:-$(dfx canister id nns-sns-wasm --network "$DFX_NETWORK" 2>/dev/null)}"
 
-SNS_PATH="$SOURCE_DIR/../bin-other/sns"
+SNS_PATH="$(dfx cache show)/sns"
 test -x "$SNS_PATH" || {
-  echo "WARNING: sns executable not found in expected location: $SNS_PATH"
-  echo "         Looking for an sns, but an alternative version MAY fail."
-  echo "         To install the recommended toolchain:"
-  echo "       '$SOURCE_DIR/dfx-sns-demo-install'"
-  { SNS_PATH="$(command -v sns)" && test -x "$SNS_PATH"; } ||
-    { SNS_PATH="$(dfx cache show)/sns" && test -x "$SNS_PATH"; } || {
-    echo "ERROR: Could not find sns executable.  Please install the recommended toolchain:"
-    echo "       '$SOURCE_DIR/dfx-sns-demo-install'"
-    exit 1
-  }
+  dfx cache install
 }
 
 jq <"$SOURCE_DIR/sns_dfx.json" -r '.canisters | to_entries | map("\(.value.config.nns_sns_wasm_name) \(.value.wasm)") | .[]' | while read -r line; do

--- a/bin/dfx-sns-wasm-upload
+++ b/bin/dfx-sns-wasm-upload
@@ -18,12 +18,26 @@ source "$(clap.build)"
 
 SNS_WASM_CANISTER_ID="${SNS_WASM_CANISTER_ID:-$(dfx canister id nns-sns-wasm --network "$DFX_NETWORK" 2>/dev/null)}"
 
+SNS_PATH="$SOURCE_DIR/../bin-other/sns"
+test -x "$SNS_PATH" || {
+  echo "WARNING: sns executable not found in expected location: $SNS_PATH"
+  echo "         Looking for an sns, but an alternative version MAY fail."
+  echo "         To install the recommended toolchain:"
+  echo "       '$SOURCE_DIR/dfx-sns-demo-install'"
+  { SNS_PATH="$(command -v sns)" && test -x "$SNS_PATH"; } ||
+    { SNS_PATH="$(dfx cache show)/sns" && test -x "$SNS_PATH"; } || {
+    echo "ERROR: Could not find sns executable.  Please install the recommended toolchain:"
+    echo "       '$SOURCE_DIR/dfx-sns-demo-install'"
+    exit 1
+  }
+}
+
 jq <"$SOURCE_DIR/sns_dfx.json" -r '.canisters | to_entries | map("\(.value.config.nns_sns_wasm_name) \(.value.wasm)") | .[]' | while read -r line; do
   # shellcheck disable=SC2086 # We do actually want to split the line into fields.
   set $line
   UPLOAD_NAME="$1"
   WASM_FILE="wasms/$2"
-  set "$(dfx cache show)/sns" add-sns-wasm-for-tests \
+  set "$SNS_PATH" add-sns-wasm-for-tests \
     --network "$DFX_NETWORK" \
     --override-sns-wasm-canister-id-for-tests "${SNS_WASM_CANISTER_ID}" \
     --wasm-file "$WASM_FILE" "$UPLOAD_NAME"


### PR DESCRIPTION
# Motivation
The `dfx-sns-wasm-upload` can fail to find the sns executable.  This can happen if the dfx cache has not been installed.

# Changes
- If `sns` is not present, install the cache.