### PR TITLE
Install optimizer

### DIFF
--- a/bin/_template
+++ b/bin/_template
@@ -4,6 +4,13 @@ SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
 . "$SOURCE_DIR/versions.bash"
 
+print_help() {
+	cat <<-EOF
+
+	Some motivational speech.
+	EOF
+}
+
 # Source the clap.bash file ---------------------------------------------------
 source "$SOURCE_DIR/clap.bash"
 # Define options

--- a/bin/_template
+++ b/bin/_template
@@ -5,7 +5,7 @@ PATH="$SOURCE_DIR:$PATH"
 . "$SOURCE_DIR/versions.bash"
 
 print_help() {
-	cat <<-EOF
+  cat <<-EOF
 
 	Some motivational speech.
 	EOF

--- a/bin/dfx-software-ic-cdk-optimizer-install
+++ b/bin/dfx-software-ic-cdk-optimizer-install
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+PATH="$SOURCE_DIR:$PATH"
+. "$SOURCE_DIR/versions.bash"
+
+print_help() {
+  cat <<-EOF
+
+	Install ic-cdk optimizer.
+
+	Note: This tool is end-of-life.
+	EOF
+}
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/clap.bash"
+# Define options
+clap.define short=v long=version desc="The version to install" variable=VERSION default="0.3.6"
+clap.define short=b long=bin desc="Local directory for executables" variable=USER_BIN default="$HOME/.local/bin"
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+
+export DFX_NETWORK
+OS="$(uname)"
+
+optimizer_version() {
+  ic-cdk-optimizer --version | awk '{print $2}'
+}
+
+check_optimizer() {
+  [[ "$(optimizer_version &>/dev/null)" == "$VERSION" ]]
+}
+
+install_optimizer() {
+  case "$OS" in
+  Linux)
+    curl --retry 5 -L --fail "https://github.com/dfinity/cdk-rs/releases/download/${VERSION}/ic-cdk-optimizer-${VERSION}-ubuntu-20.04.tar.gz" |
+      gunzip |
+      tar -x --to-stdout "ic-cdk-optimizer-${VERSION}-ubuntu-20.04/ic-cdk-optimizer" |
+      install -m 755 /dev/stdin "$USER_BIN/ic-cdk-optimizer"
+    ;;
+  Darwin)
+    temp="$(mktemp ic-cdk-optimizer-XXXXXXX)"
+    curl --retry 5 -L --fail "https://github.com/dfinity/cdk-rs/releases/download/${VERSION}/ic-cdk-optimizer-${VERSION}-macos-latest.tar.gz" |
+      gunzip |
+      tar -x --to-stdout "ic-cdk-optimizer-${VERSION}-macos-latest/ic-cdk-optimizer" >"$temp"
+    install -m 755 "$USER_BIN/ic-cdk-optimizer"
+    ;;
+  *)
+    {
+      echo "ERROR: Sorry, this platform is unsupported.  PRs are welcome."
+      exit 1
+    } >&2
+    ;;
+  esac
+}
+
+check_optimizer || {
+  install_optimizer
+  check_optimizer
+}


### PR DESCRIPTION
# Motivation
@dskloetd found that ic-cdk optimizer was not installed.  Now, in that particular case it isn't needed if the nns-dapp installation is updated, however having a fast installation method for the optimizer is still valuable.

# Changes
- Added an install script for the ic-cdk-optimizer

# Tests
- [x] Linux
```
max@sinkpad:~/dfn/snsdemo/branches/install-optimizer (1:05:41)$ rm ~/.local/bin/ic-cdk-optimizer
max@sinkpad:~/dfn/snsdemo/branches/install-optimizer (1:06:02)$ bin/dfx-software-ic-cdk-optimizer-install
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 9244k  100 9244k    0     0  2123k      0  0:00:04  0:00:04 --:--:-- 2779k
max@sinkpad:~/dfn/snsdemo/branches/install-optimizer (1:06:13)$ ~/.local/bin/ic-cdk-optimizer --version
ic-cdk-optimizer 0.3.6
max@sinkpad:~/dfn/snsdemo/branches/install-optimizer (1:06:21)$ 
```
- [ ] Mac - Untested.  Testers are welcome to try this out.