### PR TITLE
Install wasm nm

### DIFF
--- a/bin/dfx-canister-nm
+++ b/bin/dfx-canister-nm
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+PATH="$SOURCE_DIR:$PATH"
+. "$SOURCE_DIR/versions.bash"
+
+print_help() {
+  cat <<-EOF
+
+	Print functions exported by a canister.
+	EOF
+}
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/clap.bash"
+# Define options
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+
+# The only meaningful export from canister wasms is function names.
+canister_nm=(wasm-nm -je)
+
+canister_wasm="$1"
+case "$(file "$canister_wasm")" in
+*gzip*) "${canister_nm[@]}" <(gunzip <"$canister_wasm") ;;
+*) "${canister_nm[@]}" "$canister_wasm" ;;
+esac

--- a/bin/dfx-software-wasm-nm-install
+++ b/bin/dfx-software-wasm-nm-install
@@ -5,7 +5,7 @@ PATH="$SOURCE_DIR:$PATH"
 . "$SOURCE_DIR/versions.bash"
 
 print_help() {
-	cat <<-EOF
+  cat <<-EOF
 
 	Installs wasm-nm.
 
@@ -27,21 +27,21 @@ source "$(clap.build)"
 export DFX_NETWORK
 
 wasm_nm_version() {
-	wasm-nm --version | awk '{print $2}'
+  wasm-nm --version | awk '{print $2}'
 }
 wasm_nm_check() {
-	[[ "$(wasm_nm_version 2>/dev/null)" == "$VERSION" ]]
+  [[ "$(wasm_nm_version 2>/dev/null)" == "$VERSION" ]]
 }
 wasm_nm_install() {
-	cargo install wasm-nm@"$VERSION"
+  cargo install wasm-nm@"$VERSION"
 }
 
-if wasm_nm_check
-then echo "Version $VERSION is already installed."
+if wasm_nm_check; then
+  echo "Version $VERSION is already installed."
 else
-	echo "Installing wasm-nm $VERSION..."
-	wasm_nm_install
-	echo "  Checking installation..."
-	wasm_nm_check
-	echo "  Installation successful."
+  echo "Installing wasm-nm $VERSION..."
+  wasm_nm_install
+  echo "  Checking installation..."
+  wasm_nm_check
+  echo "  Installation successful."
 fi

--- a/bin/dfx-software-wasm-nm-install
+++ b/bin/dfx-software-wasm-nm-install
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+PATH="$SOURCE_DIR:$PATH"
+. "$SOURCE_DIR/versions.bash"
+
+print_help() {
+	cat <<-EOF
+
+	Installs wasm-nm.
+
+	wasm-nm prints the symbols in a wasm binary, similar to 'nm' for native executables.
+
+	Canister wasms are typically compressed, so need to be decompressed before use, or
+	use dfx-canister-nm.
+	EOF
+}
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/clap.bash"
+# Define options
+clap.define short=v long=version desc="The version of wasm-nm to install" variable=VERSION default="0.2.0"
+clap.define short=b long=bin desc="Local directory for executables" variable=USER_BIN default="$HOME/.local/bin"
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+
+export DFX_NETWORK
+
+wasm_nm_version() {
+	wasm-nm --version | awk '{print $2}'
+}
+wasm_nm_check() {
+	[[ "$(wasm_nm_version 2>/dev/null)" == "$VERSION" ]]
+}
+wasm_nm_install() {
+	cargo install wasm-nm@"$VERSION"
+}
+
+if wasm_nm_check
+then echo "Version $VERSION is already installed."
+else
+	echo "Installing wasm-nm $VERSION..."
+	wasm_nm_install
+	echo "  Checking installation..."
+	wasm_nm_check
+	echo "  Installation successful."
+fi


### PR DESCRIPTION
# Motivation
In https://dfinity.atlassian.net/browse/GIX-1521, @dskloetd found that wasm-nm is expected but not available.

# Changes
- Add an install script for wasm-nm
- Add a wrapper for canister wasms, as we always use the same incantation.  At least, I do.

# TODO
Find all places where this is relevant and insert it.

# Tests
Rollback and forwards:
```
$ chronic ./bin/dfx-software-wasm-nm-install --version 0.1.0 && wasm-nm --version && chronic ./bin/dfx-software-wasm-nm-install --version 0.2.0 && wasm-nm --version
wasm-nm 0.1.0
wasm-nm 0.2.0
```

Check that the wrapper parses canisters:
```
bin/dfx-canister-nm ../../../nns-dapp/nns-dapp.wasm 
canister_query http_request
canister_query get_account
canister_update add_account
canister_query get_transactions
[SNIP]
```
Note:  Running on all wasms found on my  machine found some that failed to be parsed by wasm-nm.  These use simd instructions that are not supported by wasm-nm:
```
max@sinkpad:~/dfn/snsdemo/branches/install-wasm-nm (1:45:09)$ locate -r '\.wasm$' | head | xargs -I{} ./bin/dfx-canister-nm  {}
[SNIP]
error: /home/max/.cache/bazel/_bazel_max/11b917098ce4ca861488a79c139364ca/execroot/ic/bazel-out/k8-opt/bin/external/sw_npm/node_modules/@dfinity/response-verification/debug/nodejs/nodejs_bg.wasm: Unknown opcode 192
[SNIP]
```