### PR TITLE
snsdemo: Add -v to curl to debug SSL certificate issue

### DIFF
--- a/bin/dfx-software-dfx-install
+++ b/bin/dfx-software-dfx-install
@@ -36,5 +36,5 @@ if command -v dfx >/dev/null; then
 fi
 
 export DFX_VERSION
-sh -ci "$(curl --retry 5 -fsSL https://internetcomputer.org/install.sh)"
+sh -ci "$(curl --retry 5 -fsSLv https://internetcomputer.org/install.sh)"
 lazy_dfx_cache_install


### PR DESCRIPTION
# Motivation

We have been seeing errors in nns-dapp CI:
```
curl: (60) SSL: no alternative certificate subject name matches target host name 'internetcomputer.org'
More details here: https://curl.haxx.se/docs/sslcerts.html

curl failed to verify the legitimacy of the server and therefore could not
```

I asked the boundary node team about it and they asked us to add `-v` to the curl command to help debug.

# Changes

Add `-v` to the curl command to install `dfx`

# Tests

CI