### PR TITLE
snsdemo: Script to install internet identity

### DIFF
--- a/bin/dfx-network-deploy
+++ b/bin/dfx-network-deploy
@@ -61,9 +61,7 @@ if [[ "$DFX_NETWORK" == "local" ]]; then
   dfx-canister-set-id --canister_name nns-dapp --canister_id qsgjb-riaaa-aaaaa-aaaga-cai
   dfx-canister-set-id --canister_name internet_identity --canister_id qhbym-qaaaa-aaaaa-aaafq-cai
 
-  II_WASM_URL="$(dfx-software-internet-identity-ci-wasm-url --release "${DFX_II_RELEASE:-latest}" --flavor "dev")"
-  curl --retry 5 --fail -sSL "${II_WASM_URL}" -o internet_identity_dev.wasm
-  dfx canister install internet_identity --wasm internet_identity_dev.wasm --upgrade-unchanged --mode reinstall --yes
+  dfx-software-internet-identity-install --release "${DFX_II_RELEASE:-latest}" --flavor "dev" --network local
 else
   # Run remotely with one of the predefined configurations.
   # Note: This is still relatively slow and error prone.  Points of friction need to be ironed

--- a/bin/dfx-software-internet-identity-ci-wasm-url
+++ b/bin/dfx-software-internet-identity-ci-wasm-url
@@ -31,10 +31,9 @@ test -n "${RELEASE_NAME:-}" || {
 } >&2
 
 WASM_FILE="internet_identity_${DFX_II_FLAVOR}.wasm"
-RELEASE_NAME="release-2023-04-12"
 
 # If the release is later than 2023-04-12, only .gz files are available
-if [[ "${RELEASE_NAME}" > "release-2023-04-12" ]]; then
+if ! [[ "${RELEASE_NAME}" =~ "^release-[0-9]{4}-[0-9]{2}-[0-9]{2}$" && "${RELEASE_NAME}" < "release-2023-04-28" ]]; then
   WASM_FILE="${WASM_FILE}.gz"
 fi
 

--- a/bin/dfx-software-internet-identity-ci-wasm-url
+++ b/bin/dfx-software-internet-identity-ci-wasm-url
@@ -4,6 +4,16 @@ SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
 . "$SOURCE_DIR/versions.bash"
 
+print_help() {
+  cat <<-EOF
+
+	Outputs the URL of the wasm file for the internet-identity canister.
+	The URL may or may not end with .gz (and be correspondingly gzipped),
+	depending on the release date.
+
+	EOF
+}
+
 # Source the clap.bash file ---------------------------------------------------
 source "$SOURCE_DIR/clap.bash"
 # Define options
@@ -19,4 +29,13 @@ RELEASE_NAME="$(dfx-software-internet-identity-version --verbose "${DFX_II_RELEA
 test -n "${RELEASE_NAME:-}" || {
   echo "ERROR: Could not find release '${DFX_II_RELEASE}'"
 } >&2
-echo "https://github.com/dfinity/internet-identity/releases/download/${RELEASE_NAME}/internet_identity_${DFX_II_FLAVOR}.wasm"
+
+WASM_FILE="internet_identity_${DFX_II_FLAVOR}.wasm"
+RELEASE_NAME="release-2023-04-12"
+
+# If the release is later than 2023-04-12, only .gz files are available
+if [[ "${RELEASE_NAME}" > "release-2023-04-12" ]]; then
+  WASM_FILE="${WASM_FILE}.gz"
+fi
+
+echo "https://github.com/dfinity/internet-identity/releases/download/${RELEASE_NAME}/${WASM_FILE}"

--- a/bin/dfx-software-internet-identity-ci-wasm-url
+++ b/bin/dfx-software-internet-identity-ci-wasm-url
@@ -33,7 +33,7 @@ test -n "${RELEASE_NAME:-}" || {
 WASM_FILE="internet_identity_${DFX_II_FLAVOR}.wasm"
 
 # If the release is later than 2023-04-12, only .gz files are available
-if ! [[ "${RELEASE_NAME}" =~ "^release-[0-9]{4}-[0-9]{2}-[0-9]{2}$" && "${RELEASE_NAME}" < "release-2023-04-28" ]]; then
+if ! [[ "${RELEASE_NAME}" =~ ^release-[0-9]{4}-[0-9]{2}-[0-9]{2}$ && "${RELEASE_NAME}" < "release-2023-04-28" ]]; then
   WASM_FILE="${WASM_FILE}.gz"
 fi
 

--- a/bin/dfx-software-internet-identity-install
+++ b/bin/dfx-software-internet-identity-install
@@ -25,11 +25,7 @@ echo "network $DFX_NETWORK, release $DFX_II_RELEASE, flavor $DFX_II_FLAVOR"
 
 II_WASM_URL="$(dfx-software-internet-identity-ci-wasm-url --release "${DFX_II_RELEASE}" --flavor "${DFX_II_FLAVOR}")"
 
-# If II_WASM_URL ends with .gz, unzip the result
-if [[ "${II_WASM_URL}" =~ \.gz$ ]]; then
-  curl --retry 5 --fail -sSL "${II_WASM_URL}" | gunzip >internet_identity_dev.wasm
-else
-  curl --retry 5 --fail -sSL "${II_WASM_URL}" >internet_identity_dev.wasm
-fi
+# The URL might point to a .gz file, but dfx can install gzipped wasms directly.
+curl --retry 5 --fail -sSL "${II_WASM_URL}" >internet_identity_dev.wasm
 
 dfx canister install internet_identity --wasm internet_identity_dev.wasm --upgrade-unchanged --mode reinstall --yes --network "${DFX_NETWORK}"

--- a/bin/dfx-software-internet-identity-install
+++ b/bin/dfx-software-internet-identity-install
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -xeuo pipefail
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+PATH="$SOURCE_DIR:$PATH"
+
+print_help() {
+  cat <<-EOF
+
+  Fetches and installs the internet-identity canister wasm file.
+
+	EOF
+}
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/clap.bash"
+# Define options
+clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
+clap.define short=r long=release desc="The release name" variable=DFX_II_RELEASE default="latest"
+# See https://github.com/dfinity/internet-identity#flavors
+clap.define short=f long=flavor desc="production, test, or dev" variable=DFX_II_FLAVOR default="dev"
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+
+echo "network $DFX_NETWORK, release $DFX_II_RELEASE, flavor $DFX_II_FLAVOR"
+
+II_WASM_URL="$(dfx-software-internet-identity-ci-wasm-url --release "${DFX_II_RELEASE}" --flavor "${DFX_II_FLAVOR}")"
+
+# If II_WASM_URL ends with .gz, unzip the result
+if [[ "${II_WASM_URL}" =~ \.gz$ ]]; then
+  curl --retry 5 --fail -sSL "${II_WASM_URL}" | gunzip >internet_identity_dev.wasm
+else 
+  curl --retry 5 --fail -sSL "${II_WASM_URL}" >internet_identity_dev.wasm
+fi
+
+dfx canister install internet_identity --wasm internet_identity_dev.wasm --upgrade-unchanged --mode reinstall --yes --network "${DFX_NETWORK}"

--- a/bin/dfx-software-internet-identity-install
+++ b/bin/dfx-software-internet-identity-install
@@ -28,7 +28,7 @@ II_WASM_URL="$(dfx-software-internet-identity-ci-wasm-url --release "${DFX_II_RE
 # If II_WASM_URL ends with .gz, unzip the result
 if [[ "${II_WASM_URL}" =~ \.gz$ ]]; then
   curl --retry 5 --fail -sSL "${II_WASM_URL}" | gunzip >internet_identity_dev.wasm
-else 
+else
   curl --retry 5 --fail -sSL "${II_WASM_URL}" >internet_identity_dev.wasm
 fi
 


### PR DESCRIPTION
# Motivation

Internet identity stopped providing downloadable artifacts which are not gzipped, but in the past didn't provide downloadable artifacts which are gzipped.

Note that `dfx-software-internet-identity-version` doesn't actually work the way it's currently used by `bin/dfx-software-internet-identity-ci-wasm-url` but that's a separate issue which I'll discuss with Max when he's back. That's not blocking us right now.

# Changes

1. Change `bin/dfx-software-internet-identity-ci-wasm-url` to add `.gz` to the URL if the release is after `release-2023-04-12`
2. Add `bin/dfx-software-internet-identity-install` which installs internet identity and which understands that the downloaded artifact

# Tested

Manually hard coded different release names and checked that ii was installed with and without `.gz`.