### PR TITLE
nargs=0 for --mainnet in dfx-software-internet-identity-version

### DIFF
--- a/bin/dfx-software-internet-identity-version
+++ b/bin/dfx-software-internet-identity-version
@@ -13,7 +13,7 @@ clap.define short=l long=pinned desc="Get the pinned version from versions.bash"
 clap.define short=l long=latest desc="Get the latest version" variable=GET_LATEST nargs=0
 clap.define short=n long=network desc="Get the version deployed on the given network" variable=DFX_NETWORK default=""
 clap.define short=c long=canister desc="Get the version deployed to the given canster of the specified network" variable=CANISTER
-clap.define short=m long=mainnet desc="Get the version deployed in production" variable=GET_MAINNET
+clap.define short=m long=mainnet desc="Get the version deployed in production" variable=GET_MAINNET nargs=0
 clap.define short=h long=hash desc="Get the version of a given hash" variable=GET_HASH
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"


### PR DESCRIPTION
# Motivation

`dfx-software-internet-identity-version` has a flag called `mainnet`.
It's used [here](https://github.com/dfinity/snsdemo/blob/main/bin/dfx-network-deploy#:~:text=%2d%2dmainnet) and [here](https://github.com/dfinity/snsdemo/blob/main/bin/dfx-software-internet-identity-version#:~:text=%2d%2dmainnet).
In both cases it's used without any arguments following it.

# Changes

Add `nargs=0` to the `mainnet` flag definition in `bin/dfx-software-internet-identity-version`

# Tests

Without `nargs=0`, I get:
```
$ bin/dfx-software-internet-identity-version --mainnet
/var/folders/y7/7y8tncrs5t9g9xjm354s2cch0000gn/T/clap-XXXXXX.tmp.xGrSTeBt: line 52: $1: unbound variable
```
With it, I get
```
$ bin/dfx-software-internet-identity-version --mainnet
WARN: The default identity is not stored securely. Do not use it to control a lot of cycles/ICP. Create a new identity with `dfx identity new` and use it in mainnet-facing commands with the `--identity` flag
sed: 1: "s,.*(https://github.com ...": undefined label 'a;b;:a;p;q'
sed: 1: "s,.*(https://github.com ...": undefined label 'a;b;:a;p;q'
sed: 1: "s,.*(https://github.com ...": undefined label 'a;b;:a;p;q'
...
```