### PR TITLE
Remove duplicate installation of internet_identity

### DIFF
--- a/bin/dfx-network-deploy
+++ b/bin/dfx-network-deploy
@@ -43,15 +43,6 @@ if [[ "$DFX_NETWORK" == "local" ]]; then
   WASM_DIR="$(dfx cache show)/wasms"
   test -d "$(dfx cache show)" || dfx cache install
   mkdir -p "$WASM_DIR"
-  : "Get the specified version of II, if requested."
-  : "Note: This does clobber the version in the global cache, which is not really OK but there is no other option at the moment."
-  test -z "${DFX_II_RELEASE:-}" || {
-    II_WASM_URL="$(dfx-software-internet-identity-ci-wasm-url --release "${DFX_II_RELEASE}")"
-    tempfile="$(mktemp ii-wasm-XXXXXX)"
-    curl -sL --fail "$II_WASM_URL" >"$tempfile"
-    cp "$tempfile" "$WASM_DIR/internet_identity_dev.wasm"
-    rm "$tempfile"
-  }
   : "Get the specified version of the nns-sns-wasm.wasm"
   curl "https://download.dfinity.systems/ic/${DFX_IC_COMMIT}/canisters/sns-wasm-canister.wasm.gz" | gunzip >"${WASM_DIR}/sns-wasm-canister.wasm"
 


### PR DESCRIPTION
# Motivation

`bin/dfx-network-deploy` has 2 blocks of code to install `internet_identity`. One is conditional and one always installs it.

# Changes

Remove the code that conditionally installs internet_identity since it will be installed again anyway.

# Tests

CI.