### PR TITLE
Clean up dfx nns import commands

### DIFF
--- a/bin/dfx-network-deploy
+++ b/bin/dfx-network-deploy
@@ -47,8 +47,7 @@ if [[ "$DFX_NETWORK" == "local" ]]; then
   curl "https://download.dfinity.systems/ic/${DFX_IC_COMMIT}/canisters/sns-wasm-canister.wasm.gz" | gunzip >"${WASM_DIR}/sns-wasm-canister.wasm"
 
   dfx start --clean --background
-  dfx nns install
-  dfx-nns-import
+  dfx-nns-import --network-mapping "$DFX_NETWORK=local"
   dfx-canister-set-id --canister_name nns-dapp --canister_id qsgjb-riaaa-aaaaa-aaaga-cai
   dfx-canister-set-id --canister_name internet_identity --canister_id qhbym-qaaaa-aaaaa-aaafq-cai
 
@@ -61,6 +60,7 @@ else
   ND_REPO_DIR="${ND_REPO_DIR:-$HOME/dfn/nns-dapp/}"
   dfx-network-deploy-testnet --network "$DFX_NETWORK" --ic_dir "${IC_REPO_DIR}" --nd_dir "${ND_REPO_DIR}"
   dfx-network-deploy-config --network "$DFX_NETWORK" --ic_dir "${IC_REPO_DIR}" --nd_dir "${ND_REPO_DIR}"
+  dfx-nns-import --network-mapping "$DFX_NETWORK=local"
   dfx-network-deploy-frontends --network "$DFX_NETWORK" --ic_dir "${IC_REPO_DIR}" --nd_dir "${ND_REPO_DIR}"
 fi
 

--- a/bin/dfx-nns-import
+++ b/bin/dfx-nns-import
@@ -4,7 +4,7 @@ set -euo pipefail
 # Polyfill for dfx nns import, to fix some issues that should be fixed upstream.
 # There is a PR for upstream, but it will take time to be released.
 
-dfx nns import
+dfx nns import "${@}"
 
 jq -s '.[0] * .[1]' dfx.json <(
   cat <<EOF

--- a/bin/dfx-sns-demo
+++ b/bin/dfx-sns-demo
@@ -56,14 +56,8 @@ dfx-network-deploy --network "$DFX_NETWORK" --ic_dir "$IC_REPO_DIR" --nd_dir "$N
 # Make sure that we use snsdemo8, in case the network deployment needed to change that.
 dfx identity use snsdemo8
 
-# dfx nns import --network-mapping "$DFX_NETWORK=mainnet"
-# The above does NOT include nns-sns-wasm.  So import for local (which does include the canister????) and then copy to the requested network.
-# dfx nns import
-# jq '.*(.canisters | to_entries | map(select(.key | startswith("nns-")) | .value.remote.id[env.DFX_NETWORK] = .value.remote.id.local) |from_entries | {canisters:.})' dfx.json | sponge dfx.json
 sleep 1
-dfx nns import --network-mapping "$DFX_NETWORK=local"
-# Performs functionality that should have been done by `dfx nns import`
-dfx-nns-import
+dfx-nns-import --network-mapping "$DFX_NETWORK=local"
 sleep 1
 dfx sns import
 sleep 1


### PR DESCRIPTION
# Motivation
There is a polyfill for dfx nns import, however it is applied inconsistently.

# Changes
- Pass polyfill arguments through, so that the polyfill can be used for networks other than local.
- Apply the polyfill in more places.

# Tests
- See CI for local deployments
- The small09 testnet was deployed with these changes.