### PR TITLE
clean: Rm unused flag

### DIFF
--- a/bin/dfx-network-deploy
+++ b/bin/dfx-network-deploy
@@ -61,7 +61,7 @@ else
   ND_REPO_DIR="${ND_REPO_DIR:-$HOME/dfn/nns-dapp/}"
   dfx-network-deploy-testnet --network "$DFX_NETWORK" --ic_dir "${IC_REPO_DIR}" --nd_dir "${ND_REPO_DIR}"
   dfx-network-deploy-config --network "$DFX_NETWORK" --ic_dir "${IC_REPO_DIR}" --nd_dir "${ND_REPO_DIR}"
-  dfx-network-deploy-frontends --network "$DFX_NETWORK" --ic_dir "${IC_REPO_DIR}" --nd_dir "${ND_REPO_DIR}"
+  dfx-network-deploy-frontends --network "$DFX_NETWORK" --nd_dir "${ND_REPO_DIR}"
 fi
 
 # However the network is deloyed, we also need a placeholder for the aggregator canister.

--- a/bin/dfx-network-deploy-frontends
+++ b/bin/dfx-network-deploy-frontends
@@ -11,7 +11,6 @@ clap.define short=c long=commit desc="The IC commit of the wasms" variable=DFX_I
   . "$SOURCE_DIR/versions.bash"
   echo "$DFX_IC_COMMIT"
 )"
-clap.define short=x long=ic_dir desc="Directory containing the ic source code" variable=IC_REPO_DIR default="$HOME/dfn/ic"
 clap.define short=y long=nd_dir desc="Directory containing the nns-dapp source code" variable=ND_REPO_DIR default="$HOME/dfn/nns-dapp"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
@@ -24,7 +23,6 @@ else
   # Run remotely with one of the predefined configurations.
   # Note: This is still relatively slow and error prone.  Points of friction need to be ironed
   # out before we can resonably ask people to do this.
-  IC_REPO_DIR="${IC_REPO_DIR:-$HOME/dfn/ic-github/}"
   ND_REPO_DIR="${ND_REPO_DIR:-$HOME/dfn/nns-dapp/}"
   test -d "$ND_REPO_DIR" || {
     echo "Invalid directory for nns-dapp source code: $ND_REPO_DIR"


### PR DESCRIPTION
# Motivation
There is an unused flag in `bin/dfx-network-deploy`.

# Changes
Delete the flag and remove the one place where it is used.

# Tests
See CI