### PR TITLE
feat: Command to get nns-dapp versions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -83,4 +83,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: "Test the nns-dapp version command"
-        run: ./dfx-software-nns-dapp-version.test
+        run: ./bin/dfx-software-nns-dapp-version.test

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -76,3 +76,11 @@ jobs:
           git clean -dfx
           bin/dfx-ckbtc-deploy.test
           git clean -dfx
+  nns-dapp-canister-checks:
+    needs: formatting
+    name: NNS dapp tools
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: "Test the nns-dapp version command"
+        run: ./dfx-software-nns-dapp-version.test

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -84,3 +84,5 @@ jobs:
       - uses: actions/checkout@v3
       - name: "Test the nns-dapp version command"
         run: ./bin/dfx-software-nns-dapp-version.test
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/bin/dfx-software-nns-dapp-latest
+++ b/bin/dfx-software-nns-dapp-latest
@@ -2,7 +2,17 @@
 set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
-. "$SOURCE_DIR/versions.bash"
+
+print_help() {
+	cat <<-EOF
+	Prints the latest release of nns-dapp.
+
+	Deprecated:  Please use this instead:
+
+	  dfx-software-nns-dapp-version --latest
+
+	EOF
+}
 
 # Source the clap.bash file ---------------------------------------------------
 source "$SOURCE_DIR/clap.bash"
@@ -10,4 +20,4 @@ source "$SOURCE_DIR/clap.bash"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
-gh release list --exclude-drafts --limit 20 --repo dfinity/nns-dapp | grep -m1 proposal | sed -E 's/.*\<(proposal-[0-9]+).*/\1/g'
+dfx-software-nns-dapp-version --latest

--- a/bin/dfx-software-nns-dapp-latest
+++ b/bin/dfx-software-nns-dapp-latest
@@ -4,7 +4,7 @@ SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
 
 print_help() {
-	cat <<-EOF
+  cat <<-EOF
 	Prints the latest release of nns-dapp.
 
 	Deprecated:  Please use this instead:

--- a/bin/dfx-software-nns-dapp-version
+++ b/bin/dfx-software-nns-dapp-version
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+PATH="$SOURCE_DIR:$PATH"
+. "$SOURCE_DIR/versions.bash"
+
+print_help() {
+  cat <<-EOF
+
+	Gets the nns-dapp release from any of:
+	- The pinned release
+	- The latest release
+	- TODO: The deployed commit on a given network
+	- TODO: The commit on mainnet (shortcut for a specific case of the above)
+	EOF
+}
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/clap.bash"
+# Define options
+clap.define short=l long=pinned desc="Get the pinned version from versions.bash (default)" variable=GET_PINNED nargs=0
+clap.define short=l long=latest desc="Get the latest version" variable=GET_LATEST nargs=0
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+
+STRATEGY="${STRATEGY:-${GET_PINNED:+pinned}}"
+STRATEGY="${STRATEGY:-${GET_LATEST:+latest}}"
+STRATEGY="${STRATEGY:-pinned}" # Default - not guaranteed to be stable
+case "${STRATEGY}" in
+pinned)
+  . "$SOURCE_DIR/versions.bash"
+  echo "$NNS_DAPP_RELEASE"
+  ;;
+latest)
+  gh release list --exclude-drafts --exclude-pre-releases --limit 100 --repo dfinity/nns-dapp | grep -Eo 'proposal-[0-9]+' | head -1
+  ;;
+*)
+  {
+    echo "ERROR: Unsupported strategy '${STRATEGY:-}'"
+    exit 1
+  } >&2
+  ;;
+esac

--- a/bin/dfx-software-nns-dapp-version
+++ b/bin/dfx-software-nns-dapp-version
@@ -32,7 +32,7 @@ pinned)
   echo "$NNS_DAPP_RELEASE"
   ;;
 latest)
-  gh release list --exclude-drafts --exclude-pre-releases --limit 100 --repo dfinity/nns-dapp | grep -Eo 'proposal-[0-9]+' | head -1
+  gh release list --exclude-drafts --exclude-pre-releases --limit 100 --repo dfinity/nns-dapp | grep -Eo '^proposal-[0-9]+$' | head -1
   ;;
 *)
   {

--- a/bin/dfx-software-nns-dapp-version
+++ b/bin/dfx-software-nns-dapp-version
@@ -32,7 +32,7 @@ pinned)
   echo "$NNS_DAPP_RELEASE"
   ;;
 latest)
-  gh release list --exclude-drafts --exclude-pre-releases --limit 100 --repo dfinity/nns-dapp | grep -Eo '^proposal-[0-9]+$' | head -1
+  gh release list --exclude-drafts --exclude-pre-releases --limit 100 --repo dfinity/nns-dapp | grep -wEo 'proposal-[0-9]+' | head -1
   ;;
 *)
   {

--- a/bin/dfx-software-nns-dapp-version.test
+++ b/bin/dfx-software-nns-dapp-version.test
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+PATH="$SOURCE_DIR:$PATH"
+
+(
+  echo "Using --pinned should get a release from the versions file"
+  ACTUAL_RELEASE="$(dfx-software-nns-dapp-version --pinned)"
+  EXPECTED_RELEASE="$(. "$SOURCE_DIR/versions.bash" && echo "${NNS_DAPP_RELEASE}")"
+  [[ "$ACTUAL_RELEASE" =~ ^proposal-[0-9]*$ ]] || {
+    echo "ERROR: The release is not a proposal tag: '$ACTUAL_RELEASE'"
+    exit 1
+  } >&2
+  [[ "$ACTUAL_RELEASE" == "$EXPECTED_RELEASE" ]] || {
+    echo "ERROR: The release does not correspond to a naive reading of the versions file."
+    echo "   EXPECTED: '$EXPECTED_RELEASE'"
+    echo "   ACTUAL:   '$ACTUAL_RELEASE'"
+    exit 1
+  } >&2
+)
+
+(
+  echo "Using --latest should get a release"
+  ACTUAL_RELEASE="$(dfx-software-nns-dapp-version --latest)"
+  [[ "$ACTUAL_RELEASE" =~ ^proposal-[0-9]*$ ]] || {
+    echo "ERROR: The release is not a proposal tag: '$ACTUAL_RELEASE'"
+    echo "Note:  This may fail legitimately if there have been many non-proposal"
+    echo "       releases since the last proposal.  This is unlikely but possible."
+    echo "       Please check."
+    exit 1
+  } >&2
+)
+
+(
+  echo "Providing no flags should provide the pinned version"
+  DEFAULT_RELEASE="$(dfx-software-nns-dapp-version)"
+  PINNED_RELEASE="$(dfx-software-nns-dapp-version --pinned)"
+  [[ "$DEFAULT_RELEASE" == "$PINNED_RELEASE" ]] || {
+    echo "ERROR: The default release does not match the pinned release."
+    echo "   PINNED:  '$PINNED_RELEASE'"
+    echo "   DEFAULT: '$DEFAULT_RELEASE'"
+    exit 1
+  } >&2
+)
+
+echo "$(basename "$0") PASSED"

--- a/bin/dfx-software-nns-dapp-version.test
+++ b/bin/dfx-software-nns-dapp-version.test
@@ -8,11 +8,11 @@ PATH="$SOURCE_DIR:$PATH"
   ACTUAL_RELEASE="$(dfx-software-nns-dapp-version --pinned)"
   EXPECTED_RELEASE="$(. "$SOURCE_DIR/versions.bash" && echo "${NNS_DAPP_RELEASE}")"
   [[ "$ACTUAL_RELEASE" =~ ^proposal-[0-9]*$ ]] || {
-    echo "ERROR: The release is not a proposal tag: '$ACTUAL_RELEASE'"
+    echo "ERROR: The release should be a proposal tag but is not: '$ACTUAL_RELEASE'"
     exit 1
   } >&2
   [[ "$ACTUAL_RELEASE" == "$EXPECTED_RELEASE" ]] || {
-    echo "ERROR: The release does not correspond to a naive reading of the versions file."
+    echo "ERROR: The release should correspond to a naive reading of the versions file."
     echo "   EXPECTED: '$EXPECTED_RELEASE'"
     echo "   ACTUAL:   '$ACTUAL_RELEASE'"
     exit 1
@@ -23,7 +23,7 @@ PATH="$SOURCE_DIR:$PATH"
   echo "Using --latest should get a release"
   ACTUAL_RELEASE="$(dfx-software-nns-dapp-version --latest)"
   [[ "$ACTUAL_RELEASE" =~ ^proposal-[0-9]*$ ]] || {
-    echo "ERROR: The release is not a proposal tag: '$ACTUAL_RELEASE'"
+    echo "ERROR: The release should be a proposal tag: '$ACTUAL_RELEASE'"
     echo "Note:  This may fail legitimately if there have been many non-proposal"
     echo "       releases since the last proposal.  This is unlikely but possible."
     echo "       Please check."
@@ -36,7 +36,7 @@ PATH="$SOURCE_DIR:$PATH"
   DEFAULT_RELEASE="$(dfx-software-nns-dapp-version)"
   PINNED_RELEASE="$(dfx-software-nns-dapp-version --pinned)"
   [[ "$DEFAULT_RELEASE" == "$PINNED_RELEASE" ]] || {
-    echo "ERROR: The default release does not match the pinned release."
+    echo "ERROR: The default release should match the pinned release."
     echo "   PINNED:  '$PINNED_RELEASE'"
     echo "   DEFAULT: '$DEFAULT_RELEASE'"
     exit 1

--- a/bin/versions.bash
+++ b/bin/versions.bash
@@ -2,3 +2,4 @@
 # shellcheck disable=SC2034 # VAriables are expected to be unused in this file
 DFX_IC_COMMIT=204fed96ed7932e50ca5a771c768289e78664c0d
 INTERNET_IDENTITY_RELEASE=release-2023-04-12
+NNS_DAPP_RELEASE=proposal-121690


### PR DESCRIPTION
# Motivation
We wish to install the nns-dapp wasms from prebuilt releases.  For this, we need to know which version of nns-dapp to install

Note: This is similar to the code for other canisters such as `internet_identity` version command and the (get to be merged) `sns_aggregator` version command, however on close examination each has details that differ so combining them is probably not worthwhile at present.

# Changes
- Define a default (pinned) version 
- Define a command to get the pinned release or the latest release by proposal.

# Tests
A test has been added and is exercised in CI