### PR TITLE
Add a version command for the aggregator

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -59,7 +59,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: "Test the sns aggregator version command"
-        run: ./bin/dfx-software-nns-dapp-version.test
+        run: ./bin/dfx-software-sns-aggregator-version.test
         env:
           GH_TOKEN: ${{ github.token }}
   ckbtc-checks:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -52,6 +52,16 @@ jobs:
       - uses: actions/checkout@v3
       - name: Clap works
         run: ./bin/clap.test
+  sns-aggregator-canister-checks:
+    needs: formatting
+    name: SNS aggregator tools
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: "Test the sns aggregator version command"
+        run: ./bin/dfx-software-nns-dapp-version.test
+        env:
+          GH_TOKEN: ${{ github.token }}
   ckbtc-checks:
     needs: formatting
     name: CKBTC tools

--- a/bin/dfx-software-sns-aggregator-version
+++ b/bin/dfx-software-sns-aggregator-version
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+PATH="$SOURCE_DIR:$PATH"
+. "$SOURCE_DIR/versions.bash"
+
+print_help() {
+  cat <<-EOF
+
+	Gets the sns_aggregator release from any of:
+	- The pinned release
+	- The latest release
+	- TODO: The deployed commit on a given network
+	- TODO: The commit on mainnet (shortcut for a specific case of the above)
+	EOF
+}
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/clap.bash"
+# Define options
+clap.define short=l long=pinned desc="Get the pinned version from versions.bash (default)" variable=GET_PINNED nargs=0
+clap.define short=l long=latest desc="Get the latest version" variable=GET_LATEST nargs=0
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+
+STRATEGY="${STRATEGY:-${GET_PINNED:+pinned}}"
+STRATEGY="${STRATEGY:-${GET_LATEST:+latest}}"
+STRATEGY="${STRATEGY:-pinned}" # Default - not guaranteed to be stable
+case "${STRATEGY}" in
+pinned)
+  . "$SOURCE_DIR/versions.bash"
+  echo "$SNS_AGGREGATOR_RELEASE"
+  ;;
+latest)
+  gh release list --exclude-drafts --exclude-pre-releases --limit 300 --repo dfinity/nns-dapp | grep -wEo 'proposal-[0-9]+-agg' | head -1
+  ;;
+*)
+  {
+    echo "ERROR: Unsupported strategy '${STRATEGY:-}'"
+    exit 1
+  } >&2
+  ;;
+esac

--- a/bin/dfx-software-sns-aggregator-version.test
+++ b/bin/dfx-software-sns-aggregator-version.test
@@ -8,11 +8,11 @@ PATH="$SOURCE_DIR:$PATH"
   ACTUAL_RELEASE="$(dfx-software-sns-aggregator-version --pinned)"
   EXPECTED_RELEASE="$(. "$SOURCE_DIR/versions.bash" && echo "${SNS_AGGREGATOR_RELEASE}")"
   [[ "$ACTUAL_RELEASE" =~ ^proposal-[0-9]*-agg$ ]] || {
-    echo "ERROR: The release is not a proposal tag: '$ACTUAL_RELEASE'"
+    echo "ERROR: The release should be a proposal tag but is not: '$ACTUAL_RELEASE'"
     exit 1
   } >&2
   [[ "$ACTUAL_RELEASE" == "$EXPECTED_RELEASE" ]] || {
-    echo "ERROR: The release does not correspond to a naive reading of the versions file."
+    echo "ERROR: The release should correspond to a naive reading of the versions file."
     echo "   EXPECTED: '$EXPECTED_RELEASE'"
     echo "   ACTUAL:   '$ACTUAL_RELEASE'"
     exit 1
@@ -23,7 +23,7 @@ PATH="$SOURCE_DIR:$PATH"
   echo "Using --latest should get a release"
   ACTUAL_RELEASE="$(dfx-software-sns-aggregator-version --latest)"
   [[ "$ACTUAL_RELEASE" =~ ^proposal-[0-9]*-agg$ ]] || {
-    echo "ERROR: The release is not a proposal tag: '$ACTUAL_RELEASE'"
+    echo "ERROR: The release should be a proposal tag: '$ACTUAL_RELEASE'"
     echo "Note:  This may fail legitimately if there have been many non-proposal"
     echo "       releases since the last proposal.  This is unlikely but possible."
     echo "       Please check."
@@ -36,7 +36,7 @@ PATH="$SOURCE_DIR:$PATH"
   DEFAULT_RELEASE="$(dfx-software-sns-aggregator-version)"
   PINNED_RELEASE="$(dfx-software-sns-aggregator-version --pinned)"
   [[ "$DEFAULT_RELEASE" == "$PINNED_RELEASE" ]] || {
-    echo "ERROR: The default release does not match the pinned release."
+    echo "ERROR: The default release should match the pinned release."
     echo "   PINNED:  '$PINNED_RELEASE'"
     echo "   DEFAULT: '$DEFAULT_RELEASE'"
     exit 1

--- a/bin/dfx-software-sns-aggregator-version.test
+++ b/bin/dfx-software-sns-aggregator-version.test
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+PATH="$SOURCE_DIR:$PATH"
+
+(
+  echo "Using --pinned should get a release from the versions file"
+  ACTUAL_RELEASE="$(dfx-software-sns-aggregator-version --pinned)"
+  EXPECTED_RELEASE="$(. "$SOURCE_DIR/versions.bash" && echo "${SNS_AGGREGATOR_RELEASE}")"
+  [[ "$ACTUAL_RELEASE" =~ ^proposal-[0-9]*-agg$ ]] || {
+    echo "ERROR: The release is not a proposal tag: '$ACTUAL_RELEASE'"
+    exit 1
+  } >&2
+  [[ "$ACTUAL_RELEASE" == "$EXPECTED_RELEASE" ]] || {
+    echo "ERROR: The release does not correspond to a naive reading of the versions file."
+    echo "   EXPECTED: '$EXPECTED_RELEASE'"
+    echo "   ACTUAL:   '$ACTUAL_RELEASE'"
+    exit 1
+  } >&2
+)
+
+(
+  echo "Using --latest should get a release"
+  ACTUAL_RELEASE="$(dfx-software-sns-aggregator-version --latest)"
+  [[ "$ACTUAL_RELEASE" =~ ^proposal-[0-9]*-agg$ ]] || {
+    echo "ERROR: The release is not a proposal tag: '$ACTUAL_RELEASE'"
+    echo "Note:  This may fail legitimately if there have been many non-proposal"
+    echo "       releases since the last proposal.  This is unlikely but possible."
+    echo "       Please check."
+    exit 1
+  } >&2
+)
+
+(
+  echo "Providing no flags should provide the pinned version"
+  DEFAULT_RELEASE="$(dfx-software-sns-aggregator-version)"
+  PINNED_RELEASE="$(dfx-software-sns-aggregator-version --pinned)"
+  [[ "$DEFAULT_RELEASE" == "$PINNED_RELEASE" ]] || {
+    echo "ERROR: The default release does not match the pinned release."
+    echo "   PINNED:  '$PINNED_RELEASE'"
+    echo "   DEFAULT: '$DEFAULT_RELEASE'"
+    exit 1
+  } >&2
+)
+
+echo "$(basename "$0") PASSED"

--- a/bin/versions.bash
+++ b/bin/versions.bash
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2034 # VAriables are expected to be unused in this file
 DFX_IC_COMMIT=204fed96ed7932e50ca5a771c768289e78664c0d
+SNS_AGGREGATOR_RELEASE=proposal-115273-agg
 INTERNET_IDENTITY_RELEASE=release-2023-04-12


### PR DESCRIPTION
# Motivation
We wish to deploy the sns aggregator from a prebuilt wasm.  To start, we need a way to get the version to deploy.

# Changes
- Add a command to get the pinned version and the latest released version

# Tests
- A test has been added and is exercised in CI