### PR TITLE
Clear dfx wasms cache before 'dfx nns install'

### DIFF
--- a/bin/dfx-nns-install
+++ b/bin/dfx-nns-install
@@ -26,8 +26,9 @@ clap.define short=c long=ic_commit desc="The IC commit of the wasms" variable=DF
 source "$(clap.build)"
 
 WASMS_DIR="$(dfx cache show)/wasms"
+mkdir -p $WASMS_DIR
 
-if [ -d $WASMS_DIR ]; then
+if [ "$(ls -A "$WASMS_DIR")" ]; then
   # 'dfx nns install' will use wasms present in $WASMS_DIR, even if they do not
   # match the requested DFX_IC_COMMIT. So we move anything in $WASMS_DIR out of
   # the way to guarantee a predictable experience.
@@ -43,8 +44,6 @@ if [ -d $WASMS_DIR ]; then
   }
 
   trap restore_backup EXIT
-else
-  mkdir -p $WASMS_DIR
 fi
 
 # The URL of the lifeline.wasm changed at some point. If the new URL exists for

--- a/bin/dfx-nns-install
+++ b/bin/dfx-nns-install
@@ -26,7 +26,7 @@ clap.define short=c long=ic_commit desc="The IC commit of the wasms" variable=DF
 source "$(clap.build)"
 
 WASMS_DIR="$(dfx cache show)/wasms"
-mkdir -p $WASMS_DIR
+mkdir -p "$WASMS_DIR"
 
 if [ "$(ls -A "$WASMS_DIR")" ]; then
   # 'dfx nns install' will use wasms present in $WASMS_DIR, even if they do not

--- a/bin/dfx-nns-install
+++ b/bin/dfx-nns-install
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -xeuo pipefail
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 
 print_help() {
@@ -26,6 +26,26 @@ clap.define short=c long=ic_commit desc="The IC commit of the wasms" variable=DF
 source "$(clap.build)"
 
 WASMS_DIR="$(dfx cache show)/wasms"
+
+if [ -d $WASMS_DIR ]; then
+  # 'dfx nns install' will use wasms present in $WASMS_DIR, even if they do not
+  # match the requested DFX_IC_COMMIT. So we move anything in $WASMS_DIR out of
+  # the way to guarantee a predictable experience.
+  DFX_CACHE_WASMS_BACKUP_DIR="$HOME/dfx-cache-wasms-backup-$(date +"%Y%m%d_%H%M%S")"
+  mkdir -p "$DFX_CACHE_WASMS_BACKUP_DIR"
+  echo "Moving wasms from ${WASMS_DIR} to ${DFX_CACHE_WASMS_BACKUP_DIR}"
+  mv "$WASMS_DIR"/* "$DFX_CACHE_WASMS_BACKUP_DIR"
+
+  restore_backup() {
+    echo "Moving wasms from ${DFX_CACHE_WASMS_BACKUP_DIR} back to ${WASMS_DIR}"
+    mv "$DFX_CACHE_WASMS_BACKUP_DIR"/* "$WASMS_DIR"
+    rmdir "$DFX_CACHE_WASMS_BACKUP_DIR"
+  }
+
+  trap restore_backup EXIT
+else
+  mkdir -p $WASMS_DIR
+fi
 
 # The URL of the lifeline.wasm changed at some point. If the new URL exists for
 # the given commit, download it to prepopulate the wasms cache with the old


### PR DESCRIPTION
# Motivation

When running `dfx nns install` you can specify a `DFX_IC_COMMIT` to determine which versions of canisters will be installed. But if canisters are already present in `$(dfx cache show)/wasms`, those will be used regardless of which version they are.
This results in unpredictable canister versions being installed on a manually created snapshot.
We would like a manually created snapshot to mirror CI as close as possible to we can test locally under conditions as similar as possible to CI.

# Changes

1. In `bin/dfx-nns-install`, empty the dfx wasms cache directory before running `dfx nns install`.
2. Move the removed wasms back to the cache afterwards.

I intentionally didn't remove wasms that weren't there before. This is debatable but I think it might be useful to have them and it's most important that the snapshot itself is predictable. Let me know if you disagree.

# Tests

Ran `bin/dfx-nns-install` (both with empty and non-empty wasms cache) and watched it empty the cache, download wasms and restore them afterwards.