### PR TITLE
Update dfx canister url

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -112,7 +112,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install dfx
         run: ./bin/dfx-software-dfx-install --version "$(jq -r .dfx dfx.json)"
-      - name: Import ckbtc works
+      - name: dfx-canister-url works
         run: |
           set -euxo pipefail
           echo "This modifies files, so make sure the state is clean before and after"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -117,5 +117,5 @@ jobs:
           set -euxo pipefail
           echo "This modifies files, so make sure the state is clean before and after"
           git clean -dfx
-          bin/dfx-canister-url.test
+          bin/dfx-canister-url.test --verbose
           git clean -dfx

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -102,3 +102,20 @@ jobs:
         run: ./bin/dfx-software-nns-dapp-version.test
         env:
           GH_TOKEN: ${{ github.token }}
+  dfx-canister-url-checks:
+    needs: formatting
+    name: Canister URL checks
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Install apt-dependencies
+        run: sudo apt-get update && sudo apt-get install moreutils -yy && command -v more
+      - uses: actions/checkout@v3
+      - name: Install dfx
+        run: ./bin/dfx-software-dfx-install --version "$(jq -r .dfx dfx.json)"
+      - name: Import ckbtc works
+        run: |
+          set -euxo pipefail
+          echo "This modifies files, so make sure the state is clean before and after"
+          git clean -dfx
+          bin/dfx-canister-url.test
+          git clean -dfx

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -59,7 +59,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install tools
-        run: ./bin/dfx-software-wasm-nm-install 
+        run: ./bin/dfx-software-wasm-nm-install
       - name: "Test the sns aggregator version command"
         run: ./bin/dfx-software-sns-aggregator-version.test
         env:

--- a/bin/dfx-canister-url
+++ b/bin/dfx-canister-url
@@ -102,7 +102,7 @@ done
 #          "ic": "https://nns.ic0.app",
 #          "mainnet": "https://nns.ic0.app"
 # } }  } }
-url="$(c="$DFX_CANISTER" n="$DFX_NETWORK" jq -r '.canisters[env.DFX_CANISTER].url[env.DFX_NETWORK] // ""' dfx.json)"
+url="$(jq -r '.canisters[env.DFX_CANISTER].url[env.DFX_NETWORK] // ""' dfx.json)"
 
 # Not found?
 # Each network also has a pattern for canister URLs of the form: https://CANISTER_ID.NETWORK_URL

--- a/bin/dfx-canister-url
+++ b/bin/dfx-canister-url
@@ -130,10 +130,10 @@ test -n "${url:-}" || url="$(network_config | h="${DFX_URL_TYPE^^}_HOST" jq -re 
 
 # ... The network may be local
 test -n "${url}" || [[ "${DFX_NETWORK:-}" != "local" ]] || {
-    case "$DFX_URL_TYPE" in
-    static) url="http://${CANISTER_ID}:8080" ;; # Note: The canister ID is NOT provided as a subdomain and no web assets are served.
-    api) url="http://localhost:8080" ;;
-    esac
+  case "$DFX_URL_TYPE" in
+  static) url="http://${CANISTER_ID}:8080" ;; # Note: The canister ID is NOT provided as a subdomain and no web assets are served.
+  api) url="http://localhost:8080" ;;
+  esac
 }
 
 # Last try:  Assume the network is a testnet.

--- a/bin/dfx-canister-url
+++ b/bin/dfx-canister-url
@@ -69,7 +69,7 @@ test -n "$url" || {
   if [[ "$DFX_NETWORK" == "ic" ]]; then
     case "$DFX_URL_TYPE" in
     static) url="https://${CANISTER_ID}.icp0.io" ;;
-    api) HOST="https://icp-api.io" ;; # Note: The canister ID is NOT provided as a subdomain and no web assets are served.
+    api) url="https://icp-api.io" ;; # Note: The canister ID is NOT provided as a subdomain and no web assets are served.
     esac
   fi
 }

--- a/bin/dfx-canister-url
+++ b/bin/dfx-canister-url
@@ -62,7 +62,7 @@ URL_TYPES=(static api)
 # Define options
 clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
 clap.define short=c long=canister desc="The canister name" variable=DFX_CANISTER
-clap.define short=t long=type desc="The canister type (options: ${URL_TYPES[@]})" variable=DFX_URL_TYPE default=static
+clap.define short=t long=type desc="The canister type (options: ${URL_TYPES[*]})" variable=DFX_URL_TYPE default=static
 clap.define short=o long=open desc="Open the URL in a browser" variable=DFX_OPEN nargs=0
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
@@ -81,7 +81,6 @@ printf '%s\0' "${URL_TYPES[@]}" | grep -Fxqz -- "$DFX_URL_TYPE" || {
   printf "       * %s\n" "${URL_TYPES[@]}"
   exit 1
 } >&2
-PREFERRED_HOST="HOST_${DFX_URL_TYPE^^}"
 
 export DFX_NETWORK
 export DFX_CANISTER

--- a/bin/dfx-canister-url
+++ b/bin/dfx-canister-url
@@ -65,10 +65,10 @@ test -n "$url" || url="https://${CANISTER_ID}.${DFX_NETWORK}.testnet.dfinity.net
 
 if [[ "${DFX_OPEN:-}" == "true" ]]; then
   command=xdg-open                      # Uses Linux default browser
-  command -v "$command" || command=open # Uses mac default browser
-  command -v "$command" || command=firefox
-  command -v "$command" || command=google-chrome
-  command -v "$command" || {
+  command -v "$command" &>/dev/null || command=open # Uses mac default browser
+  command -v "$command" &>/dev/null || command=firefox
+  command -v "$command" &>/dev/null || command=google-chrome
+  command -v "$command" &>/dev/null || {
     printf "ERROR: %s\n" "Unable to detect how to open your browser."
     exit 1
   } >&2

--- a/bin/dfx-canister-url
+++ b/bin/dfx-canister-url
@@ -87,6 +87,7 @@ export DFX_NETWORK
 export DFX_CANISTER
 export CANISTER_ID
 
+# Look for dfx.json in the current and parent directories.
 while ! test -e dfx.json; do
   cd .. || {
     echo "ERROR: dfx.json not found"
@@ -95,14 +96,6 @@ while ! test -e dfx.json; do
 done
 
 # Some canisters have custom URLs, such as identity.ic0.app.
-# There is no standard for this.  There should be.  So we will start one:
-# For nns-dapp, dfx.json should include:
-# { "canisters": {
-#      "nns-dapp": {
-#        "url": {
-#          "ic": "https://nns.ic0.app",
-#          "mainnet": "https://nns.ic0.app"
-# } }  } }
 url="$(jq -r '.canisters[env.DFX_CANISTER].url[env.DFX_NETWORK] // ""' dfx.json)"
 
 # Not found?
@@ -132,11 +125,11 @@ test -n "$url" || {
   fi
 }
 
-# ... The network URL may be in the local dfx.json or in the common config.
+# ... The network URL may be in dfx.json or in the user's global network config, if it exists.
 GLOBAL_NETWORK_CONFIG_FILE="$HOME/.config/dfx/networks.json"
 network_config() {
   : "Getting the local and global network config..."
-  ! test -e dfx.json || jq '.networks // {}' dfx.json
+  jq '.networks // {}' dfx.json
   ! test -e "$GLOBAL_NETWORK_CONFIG_FILE" || cat "$GLOBAL_NETWORK_CONFIG_FILE"
 }
 test -n "${url:-}" || url="$(network_config | h="${DFX_URL_TYPE^^}_HOST" jq -re '.[env.DFX_NETWORK].config | .[env.h] // .HOST // empty' | inject_canister_id || true)"

--- a/bin/dfx-canister-url
+++ b/bin/dfx-canister-url
@@ -131,8 +131,8 @@ test -n "${url:-}" || url="$(network_config | h="${DFX_URL_TYPE^^}_HOST" jq -re 
 # ... The network may be local
 test -n "${url}" || [[ "${DFX_NETWORK:-}" != "local" ]] || {
     case "$DFX_URL_TYPE" in
-    static) url="http://localhost:8080" ;;
-    api) url="http://${CANISTER_ID}:8080" ;; # Note: The canister ID is NOT provided as a subdomain and no web assets are served.
+    static) url="http://${CANISTER_ID}:8080" ;; # Note: The canister ID is NOT provided as a subdomain and no web assets are served.
+    api) url="http://localhost:8080" ;;
     esac
 }
 

--- a/bin/dfx-canister-url
+++ b/bin/dfx-canister-url
@@ -111,14 +111,14 @@ canister_id() {
   dfx canister id --network "$DFX_NETWORK" "$DFX_CANISTER"
 }
 inject_canister_id() {
-	read -r root_url
-	test -n "${root_url:-}" || return
+  read -r root_url
+  test -n "${root_url:-}" || return
   case "$DFX_URL_TYPE" in
-	  static)
-		  local CANISTER_ID="$(canister_id)"
-		  printf "%s\n" "$root_url" | sed -E "s,^(https?://)?,&${CANISTER_ID}.,g"
-		  ;;
-	  *) printf "%s\n" "$root_url" ;;
+  static)
+    local CANISTER_ID="$(canister_id)"
+    printf "%s\n" "$root_url" | sed -E "s,^(https?://)?,&${CANISTER_ID}.,g"
+    ;;
+  *) printf "%s\n" "$root_url" ;;
   esac
 }
 
@@ -126,7 +126,7 @@ inject_canister_id() {
 test -n "$url" || {
   if [[ "$DFX_NETWORK" == "ic" ]]; then
     case "$DFX_URL_TYPE" in
-	    static) url="https://$(canister_id).icp0.io" ;;
+    static) url="https://$(canister_id).icp0.io" ;;
     api) url="https://icp-api.io" ;; # Note: The canister ID is NOT provided as a subdomain and no web assets are served.
     esac
   fi

--- a/bin/dfx-canister-url
+++ b/bin/dfx-canister-url
@@ -13,10 +13,12 @@ print_help() {
 
 # Source the clap.bash file ---------------------------------------------------
 source "$SOURCE_DIR/clap.bash"
+URL_TYPES=( static api )
 # Define options
 clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
 clap.define short=c long=canister desc="The canister name" variable=DFX_CANISTER
-clap.define short=o long=open desc="Open the URL ina  browser" variable=DFX_OPEN nargs=0
+clap.define short=t long=type desc="The canister type (options: ${URL_TYPES[@]})" variable=DFX_URL_TYPE default=static
+clap.define short=o long=open desc="Open the URL in a browser" variable=DFX_OPEN nargs=0
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
@@ -26,6 +28,15 @@ test -n "${DFX_CANISTER:-}" || {
   echo "ERROR: Please specify a canister name or ID"
   exit 1
 }
+
+# Sanity check the URL type
+printf '%s\0' "${URL_TYPES[@]}" | grep -Fxqz -- "$DFX_URL_TYPE" || {
+  echo "ERROR: Unsupported URL type: '$DFX_URL_TYPE'"
+  echo "       Valid options:"
+  printf "       * %s\n" "${URL_TYPES[@]}"
+  exit 1
+} >&2
+PREFERRED_HOST="HOST_${DFX_URL_TYPE^^}"
 
 export DFX_NETWORK
 export DFX_CANISTER
@@ -53,13 +64,30 @@ url="$(c="$DFX_CANISTER" n="$DFX_NETWORK" jq -r '.canisters[env.DFX_CANISTER].ur
 # Each network also has a pattern for canister URLs of the form: https://CANISTER_ID.NETWORK_URL
 test -n "${url:-}" || CANISTER_ID="$(dfx canister id --network  "$DFX_NETWORK" "$DFX_CANISTER")"
 
-# .. Maybe this is in production.  Prioritize this so that prod builds are not easily affected by local configuration.
-test -n "$url" || [[ "$DFX_NETWORK" != "mainnet" ]] || url="https://${CANISTER_ID}.internetcomputer.org"
-test -n "$url" || [[ "$DFX_NETWORK" != "ic" ]] || url="https://${CANISTER_ID}.internetcomputer.org"
-# ... The network URL may be in the local dfx.json or in the common config.
-test -n "${url:-}" || url="$(jq -r '.networks[env.DFX_NETWORK].config.HOST // "" | sub("^(?<p>https?://)";"\(.p)\(env.CANISTER_ID).")' dfx.json)"
-test -n "${url:-}" || url="$(jq -r '        .[env.DFX_NETWORK].config.HOST // "" | sub("^(?<p>https?://)";"\(.p)\(env.CANISTER_ID).")' "$HOME/.config/dfx/networks.json")"
+# .. Maybe this is in production.  Prioritize this so that production builds are not easily affected by local configuration.
+test -n "$url" || {
+	if [[ "$DFX_NETWORK" =~ ^(mainnet|ic)$ ]] ; then
+  case "$DFX_URL_TYPE" in
+  static) url="https://${CANISTER_ID}.icp0.io" ;;
+  api) HOST="https://icp-api.io" ;; # Note: The canister ID is NOT provided as a subdomain and no web assets are served.
+  esac
+	fi
+}
 
+# ... The network URL may be in the local dfx.json or in the common config.
+GLOBAL_NETWORK_CONFIG_FILE="$HOME/.config/dfx/networks.json"
+network_config() {
+    ! test -e dfx.json || jq '.networks // {}' dfx.json
+    ! test -e "$GLOBAL_NETWORK_CONFIG_FILE" || cat "$GLOBAL_NETWORK_CONFIG_FILE"
+}
+case "${DFX_URL_TYPE:-}" in
+	static)
+		test -n "${url:-}" || url="$(network_config | jq -re '.[env.DFX_NETWORK].config | .STATIC_HOST // .HOST | first // ""')" ;;
+	api)
+		test -n "${url:-}" || url="$(jq -re '.networks[env.DFX_NETWORK].config.API_HOST // .networks[env.DFX_NETWORK].config.API_HOST // ""' dfx.json)"
+		test -n "${url:-}" || ! test -e "$GLOBAL_NETWORK_CONFIG_FILE" || url="$(jq -re '.[env.DFX_NETWORK].config.API_HOST // .[env.DFX_NETWORK].config.API_HOST' "$GLOBAL_NETWORK_CONFIG_FILE")"
+		;;
+esac
 
 # Last try:  Assume the network is a testnet.
 test -n "$url" || url="https://${CANISTER_ID}.${DFX_NETWORK}.testnet.dfinity.network"

--- a/bin/dfx-canister-url
+++ b/bin/dfx-canister-url
@@ -77,23 +77,11 @@ test -n "$url" || {
 # ... The network URL may be in the local dfx.json or in the common config.
 GLOBAL_NETWORK_CONFIG_FILE="$HOME/.config/dfx/networks.json"
 network_config() {
+	: "Getting the local and global network config..."
   ! test -e dfx.json || jq '.networks // {}' dfx.json
   ! test -e "$GLOBAL_NETWORK_CONFIG_FILE" || cat "$GLOBAL_NETWORK_CONFIG_FILE"
 }
-case "${DFX_URL_TYPE:-}" in
-static)
-  test -n "${url:-}" || url="$(network_config | jq -re '.[env.DFX_NETWORK].config | .STATIC_HOST // .HOST | first // ""')"
-  ;;
-api)
-  test -n "${url:-}" || url="$(network_config | jq -re '.[env.DFX_NETWORK].config | .API_HOST // .HOST | first // ""')"
-  ;;
-*)
-  {
-    echo "ERROR: Unsupported url type: '$DFX_URL_TYPE'"
-    exit 1
-  } >&2
-  ;;
-esac
+test -n "${url:-}" || url="$(network_config | h="${DFX_URL_TYPE^^}_HOST" jq -re '.[env.DFX_NETWORK].config | .[env.h] // .HOST // empty | sub("^(?<p>https?://)";"\(.p)\(env.CANISTER_ID).")' | head -n1)"
 
 # Last try:  Assume the network is a testnet.
 test -n "$url" || url="https://${CANISTER_ID}.${DFX_NETWORK}.testnet.dfinity.network"

--- a/bin/dfx-canister-url
+++ b/bin/dfx-canister-url
@@ -7,7 +7,7 @@ PATH="$SOURCE_DIR:$PATH"
 print_help() {
   cat <<-"EOF"
 
-	Prints the URL for a canister frontend.
+	Prints the URL for a canister.
 
 	There are two types of URL:
 	- "api" that serve only API calls, not web pages.

--- a/bin/dfx-canister-url
+++ b/bin/dfx-canister-url
@@ -5,9 +5,54 @@ PATH="$SOURCE_DIR:$PATH"
 . "$SOURCE_DIR/versions.bash"
 
 print_help() {
-  cat <<-EOF
+  cat <<-"EOF"
 
 	Prints the URL for a canister frontend.
+
+	There are two types of URL:
+	- "api" that serve only API calls, not web pages.
+	- "static" that serve everything including web pages and API calls.
+
+	For the internet computer mainnet, the URLs of a canister are:
+	- api: https://icp-api.io  (regardless of canister ID)
+	- static: https://${CANISTER_ID}.icp0.io
+	Other domains _may_ work but are not supported by this tool.
+
+	Canisters may have custom static asset domains for a better user experience.
+	Such domains may be specified in dfx.json.  For example:
+	{ "canisters": {
+	    "my_canister": {
+	      "url": { "ic": "https://my-custom-url.com" },
+	      ...
+	    }
+	  }
+	}
+
+	If you are running a local replica with dfx start, the default canister URLs are:
+	- api:     http://localhost:8080
+	- static:  http://${CANISTER_ID}.localhost:8080
+	The port may be changed in your network configuration.
+
+	If you are running a replica on a remote test server, your setup is likely customized.
+	We recommend that you populate your global network config at ~/.config/dfx/networks.json
+	and provide the entries API_HOST and STATIC_HOST.  E.g.:
+	{
+	  "mytestnet": {
+	    "config": {
+	      "FETCH_ROOT_KEY": true,
+	      "API_HOST": "https://api.my_test_server",
+	      "STATIC_HOST": "https://my_test_server"
+	    },
+	    "providers": [
+	      "http://[2a00:fb01:111:111:111:1111:111:111]:8080"
+	    ],
+	    "type": "persistent"
+	  }
+	}
+	dfx-canister-url will then generate the following URLs:
+	- api:     https://api.my_test_server
+	- static:  https://${CANISTER_ID}.my_test_server
+	You can still override the URLs with custom entries in dfx.json.
 	EOF
 }
 
@@ -81,7 +126,15 @@ network_config() {
   ! test -e dfx.json || jq '.networks // {}' dfx.json
   ! test -e "$GLOBAL_NETWORK_CONFIG_FILE" || cat "$GLOBAL_NETWORK_CONFIG_FILE"
 }
-test -n "${url:-}" || url="$(network_config | h="${DFX_URL_TYPE^^}_HOST" jq -re '.[env.DFX_NETWORK].config | .[env.h] // .HOST // empty | sub("^(?<p>https?://)";"\(.p)\(env.CANISTER_ID).")' | head -n1)"
+test -n "${url:-}" || url="$(network_config | h="${DFX_URL_TYPE^^}_HOST" jq -re '.[env.DFX_NETWORK].config | .[env.h] // .HOST // empty | sub("^(?<p>https?://)";"\(.p)\(env.CANISTER_ID).")' | head -n1 || true)"
+
+# ... The network may be local
+test -n "${url}" || [[ "${DFX_NETWORK:-}" != "local" ]] || {
+    case "$DFX_URL_TYPE" in
+    static) url="http://localhost:8080" ;;
+    api) url="http://${CANISTER_ID}:8080" ;; # Note: The canister ID is NOT provided as a subdomain and no web assets are served.
+    esac
+}
 
 # Last try:  Assume the network is a testnet.
 test -n "$url" || url="https://${CANISTER_ID}.${DFX_NETWORK}.testnet.dfinity.network"

--- a/bin/dfx-canister-url
+++ b/bin/dfx-canister-url
@@ -137,7 +137,14 @@ test -n "${url}" || [[ "${DFX_NETWORK:-}" != "local" ]] || {
 }
 
 # Last try:  Assume the network is a testnet.
-test -n "$url" || url="https://${CANISTER_ID}.${DFX_NETWORK}.testnet.dfinity.network"
+test -n "$url" || {
+  PREFIX="https://"
+  DOMAIN="testnet.dfinity.network"
+  case "$DFX_URL_TYPE" in
+  static) url="${PREFIX}${CANISTER_ID}.${DFX_NETWORK}.${DOMAIN}" ;;
+  api) url="${PREFIX}${DOMAIN}" ;;
+  esac
+}
 
 if [[ "${DFX_OPEN:-}" == "true" ]]; then
   command=xdg-open                                  # Uses Linux default browser

--- a/bin/dfx-canister-url
+++ b/bin/dfx-canister-url
@@ -107,13 +107,26 @@ url="$(jq -r '.canisters[env.DFX_CANISTER].url[env.DFX_NETWORK] // ""' dfx.json)
 
 # Not found?
 # Each network also has a pattern for canister URLs of the form: https://CANISTER_ID.NETWORK_URL
-test -n "${url:-}" || CANISTER_ID="$(dfx canister id --network "$DFX_NETWORK" "$DFX_CANISTER")"
+canister_id() {
+  dfx canister id --network "$DFX_NETWORK" "$DFX_CANISTER"
+}
+inject_canister_id() {
+	read -r root_url
+	test -n "${root_url:-}" || return
+  case "$DFX_URL_TYPE" in
+	  static)
+		  local CANISTER_ID="$(canister_id)"
+		  printf "%s\n" "$root_url" | sed -E "s,^(https?://)?,&${CANISTER_ID}.,g"
+		  ;;
+	  *) printf "%s\n" "$root_url" ;;
+  esac
+}
 
 # .. Maybe this is in production.  Prioritize this so that production builds are not easily affected by local configuration.
 test -n "$url" || {
   if [[ "$DFX_NETWORK" == "ic" ]]; then
     case "$DFX_URL_TYPE" in
-    static) url="https://${CANISTER_ID}.icp0.io" ;;
+	    static) url="https://$(canister_id).icp0.io" ;;
     api) url="https://icp-api.io" ;; # Note: The canister ID is NOT provided as a subdomain and no web assets are served.
     esac
   fi
@@ -126,25 +139,13 @@ network_config() {
   ! test -e dfx.json || jq '.networks // {}' dfx.json
   ! test -e "$GLOBAL_NETWORK_CONFIG_FILE" || cat "$GLOBAL_NETWORK_CONFIG_FILE"
 }
-test -n "${url:-}" || url="$(network_config | h="${DFX_URL_TYPE^^}_HOST" jq -re '.[env.DFX_NETWORK].config | .[env.h] // .HOST // empty | sub("^(?<p>https?://)";"\(.p)\(env.CANISTER_ID).")' | head -n1 || true)"
+test -n "${url:-}" || url="$(network_config | h="${DFX_URL_TYPE^^}_HOST" jq -re '.[env.DFX_NETWORK].config | .[env.h] // .HOST // empty' | inject_canister_id || true)"
 
 # ... The network may be local
-test -n "${url}" || [[ "${DFX_NETWORK:-}" != "local" ]] || {
-  case "$DFX_URL_TYPE" in
-  static) url="http://${CANISTER_ID}:8080" ;; # Note: The canister ID is NOT provided as a subdomain and no web assets are served.
-  api) url="http://localhost:8080" ;;
-  esac
-}
+test -n "${url}" || [[ "${DFX_NETWORK:-}" != "local" ]] || url="$(echo "http://localhost:8080" | inject_canister_id)"
 
 # Last try:  Assume the network is a testnet.
-test -n "$url" || {
-  PREFIX="https://"
-  DOMAIN="testnet.dfinity.network"
-  case "$DFX_URL_TYPE" in
-  static) url="${PREFIX}${CANISTER_ID}.${DFX_NETWORK}.${DOMAIN}" ;;
-  api) url="${PREFIX}${DOMAIN}" ;;
-  esac
-}
+test -n "$url" || url="$(echo "https://${DFX_NETWORK}.testnet.dfinity.network" | inject_canister_id)"
 
 if [[ "${DFX_OPEN:-}" == "true" ]]; then
   command=xdg-open                                  # Uses Linux default browser

--- a/bin/dfx-canister-url
+++ b/bin/dfx-canister-url
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+PATH="$SOURCE_DIR:$PATH"
+. "$SOURCE_DIR/versions.bash"
+
+print_help() {
+  cat <<-EOF
+
+	Prints the URL for a canister frontend.
+	EOF
+}
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/clap.bash"
+# Define options
+clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
+clap.define short=c long=canister desc="The canister name" variable=DFX_CANISTER
+clap.define short=o long=open desc="Open the URL ina  browser" variable=DFX_OPEN nargs=0
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+
+# Historically, the canister name was given as a positional argument.
+test -n "${DFX_CANISTER:-}" || (( $# != 1 )) || DFX_CANISTER="${1:-}"
+test -n "${DFX_CANISTER:-}" || {
+  echo "ERROR: Please specify a canister name or ID"
+  exit 1
+}
+
+export DFX_NETWORK
+export DFX_CANISTER
+
+while ! test -e dfx.json ; do
+  cd .. || {
+    echo "ERROR: dfx.json not found"
+    exit 1
+  }
+done
+
+# Some canisters have custom URLs, such as identity.ic0.app.
+# There is no standard for this.  There should be.  So we will start one:
+# For nns-dapp, dfx.json should include:
+# { "canisters": {
+#      "nns-dapp": {
+#        "url": {
+#          "ic": "https://nns.ic0.app",
+#          "mainnet": "https://nns.ic0.app"
+# } }  } }
+url="$(c="$DFX_CANISTER" n="$DFX_NETWORK" jq -r '.canisters[env.DFX_CANISTER].url[env.DFX_NETWORK] // ""' dfx.json)"
+
+# Not found?
+# Each network also has a pattern for canister URLs of the form: https://CANISTER_ID.NETWORK_URL
+CANISTER_ID="$(dfx canister id "$DFX_CANISTER" 2>/dev/null || echo "$DFX_CANISTER")"
+export CANISTER_ID
+
+# The network URL may be in the local dfx.json or in the common config.
+test -n "${url:-}" || url="$(jq -r '.networks[env.DFX_NETWORK].config.HOST // "" | sub("^(?<p>https?://)";"\(.p)\(env.CANISTER_ID).")' dfx.json )"
+test -n "${url:-}" || url="$(jq -r '        .[env.DFX_NETWORK].config.HOST // "" | sub("^(?<p>https?://)";"\(.p)\(env.CANISTER_ID).")' "$HOME/.config/dfx/networks.json" )"
+
+# Still not found?  Maybe this is in production?
+test -n "$url" || [[ "$DFX_NETWORK" != "ic" ]] || url="https://${CANISTER_ID}.ic0.app"
+
+
+# Last try:  Assume the network is a testnet.
+test -n "$url" || url="https://${CANISTER_ID}.${DFX_NETWORK}.testnet.dfinity.network"
+
+if [[ "${DFX_OPEN:-}" == "true" ]] ; then
+    command=xdg-open                      # Uses Linux default browser
+    command -v "$command" || command=open # Uses mac default browser
+    command -v "$command" || command=firefox
+    command -v "$command" || command=google-chrome
+    command -v "$command" || {
+      printf "ERROR: %s\n" "Unable to detect how to open your browser."
+      exit 1
+    } >&2
+else
+    command="echo"
+fi
+
+"$command" "$url"

--- a/bin/dfx-canister-url
+++ b/bin/dfx-canister-url
@@ -29,6 +29,7 @@ test -n "${DFX_CANISTER:-}" || {
 
 export DFX_NETWORK
 export DFX_CANISTER
+export CANISTER_ID
 
 while ! test -e dfx.json; do
   cd .. || {
@@ -50,15 +51,15 @@ url="$(c="$DFX_CANISTER" n="$DFX_NETWORK" jq -r '.canisters[env.DFX_CANISTER].ur
 
 # Not found?
 # Each network also has a pattern for canister URLs of the form: https://CANISTER_ID.NETWORK_URL
-CANISTER_ID="$(dfx canister id "$DFX_CANISTER" 2>/dev/null || echo "$DFX_CANISTER")"
-export CANISTER_ID
+test -n "${url:-}" || CANISTER_ID="$(dfx canister id --network  "$DFX_NETWORK" "$DFX_CANISTER")"
 
-# The network URL may be in the local dfx.json or in the common config.
+# .. Maybe this is in production.  Prioritize this so that prod builds are not easily affected by local configuration.
+test -n "$url" || [[ "$DFX_NETWORK" != "mainnet" ]] || url="https://${CANISTER_ID}.internetcomputer.org"
+test -n "$url" || [[ "$DFX_NETWORK" != "ic" ]] || url="https://${CANISTER_ID}.internetcomputer.org"
+# ... The network URL may be in the local dfx.json or in the common config.
 test -n "${url:-}" || url="$(jq -r '.networks[env.DFX_NETWORK].config.HOST // "" | sub("^(?<p>https?://)";"\(.p)\(env.CANISTER_ID).")' dfx.json)"
 test -n "${url:-}" || url="$(jq -r '        .[env.DFX_NETWORK].config.HOST // "" | sub("^(?<p>https?://)";"\(.p)\(env.CANISTER_ID).")' "$HOME/.config/dfx/networks.json")"
 
-# Still not found?  Maybe this is in production?
-test -n "$url" || [[ "$DFX_NETWORK" != "ic" ]] || url="https://${CANISTER_ID}.ic0.app"
 
 # Last try:  Assume the network is a testnet.
 test -n "$url" || url="https://${CANISTER_ID}.${DFX_NETWORK}.testnet.dfinity.network"

--- a/bin/dfx-canister-url
+++ b/bin/dfx-canister-url
@@ -70,7 +70,8 @@ source "$(clap.build)"
 # Historically, the canister name was given as a positional argument.
 test -n "${DFX_CANISTER:-}" || (($# != 1)) || DFX_CANISTER="${1:-}"
 test -n "${DFX_CANISTER:-}" || {
-  echo "ERROR: Please specify a canister name or ID"
+  echo "ERROR: Please specify a canister name"
+  : "TODO: Support canister IDs as well."
   exit 1
 }
 

--- a/bin/dfx-canister-url
+++ b/bin/dfx-canister-url
@@ -64,7 +64,7 @@ test -n "$url" || [[ "$DFX_NETWORK" != "ic" ]] || url="https://${CANISTER_ID}.ic
 test -n "$url" || url="https://${CANISTER_ID}.${DFX_NETWORK}.testnet.dfinity.network"
 
 if [[ "${DFX_OPEN:-}" == "true" ]]; then
-  command=xdg-open                      # Uses Linux default browser
+  command=xdg-open                                  # Uses Linux default browser
   command -v "$command" &>/dev/null || command=open # Uses mac default browser
   command -v "$command" &>/dev/null || command=firefox
   command -v "$command" &>/dev/null || command=google-chrome

--- a/bin/dfx-canister-url
+++ b/bin/dfx-canister-url
@@ -21,7 +21,7 @@ clap.define short=o long=open desc="Open the URL ina  browser" variable=DFX_OPEN
 source "$(clap.build)"
 
 # Historically, the canister name was given as a positional argument.
-test -n "${DFX_CANISTER:-}" || (( $# != 1 )) || DFX_CANISTER="${1:-}"
+test -n "${DFX_CANISTER:-}" || (($# != 1)) || DFX_CANISTER="${1:-}"
 test -n "${DFX_CANISTER:-}" || {
   echo "ERROR: Please specify a canister name or ID"
   exit 1
@@ -30,7 +30,7 @@ test -n "${DFX_CANISTER:-}" || {
 export DFX_NETWORK
 export DFX_CANISTER
 
-while ! test -e dfx.json ; do
+while ! test -e dfx.json; do
   cd .. || {
     echo "ERROR: dfx.json not found"
     exit 1
@@ -54,27 +54,26 @@ CANISTER_ID="$(dfx canister id "$DFX_CANISTER" 2>/dev/null || echo "$DFX_CANISTE
 export CANISTER_ID
 
 # The network URL may be in the local dfx.json or in the common config.
-test -n "${url:-}" || url="$(jq -r '.networks[env.DFX_NETWORK].config.HOST // "" | sub("^(?<p>https?://)";"\(.p)\(env.CANISTER_ID).")' dfx.json )"
-test -n "${url:-}" || url="$(jq -r '        .[env.DFX_NETWORK].config.HOST // "" | sub("^(?<p>https?://)";"\(.p)\(env.CANISTER_ID).")' "$HOME/.config/dfx/networks.json" )"
+test -n "${url:-}" || url="$(jq -r '.networks[env.DFX_NETWORK].config.HOST // "" | sub("^(?<p>https?://)";"\(.p)\(env.CANISTER_ID).")' dfx.json)"
+test -n "${url:-}" || url="$(jq -r '        .[env.DFX_NETWORK].config.HOST // "" | sub("^(?<p>https?://)";"\(.p)\(env.CANISTER_ID).")' "$HOME/.config/dfx/networks.json")"
 
 # Still not found?  Maybe this is in production?
 test -n "$url" || [[ "$DFX_NETWORK" != "ic" ]] || url="https://${CANISTER_ID}.ic0.app"
 
-
 # Last try:  Assume the network is a testnet.
 test -n "$url" || url="https://${CANISTER_ID}.${DFX_NETWORK}.testnet.dfinity.network"
 
-if [[ "${DFX_OPEN:-}" == "true" ]] ; then
-    command=xdg-open                      # Uses Linux default browser
-    command -v "$command" || command=open # Uses mac default browser
-    command -v "$command" || command=firefox
-    command -v "$command" || command=google-chrome
-    command -v "$command" || {
-      printf "ERROR: %s\n" "Unable to detect how to open your browser."
-      exit 1
-    } >&2
+if [[ "${DFX_OPEN:-}" == "true" ]]; then
+  command=xdg-open                      # Uses Linux default browser
+  command -v "$command" || command=open # Uses mac default browser
+  command -v "$command" || command=firefox
+  command -v "$command" || command=google-chrome
+  command -v "$command" || {
+    printf "ERROR: %s\n" "Unable to detect how to open your browser."
+    exit 1
+  } >&2
 else
-    command="echo"
+  command="echo"
 fi
 
 "$command" "$url"

--- a/bin/dfx-canister-url
+++ b/bin/dfx-canister-url
@@ -13,7 +13,7 @@ print_help() {
 
 # Source the clap.bash file ---------------------------------------------------
 source "$SOURCE_DIR/clap.bash"
-URL_TYPES=( static api )
+URL_TYPES=(static api)
 # Define options
 clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
 clap.define short=c long=canister desc="The canister name" variable=DFX_CANISTER
@@ -62,31 +62,37 @@ url="$(c="$DFX_CANISTER" n="$DFX_NETWORK" jq -r '.canisters[env.DFX_CANISTER].ur
 
 # Not found?
 # Each network also has a pattern for canister URLs of the form: https://CANISTER_ID.NETWORK_URL
-test -n "${url:-}" || CANISTER_ID="$(dfx canister id --network  "$DFX_NETWORK" "$DFX_CANISTER")"
+test -n "${url:-}" || CANISTER_ID="$(dfx canister id --network "$DFX_NETWORK" "$DFX_CANISTER")"
 
 # .. Maybe this is in production.  Prioritize this so that production builds are not easily affected by local configuration.
 test -n "$url" || {
-	if [[ "$DFX_NETWORK" =~ ^(mainnet|ic)$ ]] ; then
-  case "$DFX_URL_TYPE" in
-  static) url="https://${CANISTER_ID}.icp0.io" ;;
-  api) HOST="https://icp-api.io" ;; # Note: The canister ID is NOT provided as a subdomain and no web assets are served.
-  esac
-	fi
+  if [[ "$DFX_NETWORK" == "ic" ]]; then
+    case "$DFX_URL_TYPE" in
+    static) url="https://${CANISTER_ID}.icp0.io" ;;
+    api) HOST="https://icp-api.io" ;; # Note: The canister ID is NOT provided as a subdomain and no web assets are served.
+    esac
+  fi
 }
 
 # ... The network URL may be in the local dfx.json or in the common config.
 GLOBAL_NETWORK_CONFIG_FILE="$HOME/.config/dfx/networks.json"
 network_config() {
-    ! test -e dfx.json || jq '.networks // {}' dfx.json
-    ! test -e "$GLOBAL_NETWORK_CONFIG_FILE" || cat "$GLOBAL_NETWORK_CONFIG_FILE"
+  ! test -e dfx.json || jq '.networks // {}' dfx.json
+  ! test -e "$GLOBAL_NETWORK_CONFIG_FILE" || cat "$GLOBAL_NETWORK_CONFIG_FILE"
 }
 case "${DFX_URL_TYPE:-}" in
-	static)
-		test -n "${url:-}" || url="$(network_config | jq -re '.[env.DFX_NETWORK].config | .STATIC_HOST // .HOST | first // ""')" ;;
-	api)
-		test -n "${url:-}" || url="$(jq -re '.networks[env.DFX_NETWORK].config.API_HOST // .networks[env.DFX_NETWORK].config.API_HOST // ""' dfx.json)"
-		test -n "${url:-}" || ! test -e "$GLOBAL_NETWORK_CONFIG_FILE" || url="$(jq -re '.[env.DFX_NETWORK].config.API_HOST // .[env.DFX_NETWORK].config.API_HOST' "$GLOBAL_NETWORK_CONFIG_FILE")"
-		;;
+static)
+  test -n "${url:-}" || url="$(network_config | jq -re '.[env.DFX_NETWORK].config | .STATIC_HOST // .HOST | first // ""')"
+  ;;
+api)
+  test -n "${url:-}" || url="$(network_config | jq -re '.[env.DFX_NETWORK].config | .API_HOST // .HOST | first // ""')"
+  ;;
+*)
+  {
+    echo "ERROR: Unsupported url type: '$DFX_URL_TYPE'"
+    exit 1
+  } >&2
+  ;;
 esac
 
 # Last try:  Assume the network is a testnet.

--- a/bin/dfx-canister-url
+++ b/bin/dfx-canister-url
@@ -77,7 +77,7 @@ test -n "$url" || {
 # ... The network URL may be in the local dfx.json or in the common config.
 GLOBAL_NETWORK_CONFIG_FILE="$HOME/.config/dfx/networks.json"
 network_config() {
-	: "Getting the local and global network config..."
+  : "Getting the local and global network config..."
   ! test -e dfx.json || jq '.networks // {}' dfx.json
   ! test -e "$GLOBAL_NETWORK_CONFIG_FILE" || cat "$GLOBAL_NETWORK_CONFIG_FILE"
 }

--- a/bin/dfx-canister-url.test
+++ b/bin/dfx-canister-url.test
@@ -84,7 +84,7 @@ trap cleanup EXIT
 ###############################
 
 print_title() {
-    cat <<-EOF
+  cat <<-EOF
 	#############################################
 	# $1
 	EOF
@@ -102,46 +102,46 @@ print_title() {
   }
 )
 
-  (
-    print_title "Static URL to local canisters should be correct"
-    : "Note: We test this extensively, including deploying and verifying that the URL works, given that we can do so on github CI."
-    : "Make sure the smiley dapp is deployed"
-    dfx-network-stop
-    dfx start --clean --background
-    dfx canister id smiley_dapp_assets &>/dev/null || {
-      npm ci
-      PATH="$PATH:node_modules/.bin" dfx deploy smiley_dapp_assets
-      echo "Deployed smiley_dapp_assets to: $(dfx canister id smiley_dapp_assets)"
-    } || {
-      echo "ERROR IN TEST SETUP: Unable to deploy smiley_dapp_assets"
+(
+  print_title "Static URL to local canisters should be correct"
+  : "Note: We test this extensively, including deploying and verifying that the URL works, given that we can do so on github CI."
+  : "Make sure the smiley dapp is deployed"
+  dfx-network-stop
+  dfx start --clean --background
+  dfx canister id smiley_dapp_assets &>/dev/null || {
+    npm ci
+    PATH="$PATH:node_modules/.bin" dfx deploy smiley_dapp_assets
+    echo "Deployed smiley_dapp_assets to: $(dfx canister id smiley_dapp_assets)"
+  } || {
+    echo "ERROR IN TEST SETUP: Unable to deploy smiley_dapp_assets"
+    exit 1
+  }
+  export CANISTER_ID
+  : "Make sure the URL we expect works"
+  CANISTER_ID="$(dfx canister id smiley_dapp_assets)"
+  EXPECTED_URL="http://${CANISTER_ID}.localhost:8080" # Note: This may change with new versions of dfx or custom config.
+  STRING_FROM_FRONTEND="powderblue"
+  curl --fail --retry 10 "$EXPECTED_URL" | grep -q -- "$STRING_FROM_FRONTEND" || {
+    echo "ERROR IN TEST SETUP: The expected URL should point to the smiley_dapp_assets."
+    echo "  EXPECTED_URL: $EXPECTED_URL"
+    exit 1
+  }
+  : "Compare with the actual URL"
+  export ACTUAL_POSITIONAL_URL ACTUAL_FLAG_URL ACTUAL_POSITIONAL_URL_WITH_EXPLICIT_NETWORK ACTUAL_FLAG_URL_WITH_EXPLICIT_NETWORK
+  ACTUAL_POSITIONAL_URL="$(dfx-canister-url smiley_dapp_assets)"
+  ACTUAL_FLAG_URL="$(dfx-canister-url --canister smiley_dapp_assets)"
+  ACTUAL_POSITIONAL_URL_WITH_EXPLICIT_NETWORK="$(dfx-canister-url --network local smiley_dapp_assets)"
+  ACTUAL_FLAG_URL_WITH_EXPLICIT_NETWORK="$(dfx-canister-url --network local --canister smiley_dapp_assets)"
+  for actual_varname in ACTUAL_POSITIONAL_URL ACTUAL_FLAG_URL ACTUAL_POSITIONAL_URL_WITH_EXPLICIT_NETWORK ACTUAL_FLAG_URL_WITH_EXPLICIT_NETWORK; do
+    [[ "$EXPECTED_URL" == "${!actual_varname}" ]] || {
+      echo "The $actual_varname should be as expected:"
+      echo "EXPECTED:    $EXPECTED_URL"
+      echo "ACTUAL:      ${!actual_varname}"
       exit 1
     }
-    export CANISTER_ID
-    : "Make sure the URL we expect works"
-    CANISTER_ID="$(dfx canister id smiley_dapp_assets)"
-    EXPECTED_URL="http://${CANISTER_ID}.localhost:8080" # Note: This may change with new versions of dfx or custom config.
-    STRING_FROM_FRONTEND="powderblue"
-    curl --fail --retry 10 "$EXPECTED_URL" | grep -q -- "$STRING_FROM_FRONTEND" || {
-      echo "ERROR IN TEST SETUP: The expected URL should point to the smiley_dapp_assets."
-      echo "  EXPECTED_URL: $EXPECTED_URL"
-      exit 1
-    }
-    : "Compare with the actual URL"
-    export ACTUAL_POSITIONAL_URL ACTUAL_FLAG_URL ACTUAL_POSITIONAL_URL_WITH_EXPLICIT_NETWORK ACTUAL_FLAG_URL_WITH_EXPLICIT_NETWORK
-    ACTUAL_POSITIONAL_URL="$(dfx-canister-url smiley_dapp_assets)"
-    ACTUAL_FLAG_URL="$(dfx-canister-url --canister smiley_dapp_assets)"
-    ACTUAL_POSITIONAL_URL_WITH_EXPLICIT_NETWORK="$(dfx-canister-url --network local smiley_dapp_assets)"
-    ACTUAL_FLAG_URL_WITH_EXPLICIT_NETWORK="$(dfx-canister-url --network local --canister smiley_dapp_assets)"
-    for actual_varname in ACTUAL_POSITIONAL_URL ACTUAL_FLAG_URL ACTUAL_POSITIONAL_URL_WITH_EXPLICIT_NETWORK ACTUAL_FLAG_URL_WITH_EXPLICIT_NETWORK; do
-      [[ "$EXPECTED_URL" == "${!actual_varname}" ]] || {
-        echo "The $actual_varname should be as expected:"
-        echo "EXPECTED:    $EXPECTED_URL"
-        echo "ACTUAL:      ${!actual_varname}"
-        exit 1
-      }
-    done
-    git checkout dfx.json
-  )
+  done
+  git checkout dfx.json
+)
 
 (
   print_title "Custom URL should be used if available"

--- a/bin/dfx-canister-url.test
+++ b/bin/dfx-canister-url.test
@@ -19,6 +19,48 @@ source "$(clap.build)"
 
 export DFX_NETWORK
 
+###############################
+#### GLOBAL NETWORK CONFIG ####
+GLOBAL_NETWORK_CONFIG="$HOME/.config/dfx/networks.json"
+save_global_network_config() {
+	if test -e "$GLOBAL_NETWORK_CONFIG" ; then
+  mv "$GLOBAL_NETWORK_CONFIG" "$GLOBAL_NETWORK_CONFIG.hide"
+	fi
+}
+restore_global_network_config() {
+	if test -e "$GLOBAL_NETWORK_CONFIG.hide" ; then
+  mv "$GLOBAL_NETWORK_CONFIG.hide" "$GLOBAL_NETWORK_CONFIG"
+	fi
+}
+save_global_network_config
+trap restore_global_network_config EXIT
+global_mainnet_config() {
+	cat <<-EOF > "$GLOBAL_NETWORK_CONFIG"
+	{
+	    "mainnet": {
+	      "config": {
+		"FETCH_ROOT_KEY": false,
+		"API_HOST": "https://icp-api.io",
+		"STATIC_HOST": "https://icp0.io",
+		"FEATURE_FLAGS": {
+		  "ENABLE_SNS_VOTING": false,
+		  "ENABLE_SNS_AGGREGATOR": true,
+		  "ENABLE_CKBTC": true,
+		  "ENABLE_CKTESTBTC": false
+		}
+	      },
+	      "providers": [
+		"https://icp-api.io/"
+	      ],
+	      "type": "persistent"
+	    }
+	}
+	EOF
+}
+###############################
+
+
+
 true ||
 (
   echo "URL to local canisters should be correct"
@@ -62,21 +104,39 @@ true ||
 (
   echo "Custom URL should be used if available"
   git checkout dfx.json
-  CUSTOM_URL="https://costa.concordia"
+  EXPECTED_URL="https://costa.concordia"
   NETWORKS=( local somewhere )
   for NETWORK in "${NETWORKS[@]}" ; do
-    c="$CUSTOM_URL" n="$NETWORK" jq '.canisters.smiley_dapp_assets.url[env.n] = (env.c)' dfx.json | sponge dfx.json
+    c="$EXPECTED_URL" n="$NETWORK" jq '.canisters.smiley_dapp_assets.url[env.n] = (env.c)' dfx.json | sponge dfx.json
     ACTUAL_URL="$(dfx-canister-url --network "$NETWORK" smiley_dapp_assets)"
-    [[ "${CUSTOM_URL}" == "${ACTUAL_URL:-}" ]] || {
+    [[ "${EXPECTED_URL}" == "${ACTUAL_URL:-}" ]] || {
 	    echo "ERROR: The custom URL for network '${NETWORK}' should be returned."
 	echo "  ACTUAL:   $ACTUAL_URL"
-        echo "  EXPECTED: $CUSTOM_URL"
+        echo "  EXPECTED_URL: $EXPECTED_URL"
       exit 1
     } >&2
   done
 )
 
 # TODO: Test URL to mainnet
+(
+  echo "The mainnet asset URLs should be correct"
+  git checkout dfx.json
+  NETWORKS=( ic mainnet )
+  CANISTER_ID="3r4gx-wqaaa-aaaaq-aaaia-cai" # A real canister ID - it should resolve.
+  EXPECTED_URL="https://${CANISTER_ID}.icp0.io"
+  global_mainnet_config
+  for NETWORK in "${NETWORKS[@]}" ; do
+    c="$CANISTER_ID" n="$NETWORK" jq '.canisters.smiley_dapp_assets.remote.id[env.n] = (env.c)' dfx.json | sponge dfx.json
+    ACTUAL_URL="$(dfx-canister-url --network "$NETWORK" smiley_dapp_assets)"
+    [[ "${EXPECTED_URL}" == "${ACTUAL_URL:-}" ]] || {
+            echo "ERROR: The custom URL for network '${NETWORK}' should be returned."
+        echo "  ACTUAL:   $ACTUAL_URL"
+        echo "  EXPECTED_URL: $EXPECTED_URL"
+      exit 1
+    } >&2
+  done
+)
 
 # TODO: Test URL to static testnets
 

--- a/bin/dfx-canister-url.test
+++ b/bin/dfx-canister-url.test
@@ -88,7 +88,7 @@ trap cleanup EXIT
   EXPECTED_URL="http://localhost:8080"
   ACTUAL_URL="$(dfx-canister-url --canister smiley_dapp_assets --type api)"
       [[ "$EXPECTED_URL" == "${ACTUAL_URL}" ]] || {
-        echo "The $actual_varname should be as expected:"
+        echo "The local canister api URL should be as expected:"
         echo "EXPECTED:    $EXPECTED_URL"
         echo "ACTUAL:      ${ACTUAL_URL}"
         exit 1

--- a/bin/dfx-canister-url.test
+++ b/bin/dfx-canister-url.test
@@ -83,9 +83,23 @@ fi
 trap cleanup EXIT
 ###############################
 
+(
+  echo "API URL to local canisters should be correct"
+  EXPECTED_URL="http://localhost:8080"
+  ACTUAL_URL="$(dfx-canister-url --canister smiley_dapp_assets --type api)"
+      [[ "$EXPECTED_URL" == "${ACTUAL_URL}" ]] || {
+        echo "The $actual_varname should be as expected:"
+        echo "EXPECTED:    $EXPECTED_URL"
+        echo "ACTUAL:      ${ACTUAL_URL}"
+        exit 1
+      }
+)
+
+
 true ||
   (
-    echo "URL to local canisters should be correct"
+    echo "Static URL to local canisters should be correct"
+    : "Note: We test this extensively, including deploying and verifying that the URL works, given that we can do so on github CI."
     : "Make sure the smiley dapp is deployed"
     dfx-network-stop
     dfx start --clean --background
@@ -121,6 +135,7 @@ true ||
     done
     git checkout dfx.json
   )
+
 
 # TODO: Test custom URL
 (

--- a/bin/dfx-canister-url.test
+++ b/bin/dfx-canister-url.test
@@ -22,20 +22,26 @@ export DFX_NETWORK
 ###############################
 #### GLOBAL NETWORK CONFIG ####
 GLOBAL_NETWORK_CONFIG="$HOME/.config/dfx/networks.json"
+GLOBAL_NETWORK_CONFIG_SAVE="$(mktemp "$GLOBAL_NETWORK_CONFIG.XXXXX")"
 save_global_network_config() {
-	if test -e "$GLOBAL_NETWORK_CONFIG" ; then
-  mv "$GLOBAL_NETWORK_CONFIG" "$GLOBAL_NETWORK_CONFIG.hide"
-	fi
+  if test -e "$GLOBAL_NETWORK_CONFIG"; then
+    mv "$GLOBAL_NETWORK_CONFIG" "$GLOBAL_NETWORK_CONFIG_SAVE"
+  fi
 }
 restore_global_network_config() {
-	if test -e "$GLOBAL_NETWORK_CONFIG.hide" ; then
-  mv "$GLOBAL_NETWORK_CONFIG.hide" "$GLOBAL_NETWORK_CONFIG"
-	fi
+  if test -e "$GLOBAL_NETWORK_CONFIG_SAVE"; then
+    mv "$GLOBAL_NETWORK_CONFIG_SAVE" "$GLOBAL_NETWORK_CONFIG"
+  fi
+}
+cleanup() {
+  (("$?" == 0)) || echo "EXIT FAIL" >&2
+  restore_global_network_config
+  git checkout dfx.json
 }
 save_global_network_config
-trap restore_global_network_config EXIT
+trap cleanup EXIT
 global_mainnet_config() {
-	cat <<-EOF > "$GLOBAL_NETWORK_CONFIG"
+  cat <<-EOF >"$GLOBAL_NETWORK_CONFIG"
 	{
 	    "mainnet": {
 	      "config": {
@@ -59,60 +65,58 @@ global_mainnet_config() {
 }
 ###############################
 
-
-
 true ||
-(
-  echo "URL to local canisters should be correct"
-  : "Make sure the smiley dapp is deployed"
-  dfx-network-stop
-  dfx start --clean --background
-  dfx canister id smiley_dapp_assets &>/dev/null || {
-	  npm ci
-	  PATH="$PATH:node_modules/.bin" dfx deploy smiley_dapp_assets
-  } || {
-     echo "ERROR IN TEST SETUP: Unable to deploy smiley_dapp_assets"
-     exit 1
-  }
-  export CANISTER_ID
-  : "Make sure the URL we expect works"
-  CANISTER_ID="$(dfx canister id smiley_dapp_assets)"
-  EXPECTED_URL="http://${CANISTER_ID}.localhost:8080" # Note: This may change with new versions of dfx or custom config.
-  STRING_FROM_FRONTEND="powderblue"
-  curl --fail "$EXPECTED_URL" | grep -q -- "$STRING_FROM_FRONTEND" || {
-     echo "ERROR IN TEST SETUP: The expected URL should point to the smiley_dapp_assets."
-     echo "  EXPECTED_URL: $EXPECTED_URL"
-     exit 1
-  }
-  : "Compare with the actual URL"
-  ACTUAL_POSITIONAL_URL="$(dfx-canister-url smiley_dapp_assets)"
-  ACTUAL_FLAG_URL="$(dfx-canister-url --canister smiley_dapp_assets)"
-  ACTUAL_POSITIONAL_URL_WITH_EXPLICIT_NETWORK="$(dfx-canister-url --network local smiley_dapp_assets)"
-  ACTUAL_FLAG_URL_WITH_EXPLICIT_NETWORK="$(dfx-canister-url --network local --canister smiley_dapp_assets)"
-  for actual_varname in ACTUAL_POSITIONAL_URL ACTUAL_FLAG_URL ACTUAL_POSITIONAL_URL_WITH_EXPLICIT_NETWORK ACTUAL_FLAG_URL_WITH_EXPLICIT_NETWORK ; do
-     [[ "$EXPECTED_URL" == "${!actual_varname}" ]] || {
-       echo "The $actual_varname should be as expected:"
-       echo "EXPECTED:    $EXPECTED_URL"
-       echo "ACTUAL:      ${!actual_varname}"
-       exit 1
-     }
-  done
-  git checkout dfx.json
-)
+  (
+    echo "URL to local canisters should be correct"
+    : "Make sure the smiley dapp is deployed"
+    dfx-network-stop
+    dfx start --clean --background
+    dfx canister id smiley_dapp_assets &>/dev/null || {
+      npm ci
+      PATH="$PATH:node_modules/.bin" dfx deploy smiley_dapp_assets
+    } || {
+      echo "ERROR IN TEST SETUP: Unable to deploy smiley_dapp_assets"
+      exit 1
+    }
+    export CANISTER_ID
+    : "Make sure the URL we expect works"
+    CANISTER_ID="$(dfx canister id smiley_dapp_assets)"
+    EXPECTED_URL="http://${CANISTER_ID}.localhost:8080" # Note: This may change with new versions of dfx or custom config.
+    STRING_FROM_FRONTEND="powderblue"
+    curl --fail "$EXPECTED_URL" | grep -q -- "$STRING_FROM_FRONTEND" || {
+      echo "ERROR IN TEST SETUP: The expected URL should point to the smiley_dapp_assets."
+      echo "  EXPECTED_URL: $EXPECTED_URL"
+      exit 1
+    }
+    : "Compare with the actual URL"
+    ACTUAL_POSITIONAL_URL="$(dfx-canister-url smiley_dapp_assets)"
+    ACTUAL_FLAG_URL="$(dfx-canister-url --canister smiley_dapp_assets)"
+    ACTUAL_POSITIONAL_URL_WITH_EXPLICIT_NETWORK="$(dfx-canister-url --network local smiley_dapp_assets)"
+    ACTUAL_FLAG_URL_WITH_EXPLICIT_NETWORK="$(dfx-canister-url --network local --canister smiley_dapp_assets)"
+    for actual_varname in ACTUAL_POSITIONAL_URL ACTUAL_FLAG_URL ACTUAL_POSITIONAL_URL_WITH_EXPLICIT_NETWORK ACTUAL_FLAG_URL_WITH_EXPLICIT_NETWORK; do
+      [[ "$EXPECTED_URL" == "${!actual_varname}" ]] || {
+        echo "The $actual_varname should be as expected:"
+        echo "EXPECTED:    $EXPECTED_URL"
+        echo "ACTUAL:      ${!actual_varname}"
+        exit 1
+      }
+    done
+    git checkout dfx.json
+  )
 
 # TODO: Test custom URL
 (
   echo "Custom URL should be used if available"
   git checkout dfx.json
   EXPECTED_URL="https://costa.concordia"
-  NETWORKS=( local somewhere )
-  for NETWORK in "${NETWORKS[@]}" ; do
+  NETWORKS=(local somewhere)
+  for NETWORK in "${NETWORKS[@]}"; do
     c="$EXPECTED_URL" n="$NETWORK" jq '.canisters.smiley_dapp_assets.url[env.n] = (env.c)' dfx.json | sponge dfx.json
     ACTUAL_URL="$(dfx-canister-url --network "$NETWORK" smiley_dapp_assets)"
     [[ "${EXPECTED_URL}" == "${ACTUAL_URL:-}" ]] || {
-	    echo "ERROR: The custom URL for network '${NETWORK}' should be returned."
-	echo "  ACTUAL:   $ACTUAL_URL"
-        echo "  EXPECTED_URL: $EXPECTED_URL"
+      echo "ERROR: The custom URL for network '${NETWORK}' should be returned."
+      echo "  ACTUAL:   $ACTUAL_URL"
+      echo "  EXPECTED_URL: $EXPECTED_URL"
       exit 1
     } >&2
   done
@@ -122,17 +126,17 @@ true ||
 (
   echo "The mainnet asset URLs should be correct"
   git checkout dfx.json
-  NETWORKS=( ic mainnet )
+  NETWORKS=(ic mainnet)
   CANISTER_ID="3r4gx-wqaaa-aaaaq-aaaia-cai" # A real canister ID - it should resolve.
   EXPECTED_URL="https://${CANISTER_ID}.icp0.io"
   global_mainnet_config
-  for NETWORK in "${NETWORKS[@]}" ; do
+  for NETWORK in "${NETWORKS[@]}"; do
     c="$CANISTER_ID" n="$NETWORK" jq '.canisters.smiley_dapp_assets.remote.id[env.n] = (env.c)' dfx.json | sponge dfx.json
     ACTUAL_URL="$(dfx-canister-url --network "$NETWORK" smiley_dapp_assets)"
     [[ "${EXPECTED_URL}" == "${ACTUAL_URL:-}" ]] || {
-            echo "ERROR: The custom URL for network '${NETWORK}' should be returned."
-        echo "  ACTUAL:   $ACTUAL_URL"
-        echo "  EXPECTED_URL: $EXPECTED_URL"
+      echo "ERROR: The custom URL for network '${NETWORK}' should be returned."
+      echo "  ACTUAL:   $ACTUAL_URL"
+      echo "  EXPECTED_URL: $EXPECTED_URL"
       exit 1
     } >&2
   done

--- a/bin/dfx-canister-url.test
+++ b/bin/dfx-canister-url.test
@@ -14,6 +14,7 @@ print_help() {
 # Source the clap.bash file ---------------------------------------------------
 source "$SOURCE_DIR/clap.bash"
 # Define options
+clap.define long=setup desc="Populate the global networks file for testing.  DO not test." variable=DFX_SETUP nargs=0
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
@@ -35,11 +36,11 @@ restore_global_network_config() {
 }
 cleanup() {
   (("$?" == 0)) || echo "EXIT FAIL" >&2
+  dfx-network-stop
   restore_global_network_config
   git checkout dfx.json
 }
 save_global_network_config
-trap cleanup EXIT
 global_mainnet_config() {
   cat <<-EOF >"$GLOBAL_NETWORK_CONFIG"
 	{
@@ -63,6 +64,13 @@ global_mainnet_config() {
 	}
 	EOF
 }
+if [[ "${DFX_SETUP:-}" == "true" ]] ; then
+  global_mainnet_config
+  echo "Backed up network config.  To restore:"
+  echo "  mv '$GLOBAL_NETWORK_CONFIG_SAVE' '$GLOBAL_NETWORK_CONFIG'"
+  exit 0
+fi
+#trap cleanup EXIT
 ###############################
 
 true ||
@@ -132,6 +140,10 @@ true ||
   global_mainnet_config
   for NETWORK in "${NETWORKS[@]}"; do
     c="$CANISTER_ID" n="$NETWORK" jq '.canisters.smiley_dapp_assets.remote.id[env.n] = (env.c)' dfx.json | sponge dfx.json
+    [[ "$(dfx canister id --network "$NETWORK" smiley_dapp_assets)" == "$CANISTER_ID" ]] || {
+      echo "ERROR in test setup: canister ID for smiley_dapp_assets on $NETWORK network not set correctly."
+      exit 1
+    }
     ACTUAL_URL="$(dfx-canister-url --network "$NETWORK" smiley_dapp_assets)"
     [[ "${EXPECTED_URL}" == "${ACTUAL_URL:-}" ]] || {
       echo "ERROR: The custom URL for network '${NETWORK}' should be returned."

--- a/bin/dfx-canister-url.test
+++ b/bin/dfx-canister-url.test
@@ -36,7 +36,6 @@ restore_global_network_config() {
 }
 cleanup() {
   (("$?" == 0)) || echo "EXIT FAIL" >&2
-  dfx-network-stop
   restore_global_network_config
   git checkout dfx.json
 }
@@ -104,27 +103,13 @@ print_title() {
 
 (
   print_title "Static URL to local canisters should be correct"
-  : "Note: We test this extensively, including deploying and verifying that the URL works, given that we can do so on github CI."
-  : "Make sure the smiley dapp is deployed"
-  dfx-network-stop
-  dfx start --clean --background
-  dfx canister id smiley_dapp_assets &>/dev/null || {
-    npm ci
-    PATH="$PATH:node_modules/.bin" dfx deploy smiley_dapp_assets
-    echo "Deployed smiley_dapp_assets to: $(dfx canister id smiley_dapp_assets)"
-  } || {
-    echo "ERROR IN TEST SETUP: Unable to deploy smiley_dapp_assets"
-    exit 1
-  }
-  export CANISTER_ID
-  : "Make sure the URL we expect works"
-  CANISTER_ID="$(dfx canister id smiley_dapp_assets)"
+  : Set a canister ID
+  CANISTER_ID="3r4gx-wqaaa-aaaaq-aaaia-cai" # A real canister ID - it should resolve.
   EXPECTED_URL="http://${CANISTER_ID}.localhost:8080" # Note: This may change with new versions of dfx or custom config.
-  STRING_FROM_FRONTEND="powderblue"
-  curl --fail --retry 10 "$EXPECTED_URL" | grep -q -- "$STRING_FROM_FRONTEND" || {
-    echo "ERROR IN TEST SETUP: The expected URL should point to the smiley_dapp_assets."
-    echo "  EXPECTED_URL: $EXPECTED_URL"
-    exit 1
+  git checkout dfx.json
+  c="$CANISTER_ID" jq '.canisters.smiley_dapp_assets.remote.id.local = (env.c)' dfx.json | sponge dfx.json
+  [[ "$(dfx canister id smiley_dapp_assets)" == "$CANISTER_ID" ]] || {
+    echo "ERROR in test setup:  Failed to set canister ID."
   }
   : "Compare with the actual URL"
   export ACTUAL_POSITIONAL_URL ACTUAL_FLAG_URL ACTUAL_POSITIONAL_URL_WITH_EXPLICIT_NETWORK ACTUAL_FLAG_URL_WITH_EXPLICIT_NETWORK

--- a/bin/dfx-canister-url.test
+++ b/bin/dfx-canister-url.test
@@ -144,7 +144,7 @@ true ||
 (
   echo "The mainnet asset URLs should be correct"
   git checkout dfx.json
-  NETWORKS=(ic mainnet)
+  NETWORKS=(ic)
   CANISTER_ID="3r4gx-wqaaa-aaaaq-aaaia-cai" # A real canister ID - it should resolve.
   EXPECTED_URL="https://${CANISTER_ID}.icp0.io"
   global_mainnet_config
@@ -167,7 +167,7 @@ true ||
 (
   echo "The mainnet API URLs should be correct"
   git checkout dfx.json
-  NETWORKS=(ic mainnet)
+  NETWORKS=(ic)
   CANISTER_ID="3r4gx-wqaaa-aaaaq-aaaia-cai" # A real canister ID - it should resolve.
   EXPECTED_URL="https://icp-api.io"
   global_mainnet_config

--- a/bin/dfx-canister-url.test
+++ b/bin/dfx-canister-url.test
@@ -187,7 +187,6 @@ true ||
   done
 )
 
-
 # TODO: Test URL to static testnets
 
 echo "$(basename "$0") PASSED"

--- a/bin/dfx-canister-url.test
+++ b/bin/dfx-canister-url.test
@@ -80,7 +80,7 @@ if [[ "${DFX_SETUP:-}" == "true" ]]; then
   echo "  mv '$GLOBAL_NETWORK_CONFIG_SAVE' '$GLOBAL_NETWORK_CONFIG'"
   exit 0
 fi
-#trap cleanup EXIT
+trap cleanup EXIT
 ###############################
 
 true ||

--- a/bin/dfx-canister-url.test
+++ b/bin/dfx-canister-url.test
@@ -120,6 +120,7 @@ true ||
       exit 1
     }
     : "Compare with the actual URL"
+    export ACTUAL_POSITIONAL_URL ACTUAL_FLAG_URL ACTUAL_POSITIONAL_URL_WITH_EXPLICIT_NETWORK ACTUAL_FLAG_URL_WITH_EXPLICIT_NETWORK
     ACTUAL_POSITIONAL_URL="$(dfx-canister-url smiley_dapp_assets)"
     ACTUAL_FLAG_URL="$(dfx-canister-url --canister smiley_dapp_assets)"
     ACTUAL_POSITIONAL_URL_WITH_EXPLICIT_NETWORK="$(dfx-canister-url --network local smiley_dapp_assets)"

--- a/bin/dfx-canister-url.test
+++ b/bin/dfx-canister-url.test
@@ -64,7 +64,7 @@ global_mainnet_config() {
 	}
 	EOF
 }
-if [[ "${DFX_SETUP:-}" == "true" ]] ; then
+if [[ "${DFX_SETUP:-}" == "true" ]]; then
   global_mainnet_config
   echo "Backed up network config.  To restore:"
   echo "  mv '$GLOBAL_NETWORK_CONFIG_SAVE' '$GLOBAL_NETWORK_CONFIG'"

--- a/bin/dfx-canister-url.test
+++ b/bin/dfx-canister-url.test
@@ -14,7 +14,7 @@ print_help() {
 # Source the clap.bash file ---------------------------------------------------
 source "$SOURCE_DIR/clap.bash"
 # Define options
-clap.define long=setup desc="Populate the global networks file for testing.  DO not test." variable=DFX_SETUP nargs=0
+clap.define long=setup desc="Populate the global networks file for testing.  Do not test." variable=DFX_SETUP nargs=0
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
@@ -60,7 +60,17 @@ global_mainnet_config() {
 		"https://icp-api.io/"
 	      ],
 	      "type": "persistent"
+	    },
+	    "smallXX": {
+	      "config": {
+		"FETCH_ROOT_KEY": true
+	      },
+	      "providers": [
+		"https://1.2.3.4:999"
+	      ],
+	      "type": "persistent"
 	    }
+
 	}
 	EOF
 }
@@ -153,6 +163,30 @@ true ||
     } >&2
   done
 )
+
+(
+  echo "The mainnet API URLs should be correct"
+  git checkout dfx.json
+  NETWORKS=(ic mainnet)
+  CANISTER_ID="3r4gx-wqaaa-aaaaq-aaaia-cai" # A real canister ID - it should resolve.
+  EXPECTED_URL="https://icp-api.io"
+  global_mainnet_config
+  for NETWORK in "${NETWORKS[@]}"; do
+    c="$CANISTER_ID" n="$NETWORK" jq '.canisters.smiley_dapp_assets.remote.id[env.n] = (env.c)' dfx.json | sponge dfx.json
+    [[ "$(dfx canister id --network "$NETWORK" smiley_dapp_assets)" == "$CANISTER_ID" ]] || {
+      echo "ERROR in test setup: canister ID for smiley_dapp_assets on $NETWORK network not set correctly."
+      exit 1
+    }
+    ACTUAL_URL="$(dfx-canister-url --network "$NETWORK" --type api smiley_dapp_assets)"
+    [[ "${EXPECTED_URL}" == "${ACTUAL_URL:-}" ]] || {
+      echo "ERROR: The custom URL for network '${NETWORK}' should be returned."
+      echo "  ACTUAL:   $ACTUAL_URL"
+      echo "  EXPECTED_URL: $EXPECTED_URL"
+      exit 1
+    } >&2
+  done
+)
+
 
 # TODO: Test URL to static testnets
 

--- a/bin/dfx-canister-url.test
+++ b/bin/dfx-canister-url.test
@@ -87,14 +87,13 @@ trap cleanup EXIT
   echo "API URL to local canisters should be correct"
   EXPECTED_URL="http://localhost:8080"
   ACTUAL_URL="$(dfx-canister-url --canister smiley_dapp_assets --type api)"
-      [[ "$EXPECTED_URL" == "${ACTUAL_URL}" ]] || {
-        echo "The local canister api URL should be as expected:"
-        echo "EXPECTED:    $EXPECTED_URL"
-        echo "ACTUAL:      ${ACTUAL_URL}"
-        exit 1
-      }
+  [[ "$EXPECTED_URL" == "${ACTUAL_URL}" ]] || {
+    echo "The local canister api URL should be as expected:"
+    echo "EXPECTED:    $EXPECTED_URL"
+    echo "ACTUAL:      ${ACTUAL_URL}"
+    exit 1
+  }
 )
-
 
 true ||
   (
@@ -135,7 +134,6 @@ true ||
     done
     git checkout dfx.json
   )
-
 
 # TODO: Test custom URL
 (

--- a/bin/dfx-canister-url.test
+++ b/bin/dfx-canister-url.test
@@ -83,8 +83,15 @@ fi
 trap cleanup EXIT
 ###############################
 
+print_title() {
+    cat <<-EOF
+	#############################################
+	# $1
+	EOF
+}
+
 (
-  echo "API URL to local canisters should be correct"
+  print_title "API URL to local canisters should be correct"
   EXPECTED_URL="http://localhost:8080"
   ACTUAL_URL="$(dfx-canister-url --canister smiley_dapp_assets --type api)"
   [[ "$EXPECTED_URL" == "${ACTUAL_URL}" ]] || {
@@ -95,9 +102,8 @@ trap cleanup EXIT
   }
 )
 
-true ||
   (
-    echo "Static URL to local canisters should be correct"
+    print_title "Static URL to local canisters should be correct"
     : "Note: We test this extensively, including deploying and verifying that the URL works, given that we can do so on github CI."
     : "Make sure the smiley dapp is deployed"
     dfx-network-stop
@@ -105,6 +111,7 @@ true ||
     dfx canister id smiley_dapp_assets &>/dev/null || {
       npm ci
       PATH="$PATH:node_modules/.bin" dfx deploy smiley_dapp_assets
+      echo "Deployed smiley_dapp_assets to: $(dfx canister id smiley_dapp_assets)"
     } || {
       echo "ERROR IN TEST SETUP: Unable to deploy smiley_dapp_assets"
       exit 1
@@ -114,7 +121,7 @@ true ||
     CANISTER_ID="$(dfx canister id smiley_dapp_assets)"
     EXPECTED_URL="http://${CANISTER_ID}.localhost:8080" # Note: This may change with new versions of dfx or custom config.
     STRING_FROM_FRONTEND="powderblue"
-    curl --fail "$EXPECTED_URL" | grep -q -- "$STRING_FROM_FRONTEND" || {
+    curl --fail --retry 10 "$EXPECTED_URL" | grep -q -- "$STRING_FROM_FRONTEND" || {
       echo "ERROR IN TEST SETUP: The expected URL should point to the smiley_dapp_assets."
       echo "  EXPECTED_URL: $EXPECTED_URL"
       exit 1
@@ -136,9 +143,8 @@ true ||
     git checkout dfx.json
   )
 
-# TODO: Test custom URL
 (
-  echo "Custom URL should be used if available"
+  print_title "Custom URL should be used if available"
   git checkout dfx.json
   EXPECTED_URL="https://costa.concordia"
   NETWORKS=(local somewhere)
@@ -154,9 +160,8 @@ true ||
   done
 )
 
-# TODO: Test URL to mainnet
 (
-  echo "The mainnet asset URLs should be correct"
+  print_title "The mainnet asset URLs should be correct"
   git checkout dfx.json
   NETWORKS=(ic)
   CANISTER_ID="3r4gx-wqaaa-aaaaq-aaaia-cai" # A real canister ID - it should resolve.
@@ -179,7 +184,7 @@ true ||
 )
 
 (
-  echo "The mainnet API URLs should be correct"
+  print_title "The mainnet API URLs should be correct"
   git checkout dfx.json
   NETWORKS=(ic)
   CANISTER_ID="3r4gx-wqaaa-aaaaq-aaaia-cai" # A real canister ID - it should resolve.

--- a/bin/dfx-canister-url.test
+++ b/bin/dfx-canister-url.test
@@ -104,7 +104,7 @@ print_title() {
 (
   print_title "Static URL to local canisters should be correct"
   : Set a canister ID
-  CANISTER_ID="3r4gx-wqaaa-aaaaq-aaaia-cai" # A real canister ID - it should resolve.
+  CANISTER_ID="3r4gx-wqaaa-aaaaq-aaaia-cai"           # A real canister ID - it should resolve.
   EXPECTED_URL="http://${CANISTER_ID}.localhost:8080" # Note: This may change with new versions of dfx or custom config.
   git checkout dfx.json
   c="$CANISTER_ID" jq '.canisters.smiley_dapp_assets.remote.id.local = (env.c)' dfx.json | sponge dfx.json

--- a/bin/dfx-canister-url.test
+++ b/bin/dfx-canister-url.test
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+PATH="$SOURCE_DIR:$PATH"
+. "$SOURCE_DIR/versions.bash"
+
+print_help() {
+  cat <<-EOF
+
+	Some motivational speech.
+	EOF
+}
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/clap.bash"
+# Define options
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+
+export DFX_NETWORK
+
+true ||
+(
+  echo "URL to local canisters should be correct"
+  : "Make sure the smiley dapp is deployed"
+  dfx-network-stop
+  dfx start --clean --background
+  dfx canister id smiley_dapp_assets &>/dev/null || {
+	  npm ci
+	  PATH="$PATH:node_modules/.bin" dfx deploy smiley_dapp_assets
+  } || {
+     echo "ERROR IN TEST SETUP: Unable to deploy smiley_dapp_assets"
+     exit 1
+  }
+  export CANISTER_ID
+  : "Make sure the URL we expect works"
+  CANISTER_ID="$(dfx canister id smiley_dapp_assets)"
+  EXPECTED_URL="http://${CANISTER_ID}.localhost:8080" # Note: This may change with new versions of dfx or custom config.
+  STRING_FROM_FRONTEND="powderblue"
+  curl --fail "$EXPECTED_URL" | grep -q -- "$STRING_FROM_FRONTEND" || {
+     echo "ERROR IN TEST SETUP: The expected URL should point to the smiley_dapp_assets."
+     echo "  EXPECTED_URL: $EXPECTED_URL"
+     exit 1
+  }
+  : "Compare with the actual URL"
+  ACTUAL_POSITIONAL_URL="$(dfx-canister-url smiley_dapp_assets)"
+  ACTUAL_FLAG_URL="$(dfx-canister-url --canister smiley_dapp_assets)"
+  ACTUAL_POSITIONAL_URL_WITH_EXPLICIT_NETWORK="$(dfx-canister-url --network local smiley_dapp_assets)"
+  ACTUAL_FLAG_URL_WITH_EXPLICIT_NETWORK="$(dfx-canister-url --network local --canister smiley_dapp_assets)"
+  for actual_varname in ACTUAL_POSITIONAL_URL ACTUAL_FLAG_URL ACTUAL_POSITIONAL_URL_WITH_EXPLICIT_NETWORK ACTUAL_FLAG_URL_WITH_EXPLICIT_NETWORK ; do
+     [[ "$EXPECTED_URL" == "${!actual_varname}" ]] || {
+       echo "The $actual_varname should be as expected:"
+       echo "EXPECTED:    $EXPECTED_URL"
+       echo "ACTUAL:      ${!actual_varname}"
+       exit 1
+     }
+  done
+  git checkout dfx.json
+)
+
+# TODO: Test custom URL
+(
+  echo "Custom URL should be used if available"
+  git checkout dfx.json
+  CUSTOM_URL="https://costa.concordia"
+  NETWORKS=( local somewhere )
+  for NETWORK in "${NETWORKS[@]}" ; do
+    c="$CUSTOM_URL" n="$NETWORK" jq '.canisters.smiley_dapp_assets.url[env.n] = (env.c)' dfx.json | sponge dfx.json
+    ACTUAL_URL="$(dfx-canister-url --network "$NETWORK" smiley_dapp_assets)"
+    [[ "${CUSTOM_URL}" == "${ACTUAL_URL:-}" ]] || {
+	    echo "ERROR: The custom URL for network '${NETWORK}' should be returned."
+	echo "  ACTUAL:   $ACTUAL_URL"
+        echo "  EXPECTED: $CUSTOM_URL"
+      exit 1
+    } >&2
+  done
+)
+
+# TODO: Test URL to mainnet
+
+# TODO: Test URL to static testnets
+
+echo "$(basename "$0") PASSED"

--- a/dfx.json
+++ b/dfx.json
@@ -11,13 +11,7 @@
         "src/smiley_dapp_assets/assets",
         "dist/smiley_dapp_assets/"
       ],
-      "type": "assets",
-      "remote": {
-        "id": {
-          "ic": "3r4gx-wqaaa-aaaaq-aaaia-cai",
-          "mainnet": "3r4gx-wqaaa-aaaaq-aaaia-cai"
-        }
-      }
+      "type": "assets"
     },
     "smiley_dapp": {
       "main": "src/smiley_dapp/main.mo",

--- a/dfx.json
+++ b/dfx.json
@@ -11,7 +11,13 @@
         "src/smiley_dapp_assets/assets",
         "dist/smiley_dapp_assets/"
       ],
-      "type": "assets"
+      "type": "assets",
+      "remote": {
+        "id": {
+          "ic": "3r4gx-wqaaa-aaaaq-aaaia-cai",
+          "mainnet": "3r4gx-wqaaa-aaaaq-aaaia-cai"
+        }
+      }
     },
     "smiley_dapp": {
       "main": "src/smiley_dapp/main.mo",


### PR DESCRIPTION
# Motivation
Finding out which URL to use is a little bit non-trivial.  Here is a description, used in the README:
```
$ dfx-canister-url --help

Prints the URL for a canister.

There are two types of URL:
- "api" that serve only API calls, not web pages.
- "static" that serve everything including web pages and API calls.

For the internet computer mainnet, the URLs of a canister are:
- api: https://icp-api.io  (regardless of canister ID)
- static: https://${CANISTER_ID}.icp0.io
Other domains _may_ work but are not supported by this tool.

Canisters may have custom static asset domains for a better user experience.
Such domains may be specified in dfx.json.  For example:
{ "canisters": {
    "my_canister": {
      "url": { "ic": "https://my-custom-url.com" },
      ...
    }
  }
}

If you are running a local replica with dfx start, the default canister URLs are:
- api:     http://localhost:8080
- static:  http://${CANISTER_ID}.localhost:8080
The port may be changed in your network configuration.

If you are running a replica on a remote test server, your setup is likely customized.
We recommend that you populate your global network config at ~/.config/dfx/networks.json
and provide the entries API_HOST and STATIC_HOST.  E.g.:
{
  "mytestnet": {
    "config": {
      "FETCH_ROOT_KEY": true,
      "API_HOST": "https://api.my_test_server",
      "STATIC_HOST": "https://my_test_server"
    },
    "providers": [
      "http://[2a00:fb01:111:111:111:1111:111:111]:8080"
    ],
    "type": "persistent"
  }
}
dfx-canister-url will then generate the following URLs:
- api:     https://api.my_test_server
- static:  https://${CANISTER_ID}.my_test_server
You can still override the URLs with custom entries in dfx.json.

usage: dfx-canister-url [OPTIONS]

OPTIONS:
        
	-n --network:                The dfx network to use [default:local]
	-c --canister:               The canister name
	-t --type:                   The canister type (options: static [default:static]
	-o --open:                   Open the URL in a browser

        -? --help  :  usage

        --verbose  :  show debug info
```

# Changes
- Add a command that provides the URL for a canister.  This actually replaces a much older command of the same name that was deleted recently as it was by now useless.

# Tests
- In progress.  There is a test command.