### PR TITLE
Fix: Newline after wait

### DIFF
--- a/bin/dfx-network-stop
+++ b/bin/dfx-network-stop
@@ -16,10 +16,11 @@ if [[ "$DFX_NETWORK" == "local" ]]; then
   pgrep --full '\<dfx\>.*\<start\>' | xargs --no-run-if-empty kill || true
   echo "Waiting for replica to stop..."
   for ((i = 100; i > 0; i--)); do
-    printf '\r % 4d' "$i"
     pgrep replica || break
+    printf '\r % 4d' "$i"
     sleep 1
   done
+  echo
 
   : "Make sure that it is dead."
   sleep 1

--- a/bin/dfx-network-stop
+++ b/bin/dfx-network-stop
@@ -20,7 +20,7 @@ if [[ "$DFX_NETWORK" == "local" ]]; then
     printf '\r % 4d' "$i"
     sleep 1
   done
-  echo
+  printf "\n...stopped.\n"
 
   : "Make sure that it is dead."
   sleep 1


### PR DESCRIPTION
# Motivation
Fix a niggling error with dfx-network-stop:
- It prints an unterminated line, so the next output is mixed in with this output
```
Stopping icx-proxy...
Stopped.
   99Running dfx start for version 0.13.1
     ^ Start of next output
```
This is caused by the wait loop that repeatedly writes the same line; it should be followed by something that ends in a new line.
# Changes
- Print after the wait loop.