### PR TITLE
snsdemo: Add confirmation_text to open SNS swap

### DIFF
--- a/bin/dfx-snapshot-stock-make
+++ b/bin/dfx-snapshot-stock-make
@@ -14,11 +14,13 @@ print_help() {
 source "$SOURCE_DIR/clap.bash"
 # Define options
 clap.define short=s long=snapshot desc="The file to save to" variable=DFX_SNAPSHOT_FILE default="stock-snsdemo-snapshot.tar.xz"
+clap.define short=c long=ic_commit desc="The IC commit to use" variable=DFX_IC_COMMIT default="$(dfx-software ic current)"
+clap.define short=x long=ic_dir desc="Directory containing the ic source code; needed for deployments to static testnets" variable=IC_REPO_DIR default="$HOME/dfn/ic"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
 : Create stock state
-dfx-stock-deploy
+dfx-stock-deploy --ic_commit "$DFX_IC_COMMIT" --ic_dir "$IC_REPO_DIR"
 
 : "Wait for a checkpoint"
 dfx-network-wait-for-checkpoint --timeout 600

--- a/bin/dfx-sns-config-random
+++ b/bin/dfx-sns-config-random
@@ -1,5 +1,20 @@
 #!/usr/bin/env bash
 set -euo pipefail
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+
+print_help() {
+  cat <<-EOF
+
+	Creates an sns.yml to configure an SNS swap.
+	EOF
+}
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/clap.bash"
+# Define options
+clap.define long=confirmation_text desc="A text that needs to be confirmed by the swap participants" variable=CONFIRMATION_TEXT default=""
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
 
 consonant() {
   openssl rand -base64 100 | tr -dc BCDFGHJKLMNPQRSTVWXZ | head -c 1
@@ -21,6 +36,15 @@ PRINCIPAL="$(dfx identity get-principal)"
 # For original cotrollers, use:
 # dfx canister info smiley_dapp --network "$DFX_NETWORK" | perl -e 'while($_ = <>){ if (s/^Controllers: *//){s/ +/, /g;print $_} }'
 
-sed "s/TOKEN_NAME/$TOKEN_NAME/g;s/TOKEN_SYMBOL/$TOKEN_SYMBOL/g;s/PRINCIPAL/$PRINCIPAL/g" "$(dirname "$(realpath "$0")")"/sns_init.yml >sns.yml
+SNS_INIT_PATH="$(dirname "$(realpath "$0")")/sns_init.yml"
+SED_COMMANDS="s/TOKEN_NAME/$TOKEN_NAME/g;
+              s/TOKEN_SYMBOL/$TOKEN_SYMBOL/g;
+              s/PRINCIPAL/$PRINCIPAL/g"
+
+if [ "${CONFIRMATION_TEXT:-}" ]; then
+  SED_COMMANDS="$SED_COMMANDS;s/# confirmation_text: \"CONFIRMATION_TEXT\"/confirmation_text: \"${CONFIRMATION_TEXT}\"/"
+fi
+
+sed "$SED_COMMANDS" "$SNS_INIT_PATH" >sns.yml
 
 echo "Created an SNS: $TOKEN_SYMBOL"

--- a/bin/dfx-sns-config-random
+++ b/bin/dfx-sns-config-random
@@ -33,7 +33,7 @@ TOKEN_SYMBOL="$(
 )"
 TOKEN_NAME="${USER}s awesome $TOKEN_SYMBOL"
 PRINCIPAL="$(dfx identity get-principal)"
-# For original cotrollers, use:
+# For original controllers, use:
 # dfx canister info smiley_dapp --network "$DFX_NETWORK" | perl -e 'while($_ = <>){ if (s/^Controllers: *//){s/ +/, /g;print $_} }'
 
 SNS_INIT_PATH="$(dirname "$(realpath "$0")")/sns_init.yml"
@@ -42,6 +42,10 @@ SED_COMMANDS="s/TOKEN_NAME/$TOKEN_NAME/g;
               s/PRINCIPAL/$PRINCIPAL/g"
 
 if [ "${CONFIRMATION_TEXT:-}" ]; then
+  # Adds the confirmation_text by replacing the entire commented out line
+  # # confirmation_text: "CONFIRMATION_TEXT"
+  # with
+  # confirmation_text: "${CONFIRMATION_TEXT}"
   SED_COMMANDS="$SED_COMMANDS;s/# confirmation_text: \"CONFIRMATION_TEXT\"/confirmation_text: \"${CONFIRMATION_TEXT}\"/"
 fi
 

--- a/bin/dfx-sns-demo-mksns
+++ b/bin/dfx-sns-demo-mksns
@@ -9,6 +9,7 @@ export PATH="$PATH:$HOME/.local/bin"
 source "$SOURCE_DIR/clap.bash"
 # Define options
 clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
+clap.define long=confirmation_text desc="A text that needs to be confirmed by the participants" variable=CONFIRMATION_TEXT default=""
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 set -x
@@ -16,7 +17,7 @@ cd "$(dirname "$(realpath "$0")")/.."
 
 ./bin/dfx-sns-whitelist-me --network "$DFX_NETWORK"
 
-./bin/dfx-sns-config-random --network "$DFX_NETWORK"
+./bin/dfx-sns-config-random --confirmation_text "${CONFIRMATION_TEXT:-}"
 dfx ledger top-up --amount 2.0 --network "$DFX_NETWORK" "$(dfx identity get-wallet --network "$DFX_NETWORK")"
 ./bin/dfx-sns-deploy --network "$DFX_NETWORK"
 

--- a/bin/dfx-sns-demo-mksns-parallel
+++ b/bin/dfx-sns-demo-mksns-parallel
@@ -73,7 +73,7 @@ create_all_sns() {
 
       ./bin/dfx-sns-whitelist-me --network "$DFX_NETWORK" --proposer "${DFX_PROPOSER:-${DEMO_USER}}"
 
-      ./bin/dfx-sns-config-random --network "$DFX_NETWORK"
+      ./bin/dfx-sns-config-random
       dfx ledger top-up --amount 4.0 --network "$DFX_NETWORK" "$(dfx identity get-wallet --network "$DFX_NETWORK")"
       dfx wallet balance
       ./bin/dfx-sns-deploy --network "$DFX_NETWORK"

--- a/bin/dfx-stock-deploy
+++ b/bin/dfx-stock-deploy
@@ -31,7 +31,7 @@ cd "$(dirname "$(realpath "$0")")/.."
 dfx-sns-demo --network "$DFX_NETWORK" --ic_commit "$DFX_IC_COMMIT" --ic_dir "$IC_REPO_DIR" --nd_dir "$ND_REPO_DIR"
 
 : Add 1 open SNS project.
-dfx-sns-demo-mksns --network "$DFX_NETWORK"
+dfx-sns-demo-mksns --network "$DFX_NETWORK" --confirmation_text "I confirm the confirmation text"
 
 : Add 10 more finalized SNS projects.
 dfx-sns-demo-mksns-parallel --network "$DFX_NETWORK" --num_sns 10 --majority snsdemo8

--- a/bin/sns_init.yml
+++ b/bin/sns_init.yml
@@ -176,6 +176,10 @@ initial_voting_period_seconds: 345600
 wait_for_quiet_deadline_increase_seconds: 86400
 #
 #
+# An optional text that if present needs to be confirmed by any participants.
+# confirmation_text: "CONFIRMATION_TEXT"
+#
+#
 # SNS INITIAL TOKEN DISTRIBUTION
 #
 # This field sets the initial token distribution. Initially, there is only support for


### PR DESCRIPTION
# Motivation

SNS swaps support a new field `confirmation_text` which is something participants need to agree to.
We want to be able to test the field in nns-dapp.

`quill` does not yet support passing `--confirmation_text` so we can use the field only for projects that we leave open and don't participate in from snsdemo.

Until we update our pinned IC_COMMIT, the new field is only taken into account when using `--ic_commit latest`.

# Changes

1. Add commented out `confirmation_text` field to `bin/sns_init.yml`.
2. Support `--confirmation_text` in `bin/dfx-sns-config-random` to use the `confirmation_text` field when generating `sns.yml` from `bin/sns_init.yml`.
3. Stop passing `--network` to `bin/dfx-sns-config-random`. The script does not support this flag and once it uses `clap` it will fail on unsupported flags.
4. Support `--confirmation_text` in `bin/dfx-sns-demo-mksns` by passing it on to `bin/dfx-sns-config-random`.
5. In `bin/dfx-snapshot-stock-make` pass `--confirmation_text` to `bin/dfx-sns-demo-mksns`, only for the SNS swap that will remain open.
6. Support `--ic_commit` and `--ic_dir` in `bin/dfx-snapshot-stock-make` to be able to create a snapshot with the latest canisters.

# Tested

I created a new stock snapshot with
```
./bin/dfx-snapshot-stock-make -s ~/snapshots/confirmation_text-2023-05-19.tar.xz --ic_commit latest -x ../../ic
```
and ran it with sns_aggregator and nns-dapp to verify that it includes the confirmation text.

I also created a snapshot without `--ic_commit latest` and verified that it works but does not include the confirmation text.