### PR TITLE
Fix dfx-network-stop for Mac

### DIFF
--- a/bin/dfx-network-stop
+++ b/bin/dfx-network-stop
@@ -12,8 +12,10 @@ source "$(clap.build)"
 export DFX_NETWORK
 
 if [[ "$DFX_NETWORK" == "local" ]]; then
+  dfx stop || true
   : "Send the equivalent of ctrl-c"
-  pgrep --full '\<dfx\>.*\<start\>' | xargs --no-run-if-empty kill || true
+  # This regex doesn't work on Mac but `dfx stop` above should work just fine.
+  pgrep -f '\<dfx\>.*\<start\>' | xargs -n 1 kill || true
   echo "Waiting for replica to stop..."
   for ((i = 100; i > 0; i--)); do
     printf '\r % 4d' "$i"


### PR DESCRIPTION
# Motivation

On Mac:
* The flag `--full` doesn't exist for `pgrep`
* The flag `--no-run-if-empty` doesn't exist for xargs
* The `\<` word boundary regex doesn't work

# Changes

1. Add back `dfx stop` to `bin/dfx-network-stop`
2. Use `pgrep -f` instead of `pgrep --full` and `xargs -n 1` instead of `xargs --no-run-if-empty` such that even though it still doesn't help on Mac (because of the regex), it would cause errors.

# Tests

Tested manually on Mac