### PR TITLE
GIX-1561 snsdemo: Bump IC commit

### DIFF
--- a/bin/dfx-ckbtc-import
+++ b/bin/dfx-ckbtc-import
@@ -67,16 +67,12 @@ ckbtc_import() {
     local remote_name="$1"
     local local_name="$2"
     local local_path="$(c="$local_name" jq -re '.canisters[env.c].candid' dfx.json)"
-    if test -e "$local_path"; then
-      echo "Skipping $local_path as it already exists"
-    else
-      local url="https://raw.githubusercontent.com/dfinity/ic/$DFX_IC_COMMIT/${remote_name}"
-      echo "Getting  $local_path from $url..."
-      curl -sSLf --retry 5 "$url" -o "$local_path"
-    fi
+    local url="https://raw.githubusercontent.com/dfinity/ic/$DFX_IC_COMMIT/${remote_name}"
+    echo "Getting  $local_path from $url..."
+    curl -sSLf --retry 5 "$url" -o "$local_path"
   }
   get_did rs/bitcoin/ckbtc/minter/ckbtc_minter.did "${LOCAL_PREFIX}minter"
-  get_did rs/rosetta-api/icrc1/ledger/icrc1.did "${LOCAL_PREFIX}ledger"
+  get_did rs/rosetta-api/icrc1/ledger/ledger.did "${LOCAL_PREFIX}ledger"
   get_did rs/rosetta-api/icrc1/index/index.did "${LOCAL_PREFIX}index"
 
   : "Ckbtc canister import complete."

--- a/bin/versions.bash
+++ b/bin/versions.bash
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2034 # VAriables are expected to be unused in this file
 SNS_AGGREGATOR_RELEASE=proposal-115273-agg
-DFX_IC_COMMIT=89129b8212791d7e05cab62ff08eece2888a86e0
+# Commit from 2023-05-17
+DFX_IC_COMMIT=5a285c40c505b103cb4d205f33e1d846eb9ed74b
 INTERNET_IDENTITY_RELEASE=release-2023-04-12
 NNS_DAPP_RELEASE=proposal-121690


### PR DESCRIPTION
# Motiviation

We need to create an SNS with `confirmation_text` and `restricted_countries`, which were added after the currently pinned IC commit.

# Changes

1. Change the IC commit to one after https://github.com/dfinity/ic/commit/9b0e2417043ea16e5bd7c9e12e7178a85e0d76fa which added the possibility to add these fields to the `sns.yml` file.
2. Change  `rs/rosetta-api/icrc1/ledger/icrc1.did` to `rs/rosetta-api/icrc1/ledger/ledger.did` in `bin/dfx-ckbtc-import` because the former no longer exists at the new commit.
3. Do not skip downloading `.did` files if they are already present, in order to guarantee that we get the version from the commit we requested.

# Tests

Created a snapshot manually on M1 Mac and on GitHub CI.