### PR TITLE
snsdemo: Document snapshot customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A snapshot is an archive (`.tar.xz`) containing local replica state.
 
 A stock snapshot can be created with
 ```
-./bin/dfx-snapshot-stock-make`
+./bin/dfx-snapshot-stock-make
 ```
 Snapshots can be shared between Linux machines but Macs can only use snapshots
 created on the same machine (it seems).
@@ -24,17 +24,17 @@ Default pinned versions of the used canisters are defined in
 `bin/versions.bash`. If you want the latest versions on the canisters from the
 IC repo, you can run
 ```
-./bin/dfx-snapshot-stock-make` --ic_commit latest --ic_dir $YOUR_IC_REPO_PATH
+./bin/dfx-snapshot-stock-make --ic_commit latest --ic_dir $YOUR_IC_REPO_PATH
 ```
 The IC repo directory is needed to find the latest usable commit. You can also
 specify a specific commit instead of `latest` and then you don't need to specify
 `--ic_dir`.
 
 If you want to customize what is included in the snapshot, you can modify
-`bin/dfx-stock-deploy.
+`bin/dfx-stock-deploy`.
 
 The SNSes that are being deployed are configure with `sns_init.yml` as well as
-the parameters passed to `ic_admin` from `bin/dfx-sns-sale-propose`.
+the parameters passed to `ic-admin` from `bin/dfx-sns-sale-propose`.
 
 ### CI
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,28 @@ A snapshot is an archive (`.tar.xz`) containing local replica state.
 
 ### Manual use
 
-A stock snapshot can be created with `./bin/dfx-snapshot-stock-make`. Snapshots
-can be shared between Linux machines but Macs can only use snapshots created on
-the same machine (it seems).
+A stock snapshot can be created with
+```
+./bin/dfx-snapshot-stock-make`
+```
+Snapshots can be shared between Linux machines but Macs can only use snapshots
+created on the same machine (it seems).
+
+Default pinned versions of the used canisters are defined in
+`bin/versions.bash`. If you want the latest versions on the canisters from the
+IC repo, you can run
+```
+./bin/dfx-snapshot-stock-make` --ic_commit latest --ic_dir $YOUR_IC_REPO_PATH
+```
+The IC repo directory is needed to find the latest usable commit. You can also
+specify a specific commit instead of `latest` and then you don't need to specify
+`--ic_dir`.
+
+If you want to customize what is included in the snapshot, you can modify
+`bin/dfx-stock-deploy.
+
+The SNSes that are being deployed are configure with `sns_init.yml` as well as
+the parameters passed to `ic_admin` from `bin/dfx-sns-sale-propose`.
 
 ### CI
 


### PR DESCRIPTION
# Motivation

It can be useful to make snapshots that diverge from the stock snapshot for specific tasks.

# Changes

Expand the section in the `README.md` about manual snapshot creation.