### PR TITLE
snsdemo: Put the open swap last

### DIFF
--- a/bin/dfx-stock-deploy
+++ b/bin/dfx-stock-deploy
@@ -30,11 +30,11 @@ cd "$(dirname "$(realpath "$0")")/.."
 : Set up SNS state and create one finalized SNS
 dfx-sns-demo --network "$DFX_NETWORK" --ic_commit "$DFX_IC_COMMIT" --ic_dir "$IC_REPO_DIR" --nd_dir "$ND_REPO_DIR"
 
-: Add 1 open SNS project.
-dfx-sns-demo-mksns --network "$DFX_NETWORK" --confirmation_text "I confirm the confirmation text"
-
 : Add 10 more finalized SNS projects.
 dfx-sns-demo-mksns-parallel --network "$DFX_NETWORK" --num_sns 10 --majority snsdemo8
+
+: Add 1 open SNS project.
+dfx-sns-demo-mksns --network "$DFX_NETWORK" --confirmation_text "I confirm the confirmation text"
 
 : Set up ckbtc canisters
 dfx-ckbtc-import --prefix ckbtc_


### PR DESCRIPTION
# Motivation

nns-dapp loads only the first page from the sns_aggregator.
It used to load only the last page and we want to change it back to loading the last page.
Eventually we should use pagination but we are not there yet.

# Changes

Create the open swap after creating the other 11 SNSes.