### PR TITLE
snsdemo: Bump IC commit and sns_aggregator release

### DIFF
--- a/bin/versions.bash
+++ b/bin/versions.bash
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2034 # VAriables are expected to be unused in this file
-SNS_AGGREGATOR_RELEASE=proposal-115273-agg
-# Commit from 2023-05-17
-DFX_IC_COMMIT=5a285c40c505b103cb4d205f33e1d846eb9ed74b
+# shellcheck disable=SC2034 # Variables are expected to be unused in this file
+# Release from 2023-05-30 which includes geo restriction fields
+SNS_AGGREGATOR_RELEASE=proposal-122625-agg
+# Commit from 2023-05-17 which includes simulate_manage_neuron
+DFX_IC_COMMIT=b9fc66eafca530e997313aa68aaac31d41e6a875
 INTERNET_IDENTITY_RELEASE=release-2023-04-12
 NNS_DAPP_RELEASE=proposal-121690
 DIDC_VERSION=2022-11-17


### PR DESCRIPTION
# Motivation

Facilitate testing locally with newer features.

# Changes

1. Bump sns_aggregator release to include geo restriction fields.
2. Bump IC commit to include simulate_manage_neuron in the governance canister.