### PR TITLE
Remove shellcheck exception

### DIFF
--- a/bin/dfx-canister-url
+++ b/bin/dfx-canister-url
@@ -108,7 +108,8 @@ inject_canister_id() {
   test -n "${root_url:-}" || return
   case "$DFX_URL_TYPE" in
   static)
-    local CANISTER_ID="$(canister_id)"
+    local CANISTER_ID
+    CANISTER_ID="$(canister_id)"
     printf "%s\n" "$root_url" | sed -E "s,^(https?://)?,&${CANISTER_ID}.,g"
     ;;
   *) printf "%s\n" "$root_url" ;;

--- a/bin/dfx-ckbtc-import
+++ b/bin/dfx-ckbtc-import
@@ -45,13 +45,14 @@ ckbtc_import() {
   : Get the wasms
   mkdir -p "$WASM_DIR"
   get_wasm() {
-    local remote_name="$1"
-    local local_name="$2"
-    local local_path="$(c="$local_name" jq -re '.canisters[env.c].wasm' dfx.json)"
+    local remote_name local_name local_path url
+    remote_name="$1"
+    local_name="$2"
+    local_path="$(c="$local_name" jq -re '.canisters[env.c].wasm' dfx.json)"
     if test -e "$local_path"; then
       echo "Skipping $local_path as it already exists"
     else
-      local url="https://download.dfinity.systems/ic/$DFX_IC_COMMIT/canisters/${remote_name}.gz"
+      url="https://download.dfinity.systems/ic/$DFX_IC_COMMIT/canisters/${remote_name}.gz"
       echo "Getting  $local_path from $url..."
       curl -sSL "$url" -o "${local_path}.gz"
       gunzip "${local_path}.gz"
@@ -64,10 +65,11 @@ ckbtc_import() {
   : Get the candid files
   mkdir -p "$CANDID_DIR"
   get_did() {
-    local remote_name="$1"
-    local local_name="$2"
-    local local_path="$(c="$local_name" jq -re '.canisters[env.c].candid' dfx.json)"
-    local url="https://raw.githubusercontent.com/dfinity/ic/$DFX_IC_COMMIT/${remote_name}"
+    local remote_name local_name local_path url
+    remote_name="$1"
+    local_name="$2"
+    local_path="$(c="$local_name" jq -re '.canisters[env.c].candid' dfx.json)"
+    url="https://raw.githubusercontent.com/dfinity/ic/$DFX_IC_COMMIT/${remote_name}"
     echo "Getting  $local_path from $url..."
     curl -sSLf --retry 5 "$url" -o "$local_path"
   }

--- a/bin/dfx-neuron-create
+++ b/bin/dfx-neuron-create
@@ -22,7 +22,8 @@ test -e "$PEM" || {
 NEURONS_DIR="$HOME/.config/dfx/identity/$DFX_IDENTITY/neurons"
 mkdir -p "$NEURONS_DIR"
 NEURONS_FILE="$NEURONS_DIR/$DFX_NETWORK"
-export IC_URL="$("$SOURCE_DIR/dfx-network-url" --network "$DFX_NETWORK")"
+IC_URL="$("$SOURCE_DIR/dfx-network-url" --network "$DFX_NETWORK")"
+export IC_URL
 # Note: Quill send puts a pile of junk on stdout and has no option to put just the response(s) somewhere safe such as a file.
 
 set quill neuron-stake --insecure-local-dev-mode --pem-file "$PEM" --amount "$ICP" --name 1

--- a/bin/dfx-sns-sale-propose
+++ b/bin/dfx-sns-sale-propose
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
-export PATH="$SOURCE_DIR:$PATH"
+PATH="$SOURCE_DIR:$PATH"
+export PATH
 
 # Source the clap.bash file ---------------------------------------------------
 source "$SOURCE_DIR/clap.bash"
@@ -12,9 +13,10 @@ clap.define short=N long=neuron desc="The dfx network to use" variable=DFX_NEURO
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
-export DFX_NEURON_ID="${DFX_NEURON_ID:-$(dfx-neuron-id --identity "$DFX_IDENTITY" --network "$DFX_NETWORK")}"
-export DFX_IDENTITY_PEM="$(dfx-identity-pem --identity "$DFX_IDENTITY")"
-export DFX_NNS_URL="$(dfx-network-provider --network "$DFX_NETWORK")"
+DFX_NEURON_ID="${DFX_NEURON_ID:-$(dfx-neuron-id --identity "$DFX_IDENTITY" --network "$DFX_NETWORK")}"
+DFX_IDENTITY_PEM="$(dfx-identity-pem --identity "$DFX_IDENTITY")"
+DFX_NNS_URL="$(dfx-network-provider --network "$DFX_NETWORK")"
+export DFX_NEURON_ID DFX_IDENTITY_PEM DFX_NNS_URL
 
 # The due date of the sale must be greater than 1 day at the time of NNS proposal execution
 SWAP_DUE_TIMESTAMP="$(perl -e 'print time() + 90 * 24 * 3600')"

--- a/bin/dfx-sns-whitelist-me
+++ b/bin/dfx-sns-whitelist-me
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
-export PATH="$SOURCE_DIR:$PATH:$(dfx cache show)"
+PATH="$SOURCE_DIR:$PATH:$(dfx cache show)"
+export PATH
 
 # Source the clap.bash file ---------------------------------------------------
 source "$SOURCE_DIR/clap.bash"
@@ -13,9 +14,10 @@ clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETW
 source "$(clap.build)"
 
 DFX_PROPOSER="${DFX_PROPOSER:-$DFX_IDENTITY}"
-export DFX_NEURON_ID="$(dfx-neuron-id --identity "$DFX_PROPOSER" --network "$DFX_NETWORK")"
-export DFX_PROPOSER_PEM="$HOME/.config/dfx/identity/$DFX_PROPOSER/identity.pem"
-export NNS_URL="$(dfx-network-provider --network "$DFX_NETWORK")"
+DFX_NEURON_ID="$(dfx-neuron-id --identity "$DFX_PROPOSER" --network "$DFX_NETWORK")"
+DFX_PROPOSER_PEM="$HOME/.config/dfx/identity/$DFX_PROPOSER/identity.pem"
+export NNS_URL DFX_PROPOSER_PEM DFX_NEURON_ID
+NNS_URL="$(dfx-network-provider --network "$DFX_NETWORK")"
 command -v "ic-admin"
 set ic-admin \
   --secret-key-pem "$DFX_PROPOSER_PEM" \

--- a/scripts/lint-sh
+++ b/scripts/lint-sh
@@ -6,4 +6,4 @@ list_files() {
   git ls-files | while read -r line; do if [[ "$line" = *.sh ]] || file "$line" | grep -qw Bourne; then echo "$line"; fi; done
 }
 
-list_files | xargs shellcheck -e SC1090 -e SC2119 -e SC1091 -e SC2121 -e SC2155 -e SC2094 -e SC2015
+list_files | xargs shellcheck -e SC1090 -e SC2119 -e SC1091 -e SC2121 -e SC2094 -e SC2015


### PR DESCRIPTION
# Motivation
By default shellcheck encourages separating variable assignment from scoping rules such as `export` or `local`.  To date this rule has been ignored in this repo but maybe shouldn't be.

# Changes
- Enable shellcheck `SC2155`
- Update the code to match