### PR TITLE
Fewer lint exceptions

### DIFF
--- a/bin/dfx-canister-url
+++ b/bin/dfx-canister-url
@@ -2,7 +2,6 @@
 set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
-. "$SOURCE_DIR/versions.bash"
 
 print_help() {
   cat <<-"EOF"

--- a/bin/dfx-ii-create-dummy-anchor
+++ b/bin/dfx-ii-create-dummy-anchor
@@ -54,8 +54,9 @@ add_device() {
   DEVICE_PUB_KEY_BLOB="$1"
   DEVICE_KEY_TYPE="$2"
   DEVICE_PURPOSE="$3"
-  set dfx canister call internet_identity add "(${ANCHOR}, record { alias = \"\"; protection = variant { unprotected }; pubkey = blob \"${DEVICE_PUB_KEY_BLOB}\"; key_type = variant { ${DEVICE_KEY_TYPE} }; purpose = variant { ${DEVICE_PURPOSE} }; })" --candid "$II_DID_FILE" --network "$DFX_NETWORK"
-  "$@" >/dev/null
+  local command
+  command=( dfx canister call internet_identity add "(${ANCHOR}, record { alias = \"\"; protection = variant { unprotected }; pubkey = blob \"${DEVICE_PUB_KEY_BLOB}\"; key_type = variant { ${DEVICE_KEY_TYPE} }; purpose = variant { ${DEVICE_PURPOSE} }; })" --candid "$II_DID_FILE" --network "$DFX_NETWORK" )
+  "${command[@]}" >/dev/null
 }
 
 echo "Adding backup device for anchor $ANCHOR."

--- a/bin/dfx-ii-create-dummy-anchor
+++ b/bin/dfx-ii-create-dummy-anchor
@@ -55,7 +55,7 @@ add_device() {
   DEVICE_KEY_TYPE="$2"
   DEVICE_PURPOSE="$3"
   local command
-  command=( dfx canister call internet_identity add "(${ANCHOR}, record { alias = \"\"; protection = variant { unprotected }; pubkey = blob \"${DEVICE_PUB_KEY_BLOB}\"; key_type = variant { ${DEVICE_KEY_TYPE} }; purpose = variant { ${DEVICE_PURPOSE} }; })" --candid "$II_DID_FILE" --network "$DFX_NETWORK" )
+  command=(dfx canister call internet_identity add "(${ANCHOR}, record { alias = \"\"; protection = variant { unprotected }; pubkey = blob \"${DEVICE_PUB_KEY_BLOB}\"; key_type = variant { ${DEVICE_KEY_TYPE} }; purpose = variant { ${DEVICE_PURPOSE} }; })" --candid "$II_DID_FILE" --network "$DFX_NETWORK")
   "${command[@]}" >/dev/null
 }
 

--- a/bin/dfx-network-wait-for-checkpoint
+++ b/bin/dfx-network-wait-for-checkpoint
@@ -50,5 +50,7 @@ done
 printf '\n' # \n == newline == advance the paper in the typewriter.  Finishes the countdown.
 
 echo "Checkpoint change (if any):"
-diff <(echo "${checkpoints_now:-}") <(echo "${checkpoints_later:-}") && echo "No change" || true
+if diff <(echo "${checkpoints_now:-}") <(echo "${checkpoints_later:-}"); then
+  echo "No change"
+fi
 sleep 5 # Make sure the checkpoint is fully populated.  It _may_ be atomic, so the directory is created only when it is fully populated; I don't know.

--- a/bin/dfx-neuron-create
+++ b/bin/dfx-neuron-create
@@ -26,7 +26,7 @@ IC_URL="$("$SOURCE_DIR/dfx-network-url" --network "$DFX_NETWORK")"
 export IC_URL
 # Note: Quill send puts a pile of junk on stdout and has no option to put just the response(s) somewhere safe such as a file.
 
-command=( quill neuron-stake --insecure-local-dev-mode --pem-file "$PEM" --amount "$ICP" --name 1)
+command=(quill neuron-stake --insecure-local-dev-mode --pem-file "$PEM" --amount "$ICP" --name 1)
 MESSAGE="$("${command[@]}")"
 test -n "${MESSAGE:-}" || {
   echo "ERROR: Created an empty message."

--- a/bin/dfx-neuron-create
+++ b/bin/dfx-neuron-create
@@ -26,23 +26,23 @@ IC_URL="$("$SOURCE_DIR/dfx-network-url" --network "$DFX_NETWORK")"
 export IC_URL
 # Note: Quill send puts a pile of junk on stdout and has no option to put just the response(s) somewhere safe such as a file.
 
-set quill neuron-stake --insecure-local-dev-mode --pem-file "$PEM" --amount "$ICP" --name 1
-MESSAGE="$("${@}")"
+command=( quill neuron-stake --insecure-local-dev-mode --pem-file "$PEM" --amount "$ICP" --name 1)
+MESSAGE="$("${command[@]}")"
 test -n "${MESSAGE:-}" || {
   echo "ERROR: Created an empty message."
   command -v quill
-  echo "${@}"
+  echo "${command[*]}"
   exit 1
 } >&2
-set quill send --yes --insecure-local-dev-mode -
-RESPONSE="$(echo "$MESSAGE" | "${@}")"
+command=(quill send --yes --insecure-local-dev-mode -)
+RESPONSE="$(echo "$MESSAGE" | "${command[@]}")"
 test -n "${RESPONSE:-}" || {
   echo "ERROR: Received an empty response."
   echo message:
   echo "$MESSAGE"
   echo
   echo command -v quill
-  echo "${@}"
+  echo "${command[*]}"
   exit 1
 } >&2
 NEURON_TEXT="$(echo "$RESPONSE" | perl -e 'while($_ = <>){if (s/NeuronId = record \{ id = ([0-9_]+) : nat64 \}/\1/){ print $_ }}')"

--- a/bin/dfx-neuron-prolong
+++ b/bin/dfx-neuron-prolong
@@ -16,7 +16,7 @@ PEM="$HOME/.config/dfx/identity/$DFX_IDENTITY/identity.pem"
 NEURON_ID="$("$SOURCE_DIR/dfx-neuron-id" --network "$DFX_NETWORK" --identity "$DFX_IDENTITY")"
 NETWORK_URL="$("$SOURCE_DIR/dfx-network-url" --network "$DFX_NETWORK")"
 
-set quill neuron-manage --insecure-local-dev-mode --pem-file "$PEM" --additional-dissolve-delay-seconds "$DISSOLVE_DELAY" "$NEURON_ID"
-echo "${@}"
-"${@}" | tee -a log |
+command=( quill neuron-manage --insecure-local-dev-mode --pem-file "$PEM" --additional-dissolve-delay-seconds "$DISSOLVE_DELAY" "$NEURON_ID")
+echo "${command[*]}"
+"${command[@]}" | tee -a log |
   IC_URL="$NETWORK_URL" quill send --yes --insecure-local-dev-mode - | tee -a log

--- a/bin/dfx-neuron-prolong
+++ b/bin/dfx-neuron-prolong
@@ -16,7 +16,7 @@ PEM="$HOME/.config/dfx/identity/$DFX_IDENTITY/identity.pem"
 NEURON_ID="$("$SOURCE_DIR/dfx-neuron-id" --network "$DFX_NETWORK" --identity "$DFX_IDENTITY")"
 NETWORK_URL="$("$SOURCE_DIR/dfx-network-url" --network "$DFX_NETWORK")"
 
-command=( quill neuron-manage --insecure-local-dev-mode --pem-file "$PEM" --additional-dissolve-delay-seconds "$DISSOLVE_DELAY" "$NEURON_ID")
+command=(quill neuron-manage --insecure-local-dev-mode --pem-file "$PEM" --additional-dissolve-delay-seconds "$DISSOLVE_DELAY" "$NEURON_ID")
 echo "${command[*]}"
 "${command[@]}" | tee -a log |
   IC_URL="$NETWORK_URL" quill send --yes --insecure-local-dev-mode - | tee -a log

--- a/bin/dfx-sns-quill
+++ b/bin/dfx-sns-quill
@@ -27,9 +27,9 @@ dfx-sns-quill-canister-ids --network "$DFX_NETWORK" >"$SNS_QUILL_CANISTER_IDS_FI
 PEM_PATH="$(dfx-identity-pem --identity "$DFX_IDENTITY")"
 
 # Call sns-quill
-set quill sns --canister-ids-file "$SNS_QUILL_CANISTER_IDS_FILE" --pem-file "$PEM_PATH" "${@}"
-echo "${@}"
-MESSAGE="$("${@}")"
+command=(quill sns --canister-ids-file "$SNS_QUILL_CANISTER_IDS_FILE" --pem-file "$PEM_PATH" "${@}")
+echo "${command[*]}"
+MESSAGE="$("${command[@]}")"
 
 # Tidy up.
 rm "$SNS_QUILL_CANISTER_IDS_FILE"

--- a/scripts/lint-sh
+++ b/scripts/lint-sh
@@ -6,4 +6,4 @@ list_files() {
   git ls-files | while read -r line; do if [[ "$line" = *.sh ]] || file "$line" | grep -qw Bourne; then echo "$line"; fi; done
 }
 
-list_files | xargs shellcheck -e SC1090 -e SC2119 -e SC1091 -e SC2121 -e SC2094
+list_files | xargs shellcheck -e SC1090 -e SC2119 -e SC1091 -e SC2121

--- a/scripts/lint-sh
+++ b/scripts/lint-sh
@@ -6,4 +6,4 @@ list_files() {
   git ls-files | while read -r line; do if [[ "$line" = *.sh ]] || file "$line" | grep -qw Bourne; then echo "$line"; fi; done
 }
 
-list_files | xargs shellcheck -e SC1090 -e SC2119 -e SC1091 -e SC2121
+list_files | xargs shellcheck -e SC1090 -e SC2119 -e SC1091

--- a/scripts/lint-sh
+++ b/scripts/lint-sh
@@ -6,4 +6,4 @@ list_files() {
   git ls-files | while read -r line; do if [[ "$line" = *.sh ]] || file "$line" | grep -qw Bourne; then echo "$line"; fi; done
 }
 
-list_files | xargs shellcheck -e SC1090 -e SC2119 -e SC1091 -e SC2121 -e SC2094 -e SC2015
+list_files | xargs shellcheck -e SC1090 -e SC2119 -e SC1091 -e SC2121 -e SC2094


### PR DESCRIPTION
# Motivation
daily cleanup:  When importing snsdemo commands to nns-dapp I sometimes hit the linter in CI.  These are due to insignificant issues, but this still causes friction.  So today's 15 minute tidy goes to reducing the number of shellcheck exceptions in this repo.

# Changes
- Remove 3 linter rules and make the corresponding changes to the code.
- Remove one unused line, that gets unneeded version info.

# Tests
- Existing tests should suffice