### PR TITLE
Update link used to find latest IC commit

### DIFF
--- a/bin/dfx-software-ic-latest
+++ b/bin/dfx-software-ic-latest
@@ -25,7 +25,7 @@ function disk_image_exists() {
 
     # Mac buids can lag or be missing
     curl -fL --output /dev/null --silent --head --fail \
-      "https://download.dfinity.systems/ic/${GIT_REVISION}/binaries/x86_64-darwin/ic-admin.gz" || exit 1
+      "https://download.dfinity.systems/ic/${GIT_REVISION}/openssl-static-binaries/x86_64-darwin/ic-admin.gz" || exit 1
     curl -fL --output /dev/null --silent --head --fail \
       "https://download.dfinity.systems/ic/${GIT_REVISION}/binaries/x86_64-linux/ic-admin.gz" || exit 1
     # Syncing to the public repo may be slow


### PR DESCRIPTION
# Motivation
The link used to install ic-admin was updated in nns-dapp.  Checking whether the link needs to be updated here as well showed that the install link is already the same as in nns-dapp, but the link used to check the latest IC commit is an old one.

# Changes
- Update the link used to check whether an IC commit release includes ic-admin.

# Tests
The link is already used when installing.