### PR TITLE
Bump macos to v12

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -12,7 +12,7 @@ jobs:
   #    strategy:
   #      fail-fast: false
   #      matrix:
-  #        os: [ macos-11, ubuntu-22.04 ]
+  #        os: [ macos-12, ubuntu-22.04 ]
   #    steps:
   #      - name: Checkout
   #        uses: actions/checkout@v3
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-11, ubuntu-22.04]
+        os: [macos-12, ubuntu-22.04]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -32,7 +32,7 @@ jobs:
           echo "$HOME/.local/bin" >> $GITHUB_PATH
           echo "$PWD/bin" >> $GITHUB_PATH
       - name: Unbork mac
-        if: matrix.os == 'macos-11'
+        if: matrix.os == 'macos-12'
         run: |
           brew install bash
           echo "/usr/local/bin" >> $GITHUB_PATH
@@ -47,11 +47,11 @@ jobs:
           ./bin/dfx-sns-sale-buy
           ./bin/dfx-sns-sale-finalize
       - name: Create lots of SNS
-        if: matrix.os != 'macos-11'
+        if: matrix.os != 'macos-12'
         run: |
           ./bin/dfx-sns-demo-mksns-parallel -s 10 -m snsdemo8
       - name: Save state
-        if: matrix.os != 'macos-11'
+        if: matrix.os != 'macos-12'
         run: |
           # Stop the replica to let it persist all its state before we save the state.
           dfx stop
@@ -67,7 +67,7 @@ jobs:
           echo "Saving state"
           bin/dfx-snapshot-save --verbose --snapshot state.tar.xz
       - name: Upload state
-        if: matrix.os != 'macos-11'
+        if: matrix.os != 'macos-12'
         uses: actions/upload-artifact@v3
         with:
           name: snsdemo
@@ -79,7 +79,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-11, ubuntu-22.04]
+        os: [macos-12, ubuntu-22.04]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -88,7 +88,7 @@ jobs:
           echo "$HOME/.local/bin" >> $GITHUB_PATH
           echo "$PWD/bin" >> $GITHUB_PATH
       - name: Unbork mac
-        if: matrix.os == 'macos-11'
+        if: matrix.os == 'macos-12'
         run: |
           brew install bash
           echo "/usr/local/bin" >> $GITHUB_PATH
@@ -111,6 +111,6 @@ jobs:
           ./bin/dfx-sns-sale-buy
           ./bin/dfx-sns-sale-finalize
       - name: Create lots of SNS
-        if: matrix.os != 'macos-11'
+        if: matrix.os != 'macos-12'
         run: |
           ./bin/dfx-sns-demo-mksns-parallel -s 10 -m snsdemo8

--- a/dfx.json
+++ b/dfx.json
@@ -24,6 +24,6 @@
       "packtool": ""
     }
   },
-  "dfx": "0.13.1",
+  "dfx": "0.14.1-beta.1",
   "version": 1
 }

--- a/dfx.json
+++ b/dfx.json
@@ -24,6 +24,6 @@
       "packtool": ""
     }
   },
-  "dfx": "0.14.1-beta.1",
+  "dfx": "0.13.1",
   "version": 1
 }


### PR DESCRIPTION
# Motivation
The current macos teleases available on GitHub are v11, v12 and v13.  We currently test snsdemo on v11.  The desire to update is also prompted by the fact that v11 no longer works with some tools, such as the latest release of ic-wasm.

Note: we can update to v12 or v13.  Either would work fine, as far as I know.

# Changes
- Update the macos version we test against from v11 to v12.

# Tests
See CI