### PR TITLE
snsdemo: Wait for aggregator

### DIFF
--- a/bin/dfx-snapshot-stock-make
+++ b/bin/dfx-snapshot-stock-make
@@ -22,6 +22,9 @@ source "$(clap.build)"
 : Create stock state
 dfx-stock-deploy --ic_commit "$DFX_IC_COMMIT" --ic_dir "$IC_REPO_DIR"
 
+: "Wait for aggregator to get all SNSs"
+dfx-sns-aggregator-wait --num_sns 12
+
 : "Wait for a checkpoint"
 dfx-network-wait-for-checkpoint --timeout 600
 

--- a/bin/dfx-sns-aggregator-wait
+++ b/bin/dfx-sns-aggregator-wait
@@ -82,10 +82,15 @@ wait_for_sns_count() {
   : Wait for aggregator to get all SNSs
   for ((try = 300; try > 0; try--)); do
     num_sns="$(get_sns_count)"
-    (("$num_sns" < "$EXPECTED_NUM_SNS")) || break
+    if (("$num_sns" == "$EXPECTED_NUM_SNS")); then
+      return
+    fi
     printf "\r #SNS: % 4d   Tries remaining: %4d" "$num_sns" "$try"
     sleep 2
   done
+  echo
+  echo "Failed to get $EXPECTED_NUM_SNS SNSs"
+  exit 1
 }
 
 save_aggregator_config

--- a/bin/dfx-sns-aggregator-wait
+++ b/bin/dfx-sns-aggregator-wait
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+PATH="$SOURCE_DIR:$PATH"
+
+print_help() {
+  cat <<-EOF
+
+	Waits for a given number of SNSs to be available in the sns_aggregator.
+	EOF
+}
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/clap.bash"
+# Define options
+clap.define short=n long=num_sns desc="The number of SNSs to wait for" variable=EXPECTED_NUM_SNS default="1"
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+
+: Make sure the candid is available and of the right version.
+DID_FILE="$(jq -r .canisters.sns_aggregator.candid dfx.json)"
+dfx canister metadata sns_aggregator candid:service >"$DID_FILE"
+
+# Sadly, the output of `dfx canister call sns_aggregator get_canister_config`
+# which has format:
+# ```
+# (
+#   record {
+#     update_interval_ms = 120_000 : nat64;
+#     fast_interval_ms = 10_000 : nat64;
+#   },
+# )
+# ```
+# can not be used as input to `dfx canister call sns_aggregator reconfigure`
+# which should have format (note the `opt`):
+# ```
+# (
+#   opt record {
+#     update_interval_ms = 120000;
+#     fast_interval_ms = 10000;
+#   },
+# )
+# ```
+# So we convert to JSON and back to Candid.
+
+save_aggregator_config() {
+  SAVED_CONFIG="$(dfx canister call sns_aggregator get_canister_config | idl2json)"
+}
+
+set_aggregator_config() {
+  config="$1"
+  fast_interval_ms="$(jq -r .fast_interval_ms <<<"$config")"
+  update_interval_ms="$(jq -r .update_interval_ms <<<"$config")"
+  dfx canister call sns_aggregator reconfigure "(opt record { update_interval_ms = $update_interval_ms; fast_interval_ms = $fast_interval_ms; })"
+}
+
+restore_aggregator_config() {
+  echo
+  echo "Restoring aggregator config"
+  set_aggregator_config "$SAVED_CONFIG"
+}
+
+speed_up_aggregator() {
+  echo "Speeding up aggregator"
+  set_aggregator_config '{"fast_interval_ms": 100, "update_interval_ms": 100}'
+}
+
+get_sns_count() {
+  for ((page = 0; page < required_page_count; page++)); do
+    {
+      aggregator_url="http://$(dfx canister id sns_aggregator).localhost:8080/v1/sns/list/page/$page/slow.json"
+      curl -fsS "$aggregator_url" | jq length
+    } 2>/dev/null || true
+  done | awk '{i+=$1}END{print i}'
+}
+
+wait_for_sns_count() {
+  echo "Waiting for $EXPECTED_NUM_SNS SNSs"
+  page_size=10
+  required_page_count=$(((EXPECTED_NUM_SNS + page_size - 1) / page_size))
+
+  : Wait for aggregator to get all SNSs
+  for ((try = 300; try > 0; try--)); do
+    num_sns="$(get_sns_count)"
+    (("$num_sns" < "$EXPECTED_NUM_SNS")) || break
+    printf "\r #SNS: % 4d   Tries remaining: %4d" "$num_sns" "$try"
+    sleep 2
+  done
+}
+
+save_aggregator_config
+trap restore_aggregator_config EXIT
+
+speed_up_aggregator
+wait_for_sns_count
+: sns_aggregator config will be restored by the trap set above.

--- a/bin/dfx-software-sns-aggregator-install
+++ b/bin/dfx-software-sns-aggregator-install
@@ -54,7 +54,7 @@ test -e "$WASM_FILE" || {
 jq -e '.canisters.sns_aggregator' dfx.json >/dev/null || {
   echo "Adding sns_aggregator to dfx.json..."
   # TODO: Include API declaration .did files in release, so that we can get the candid.
-  jq -s '.[0] * .[1]' <(echo '{"canisters": { "sns_aggregator": { "type": "custom", "candid": "placeholder", "wasm": "'"${WASM_FILE}"'", "build": "true" }}}') dfx.json | sponge dfx.json
+  jq -s '.[0] * .[1]' <(echo '{"canisters": { "sns_aggregator": { "type": "custom", "candid": "candid/sns_aggregator.did", "wasm": "'"${WASM_FILE}"'", "build": "true" }}}') dfx.json | sponge dfx.json
 }
 
 echo "Creating sns_aggregator canister..."

--- a/bin/dfx-stock-test
+++ b/bin/dfx-stock-test
@@ -28,7 +28,7 @@ export DFX_NETWORK
 
 (
   print_title "sns_aggregator should be installed"
-  index_html="$(mktemp --suffix .html index_XXXX)"
+  index_html="$(mktemp index_XXXX)"
   curl --silent --retry 5 --fail "$(dfx-canister-url sns_aggregator)" >"$index_html" || {
     echo "ERROR: Should be able to get sns_aggregator home page."
     exit 1
@@ -45,6 +45,16 @@ export DFX_NETWORK
     cat "$index_html"
     exit 1
   } >&2
+)
+
+(
+  print_title "sns_aggregator should have 12 SNSs"
+  # This means the second page should have 2 SNSs.
+  aggregator_url="http://$(dfx canister id sns_aggregator).localhost:8080/v1/sns/list/page/1/slow.json"
+  if [ "$(curl -fsS "$aggregator_url" | jq length)" != "2" ]; then
+    echo "ERROR: The aggragtor should have 12 SNSs." >&2
+    exit 1
+  fi
 )
 
 echo "$(basename "$0") PASSED"

--- a/bin/versions.bash
+++ b/bin/versions.bash
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2034 # Variables are expected to be unused in this file
 # Release from 2023-05-30 which includes geo restriction fields
-SNS_AGGREGATOR_RELEASE=proposal-122625-agg
+SNS_AGGREGATOR_RELEASE=proposal-123011-agg
 # Commit from 2023-06-09
 DFX_IC_COMMIT=da00b0b7ea9fa5e19b03979056c202e856899dfa
 INTERNET_IDENTITY_RELEASE=release-2023-04-12


### PR DESCRIPTION
# Motivation

For a snapshot to be useful out of the box, the sns_aggregator should be able to provide info on all existing SNSs.

# Changes

1. Update the used sns_aggregator version to one that has the candid interface in its metadata.
2. Change the candid placeholder in `dfx.json` to an actual candid path.
3. Add `bin/dfx-sns-aggregator-wait` which increases the speed of the aggregator, waits for a given number of SNSs to be loaded and then restores the aggregator config.
4. Call `bin/dfx-sns-aggregator-wait` from `bin/dfx-snapshot-stock-make`

# Tested

1. Ran `bin/dfx-snapshot-stock-make` manually (after `git clean -df` and `git checkout dfx.json`) and inspected the logs.
2. Add a test to `bin/dfx-stock-test`
3. CI