### PR TITLE
Bump ic commit

### DIFF
--- a/bin/versions.bash
+++ b/bin/versions.bash
@@ -2,8 +2,8 @@
 # shellcheck disable=SC2034 # Variables are expected to be unused in this file
 # Release from 2023-05-30 which includes geo restriction fields
 SNS_AGGREGATOR_RELEASE=proposal-122625-agg
-# Commit from 2023-05-17
-DFX_IC_COMMIT=5a285c40c505b103cb4d205f33e1d846eb9ed74b
+# Commit from 2023-06-09
+DFX_IC_COMMIT=da00b0b7ea9fa5e19b03979056c202e856899dfa
 INTERNET_IDENTITY_RELEASE=release-2023-04-12
 NNS_DAPP_RELEASE=proposal-121690
 DIDC_VERSION=2022-11-17


### PR DESCRIPTION
# Motivation
The ic commit is out of date.

# Changes
Bump the ic commit to the last published release before the most recent round of testnet deployments.

# Tests
See CI