### PR TITLE
Use .wasm.gz

### DIFF
--- a/bin/dfx-software-nns-dapp-ci-wasm-url
+++ b/bin/dfx-software-nns-dapp-ci-wasm-url
@@ -26,6 +26,6 @@ test -n "${RELEASE_NAME:-}" || {
   echo "ERROR: Could not find release '${DFX_ND_RELEASE}'"
 } >&2
 
-WASM_FILE="nns-dapp.wasm"
+WASM_FILE="nns-dapp.wasm.gz"
 
 echo "https://github.com/dfinity/nns-dapp/releases/download/${RELEASE_NAME}/${WASM_FILE}"

--- a/bin/dfx-software-sns-aggregator-ci-wasm-url
+++ b/bin/dfx-software-sns-aggregator-ci-wasm-url
@@ -36,6 +36,6 @@ dev | development) SUFFIX="_dev" ;;
   exit 1
 } >&2 ;;
 esac
-WASM_FILE="sns_aggregator${SUFFIX}.wasm"
+WASM_FILE="sns_aggregator${SUFFIX}.wasm.gz"
 
 echo "https://github.com/dfinity/nns-dapp/releases/download/${RELEASE_NAME}/${WASM_FILE}"

--- a/bin/dfx-software-sns-aggregator-ci-wasm-url.test
+++ b/bin/dfx-software-sns-aggregator-ci-wasm-url.test
@@ -19,14 +19,14 @@ for flavour in prod dev; do
     } >&2
     case "$flavour" in
     dev)
-      [[ "${URL}" =~ sns_aggregator_dev.wasm$ ]] || {
-        echo "ERROR: The dev URL should end with sns_aggregator_dev.wasm: $URL"
+      [[ "${URL}" =~ sns_aggregator_dev.wasm.gz$ ]] || {
+        echo "ERROR: The dev URL should end with sns_aggregator_dev.wasm.gz: $URL"
         exit 1
       } >&2
       ;;
     prod)
-      [[ "${URL}" =~ sns_aggregator.wasm$ ]] || {
-        echo "ERROR: The dev URL should end with sns_aggregator.wasm: $URL"
+      [[ "${URL}" =~ sns_aggregator.wasm.gz$ ]] || {
+        echo "ERROR: The dev URL should end with sns_aggregator.wasm.gz: $URL"
         exit 1
       } >&2
       ;;
@@ -37,7 +37,7 @@ for flavour in prod dev; do
       } >&2
       ;;
     esac
-    DOWNLOAD="$(mktemp "sns_aggregator_${flavour}.XXXX" --suffix=".wasm")"
+    DOWNLOAD="$(mktemp "sns_aggregator_${flavour}.XXXX" --suffix=".wasm.gz")"
     curl --no-progress-meter --retry 5 --fail -L "$URL" >"$DOWNLOAD"
     curl_exit_code="$?"
     ((curl_exit_code == 0)) || {
@@ -49,7 +49,7 @@ for flavour in prod dev; do
       echo "       If curl returned zero this should not happen."
       exit 1
     }
-    dfx-canister-nm "$DOWNLOAD" >"${DOWNLOAD}.symbols"
+    dfx-canister-nm "$DOWNLOAD" >"${DOWNLOAD%.gz}.symbols"
     grep -q canister_query "${DOWNLOAD}.symbols" || {
       echo "ERROR: The downloaded file should be a canister wasm file but doesn't appear to be."
       echo "       It should be:"
@@ -61,7 +61,7 @@ for flavour in prod dev; do
       echo "File stats:"
       ls -l "$DOWNLOAD"
       echo "Symbols:"
-      cat "${DOWNLOAD}.symbols"
+      cat "${DOWNLOAD%.gz}.symbols"
       exit 1
     } >&2
     rm "$DOWNLOAD"

--- a/bin/dfx-software-sns-aggregator-ci-wasm-url.test
+++ b/bin/dfx-software-sns-aggregator-ci-wasm-url.test
@@ -50,7 +50,7 @@ for flavour in prod dev; do
       exit 1
     }
     dfx-canister-nm "$DOWNLOAD" >"${DOWNLOAD%.gz}.symbols"
-    grep -q canister_query "${DOWNLOAD}.symbols" || {
+    grep -q canister_query "${DOWNLOAD%.gz}.symbols" || {
       echo "ERROR: The downloaded file should be a canister wasm file but doesn't appear to be."
       echo "       It should be:"
       echo "       - A wasm file"


### PR DESCRIPTION
# Motivation
The nns-dapp release WASMs are now called `.wasm.gz`.  The old suffix is still present but doesn't work for deploying with dfx v 0.14.1.

# Changes
- Update the nns-dapp and sns_aggregator release URLs and the paths of these files elsewhere in the repo.

# Tests
Existing CI should suffice, as this adds no new features or functionality.  Existing tests have been updated where needed.