### PR TITLE
Rm unused step

### DIFF
--- a/bin/dfx-network-deploy-testnet
+++ b/bin/dfx-network-deploy-testnet
@@ -35,13 +35,6 @@ else
   } >&2
   (
     set -euxo pipefail
-    echo "Building custom canisters..."
-    cd "$ND_REPO_DIR"
-    ./e2e-tests/scripts/nns-canister-download
-    ./e2e-tests/scripts/nns-canister-build
-  )
-  (
-    set -euxo pipefail
     echo "Deploying testnet..."
     cd "$IC_REPO_DIR"
     git checkout "$DFX_IC_COMMIT"


### PR DESCRIPTION
# Motivation
The custom NNS canister builds have not been used since February: https://github.com/dfinity/snsdemo/commit/16827cfc8e714cc22cdf9a4267c243dcf1e13da0

# Changes
- Delete unused step.

# Tests
See CI