### PR TITLE
Retry the neuron creation

### DIFF
--- a/bin/dfx-neuron-create
+++ b/bin/dfx-neuron-create
@@ -7,6 +7,8 @@ source "$SOURCE_DIR/clap.bash"
 # Define options
 clap.define short=s long=icp desc="The amount of ICP to icp" variable=ICP default=1
 clap.define short=i long=DFX_IDENTITY desc="The dfx identity to use" variable=DFX_IDENTITY default="$(dfx identity whoami)"
+clap.define long=retries desc="The number of retries" variable=DFX_RETRIES default="20"
+clap.define long=retry_interval desc="The number of seconds between retries" variable=DFX_RETRY_SLEEP default="4"
 clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
 clap.define short=V long=verbose desc="Print progress" variable=DFX_VERBOSE nargs=0
 # Source the output file ----------------------------------------------------------
@@ -16,11 +18,11 @@ test -z "${DFX_VERBOSE:-}" || set -x
 retry() {
   (
     set -eu
-    for ((i = 0; i < ${DFX_RETRIES:-20}; i++)); do
+    for ((i = 0; i < DFX_RETRIES; i++)); do
       if "${@}"; then
         return
       else
-        sleep ${DFX_RETRY_SLEEP:-4}
+        sleep "${DFX_RETRY_SLEEP}"
       fi
     done
     {

--- a/bin/dfx-neuron-create
+++ b/bin/dfx-neuron-create
@@ -13,50 +13,74 @@ clap.define short=V long=verbose desc="Print progress" variable=DFX_VERBOSE narg
 source "$(clap.build)"
 test -z "${DFX_VERBOSE:-}" || set -x
 
-# Create a neuron
-PEM="$HOME/.config/dfx/identity/$DFX_IDENTITY/identity.pem"
-test -e "$PEM" || {
-  echo "ERROR: Pem file for user '$DFX_IDENTITY' does not exist at '$PEM'"
-  exit 1
-} >&2
-NEURONS_DIR="$HOME/.config/dfx/identity/$DFX_IDENTITY/neurons"
-mkdir -p "$NEURONS_DIR"
-NEURONS_FILE="$NEURONS_DIR/$DFX_NETWORK"
-IC_URL="$("$SOURCE_DIR/dfx-network-url" --network "$DFX_NETWORK")"
-export IC_URL
-# Note: Quill send puts a pile of junk on stdout and has no option to put just the response(s) somewhere safe such as a file.
+retry() {
+  (
+    set -eu
+    for ((i = 0; i < ${DFX_RETRIES:-20}; i++)); do
+      if "${@}"; then
+        return
+      else
+        sleep ${DFX_RETRY_SLEEP:-4}
+      fi
+    done
+    {
+      echo "ERROR: Failed to run: $*"
+      exit 1
+    } >&2
+  )
+}
 
-command=(quill neuron-stake --insecure-local-dev-mode --pem-file "$PEM" --amount "$ICP" --name 1)
-MESSAGE="$("${command[@]}")"
-test -n "${MESSAGE:-}" || {
-  echo "ERROR: Created an empty message."
-  command -v quill
-  echo "${command[*]}"
-  exit 1
-} >&2
-command=(quill send --yes --insecure-local-dev-mode -)
-RESPONSE="$(echo "$MESSAGE" | "${command[@]}")"
-test -n "${RESPONSE:-}" || {
-  echo "ERROR: Received an empty response."
-  echo message:
-  echo "$MESSAGE"
-  echo
-  echo command -v quill
-  echo "${command[*]}"
-  exit 1
-} >&2
-NEURON_TEXT="$(echo "$RESPONSE" | perl -e 'while($_ = <>){if (s/NeuronId = record \{ id = ([0-9_]+) : nat64 \}/\1/){ print $_ }}')"
-test -n "${NEURON_TEXT:-}" || {
-  echo "ERROR: Could not find neuron in response:"
-  echo "$RESPONSE"
-  exit 1
-} >&2
-NEURON_ID="$(echo "$NEURON_TEXT" | tr -cd '[:alnum:]')"
-test -n "${NEURON_ID:-}" || {
-  echo "Failed to get neuron ID from line: $NEURON_TEXT"
-  exit 1
-} >&2
+mk_neuron() {
+  (
+    set -euo pipefail
+    # Create a neuron
+    PEM="$HOME/.config/dfx/identity/$DFX_IDENTITY/identity.pem"
+    test -e "$PEM" || {
+      echo "ERROR: Pem file for user '$DFX_IDENTITY' does not exist at '$PEM'"
+      exit 1
+    } >&2
+    NEURONS_DIR="$HOME/.config/dfx/identity/$DFX_IDENTITY/neurons"
+    mkdir -p "$NEURONS_DIR"
+    NEURONS_FILE="$NEURONS_DIR/$DFX_NETWORK"
+    IC_URL="$("$SOURCE_DIR/dfx-network-url" --network "$DFX_NETWORK")"
+    export IC_URL
+    # Note: Quill send puts a pile of junk on stdout and has no option to put just the response(s) somewhere safe such as a file.
 
-echo "$NEURON_ID" >>"$NEURONS_FILE"
-echo
-tail -n1 "$NEURONS_FILE"
+    command=(quill neuron-stake --insecure-local-dev-mode --pem-file "$PEM" --amount "$ICP" --name 1)
+    MESSAGE="$("${command[@]}")"
+    test -n "${MESSAGE:-}" || {
+      echo "ERROR: Created an empty message."
+      command -v quill
+      echo "${command[*]}"
+      exit 1
+    } >&2
+    command=(quill send --yes --insecure-local-dev-mode -)
+    RESPONSE="$(echo "$MESSAGE" | "${command[@]}")"
+    test -n "${RESPONSE:-}" || {
+      echo "ERROR: Received an empty response."
+      echo message:
+      echo "$MESSAGE"
+      echo
+      echo command -v quill
+      echo "${command[*]}"
+      exit 1
+    } >&2
+    NEURON_TEXT="$(echo "$RESPONSE" | perl -e 'while($_ = <>){if (s/NeuronId = record \{ id = ([0-9_]+) : nat64 \}/\1/){ print $_ }}')"
+    test -n "${NEURON_TEXT:-}" || {
+      echo "ERROR: Could not find neuron in response:"
+      echo "$RESPONSE"
+      exit 1
+    } >&2
+    NEURON_ID="$(echo "$NEURON_TEXT" | tr -cd '[:alnum:]')"
+    test -n "${NEURON_ID:-}" || {
+      echo "Failed to get neuron ID from line: $NEURON_TEXT"
+      exit 1
+    } >&2
+
+    echo "$NEURON_ID" >>"$NEURONS_FILE"
+    echo
+    tail -n1 "$NEURONS_FILE"
+  )
+}
+
+retry mk_neuron

--- a/bin/dfx-neuron-create
+++ b/bin/dfx-neuron-create
@@ -34,7 +34,6 @@ retry() {
 
 mk_neuron() {
   (
-    set -euo pipefail
     # Create a neuron
     PEM="$HOME/.config/dfx/identity/$DFX_IDENTITY/identity.pem"
     test -e "$PEM" || {


### PR DESCRIPTION
# Motivation
The neuron creation fails fairly often due to the network returning 503's.

# Changes
- Add a retry.

# Tests
- See CI
- I have deployed a testnet with this PR, albeit without command line arguments.