### PR TITLE
Rm unused flag

### DIFF
--- a/bin/dfx-network-deploy
+++ b/bin/dfx-network-deploy
@@ -60,7 +60,7 @@ else
   # out before we can resonably ask people to do this.
   IC_REPO_DIR="${IC_REPO_DIR:-$HOME/dfn/ic-github/}"
   ND_REPO_DIR="${ND_REPO_DIR:-$HOME/dfn/nns-dapp/}"
-  dfx-network-deploy-testnet --network "$DFX_NETWORK" --ic_dir "${IC_REPO_DIR}" --nd_dir "${ND_REPO_DIR}"
+  dfx-network-deploy-testnet --network "$DFX_NETWORK" --ic_dir "${IC_REPO_DIR}"
   dfx-network-deploy-config --network "$DFX_NETWORK" --ic_dir "${IC_REPO_DIR}" --nd_dir "${ND_REPO_DIR}"
   dfx-network-deploy-frontends --network "$DFX_NETWORK" --nd_dir "${ND_REPO_DIR}"
 fi

--- a/bin/dfx-network-deploy-testnet
+++ b/bin/dfx-network-deploy-testnet
@@ -12,7 +12,6 @@ clap.define short=c long=commit desc="The IC commit of the wasms" variable=DFX_I
   echo "$DFX_IC_COMMIT"
 )"
 clap.define short=x long=ic_dir desc="Directory containing the ic source code" variable=IC_REPO_DIR default="$HOME/dfn/ic"
-clap.define short=y long=nd_dir desc="Directory containing the nns-dapp source code" variable=ND_REPO_DIR default="$HOME/dfn/nns-dapp"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
@@ -27,12 +26,7 @@ else
   # Note: This is still relatively slow and error prone.  Points of friction need to be ironed
   # out before we can resonably ask people to do this.
   IC_REPO_DIR="${IC_REPO_DIR:-$HOME/dfn/ic-github/}"
-  ND_REPO_DIR="${ND_REPO_DIR:-$HOME/dfn/nns-dapp/}"
   TESTNET="$DFX_NETWORK"
-  test -d "$ND_REPO_DIR" || {
-    echo "Invalid directory for nns-dapp source code: $ND_REPO_DIR"
-    exit 1
-  } >&2
   (
     set -euxo pipefail
     echo "Deploying testnet..."
@@ -43,7 +37,6 @@ else
 			  "init_ledger_accounts":["5b315d2f6702cb3a27d826161797d7b2c2e131cd312aece51d4d5574d1247087", "2b8fbde99de881f695f279d2a892b1137bfe81a42d7694e064b1be58701e1138"]
 			}
 		EOF
-    # "custom_canister_dir": "${ND_REPO_DIR}/target/ic", <- currently causes an error
 
     ./testnet/tools/icos_deploy.sh --boundary-dev-image --git-revision "$DFX_IC_COMMIT" "$TESTNET" --ansible-args "-e @$PWD/test-accounts.json" || {
       echo "Tesnet returned an error code but it returns errors for very minor reasons.  The deployment is probably fine."


### PR DESCRIPTION
# Motivation
The command to deploy a testnet no longer uses the nns-dapp dir.

# Changes
- Delete unused flag