### PR TITLE
Specify network when making SNSs in parallel

### DIFF
--- a/bin/dfx-sns-demo-mksns-parallel
+++ b/bin/dfx-sns-demo-mksns-parallel
@@ -39,7 +39,7 @@ make_user() {
     dfx identity remove --quiet "$DEMO_USER" --drop-wallets 2>/dev/null || true
     dfx identity new --storage-mode=plaintext "$DEMO_USER"
     dfx identity use "$DEMO_USER"
-    dfx wallet balance
+    dfx wallet balance --network "$DFX_NETWORK"
     bin/dfx-ledger-get-icp --icp 5000 --network "$DFX_NETWORK"
     dfx ledger balance --network "$DFX_NETWORK"
     bin/dfx-neuron-create --icp 10 --network "$DFX_NETWORK"
@@ -75,7 +75,7 @@ create_all_sns() {
 
       ./bin/dfx-sns-config-random
       dfx ledger top-up --amount 4.0 --network "$DFX_NETWORK" "$(dfx identity get-wallet --network "$DFX_NETWORK")"
-      dfx wallet balance
+      dfx wallet balance --network "$DFX_NETWORK"
       ./bin/dfx-sns-deploy --network "$DFX_NETWORK"
 
       dfx canister id sns_root --network "$DFX_NETWORK"


### PR DESCRIPTION
# Motivation
The command for creating lots of SNSs in parallel, used for local deployments, doesn't work for testnets due to some minor omissions.

Note: More changes are needed to make this work for testnets, but the remaining problems appear to be due to insufficient funds, that need to be provided elsewhere.

# Changes
- Specify `--network` in the appropriate places.