### PR TITLE
Stop replica when dfx-snapshot-stock-make fails

### DIFF
--- a/bin/dfx-snapshot-stock-make
+++ b/bin/dfx-snapshot-stock-make
@@ -19,6 +19,17 @@ clap.define short=x long=ic_dir desc="Directory containing the ic source code; n
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
+onSetupFailure() {
+  # Stop the replica because otherwise it continues outputting logs, obscuring
+  # the fact that the script has finished and making the error message hard to
+  # find.
+  dfx-network-stop
+  echo "❌ Something went wrong. Failed to create snapshot."
+  exit 1
+}
+
+trap onSetupFailure EXIT
+
 : Create stock state
 dfx-stock-deploy --ic_commit "$DFX_IC_COMMIT" --ic_dir "$IC_REPO_DIR"
 
@@ -30,6 +41,9 @@ dfx-network-wait-for-checkpoint --timeout 600
 
 : "Stop the replica gently but forcefully.  It must be stopped and should ideally have a clean state."
 dfx-network-stop
+
+: "We made it. Remove the trap."
+trap '' EXIT
 
 echo "Saving state"
 dfx-snapshot-save --snapshot "$DFX_SNAPSHOT_FILE"


### PR DESCRIPTION
# Motivation

Multiple people have been confused by the replica continuing to log after `dfx-snapshot-stock-make` fails.
This makes it hard to see if the script has finished and what the error was.

# Changes

1. Set a trap in `bin/dfx-snapshot-stock-make` to stop the replica and to explain that the script fails.
2. Remove the trap once the replica is stopped normally, otherwise it would still trigger when the script exits successfully.

# Tested

I introduced a type in another script and verified that the replica was stopped and the error message displayed.
Then I removed the type and verified that the snapshot is made successfully without error message.