### PR TITLE
Action to check for dfx updates

### DIFF
--- a/.github/actions/slack/README.md
+++ b/.github/actions/slack/README.md
@@ -1,0 +1,21 @@
+# Slack
+
+A GitHub Action for sending slack notifications. For more information, see slack's [documentation](https://api.slack.com/messaging/webhooks). In particular, note that the channel and workspace are set by the webhook URL, not directly by this action.
+
+## Usage
+
+```yaml
+name: My Action
+
+on:
+  push:
+
+jobs:
+  share-love:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/slack
+        with:
+          WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          MESSAGE: "I love you guys."
+```

--- a/.github/actions/slack/SOURCE.md
+++ b/.github/actions/slack/SOURCE.md
@@ -1,0 +1,3 @@
+The slack action is copied from here:
+
+https://github.com/dfinity/internet-identity/tree/main/.github/actions/slack

--- a/.github/actions/slack/action.yml
+++ b/.github/actions/slack/action.yml
@@ -1,0 +1,19 @@
+name: 'Slack'
+description: 'A simple action that sends a slack message to a channel.'
+inputs:
+  message:
+    description: 'The message to send. A link to the action run will be appended.'
+    required: true
+  webhook_url:
+    description: 'The webhook URL as described here: https://api.slack.com/messaging/webhooks'
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - run: |
+        echo '{}' | jq --arg text "$MESSAGE: https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" '.text = $text' | \
+            curl -X POST -H 'Content-Type: application/json' --data @- "$WEBHOOK_URL"
+      shell: bash
+      env:
+        WEBHOOK_URL: ${{ inputs.webhook_url }}
+        MESSAGE: ${{ inputs.message }}

--- a/.github/workflows/update-dfx.yml
+++ b/.github/workflows/update-dfx.yml
@@ -6,8 +6,10 @@ on:
     # check for new dfx versions weekly
     - cron: '30 3 * * FRI'
   workflow_dispatch:
+  # Provide an option to run this manually.
   push:
     branches:
+      # Development branch for this workflow:
       - "update-dfx"
 jobs:
   rust-update:
@@ -44,7 +46,7 @@ jobs:
           commit-message: Update dfx version
           committer: GitHub <noreply@github.com>
           author: gix-bot <gix-bot@users.noreply.github.com>
-          branch: bot-rust-update
+          branch: bot-dfx-update
           delete-branch: true
           title: 'Update dfx version'
           # Since the this is a scheduled job, a failure won't be shown on any

--- a/.github/workflows/update-dfx.yml
+++ b/.github/workflows/update-dfx.yml
@@ -28,8 +28,10 @@ jobs:
 
           if [ "$current_dfx_version" != "$latest_dfx_version" ]
           then
-            version="$latest_dfx_version" jq '.dfx=(env.version)' dfx.json > dfx-new.json
-            mv dfx-new.json dfx.json
+            for file in dfx.json dfx.json.original ; do
+              version="$latest_dfx_version" jq '.dfx=(env.version)' "$file" > "$file.new"
+              mv "$file.new" "$file"
+            done
             echo An update is available for dfx.
             git diff
             echo "updated=1" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/update-dfx.yml
+++ b/.github/workflows/update-dfx.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           token: ${{ secrets.GIX_SNSDEMO_BOT_GH_TOKEN }}
           base: main
-          add-paths: ./dfx.json
+          add-paths: dfx.json
           commit-message: Update dfx version
           committer: GitHub <noreply@github.com>
           author: gix-bot <gix-bot@users.noreply.github.com>

--- a/.github/workflows/update-dfx.yml
+++ b/.github/workflows/update-dfx.yml
@@ -31,6 +31,7 @@ jobs:
             version="$latest_dfx_version" jq '.dfx=(.env.version)' dfx.json > dfx-new.json
             mv dfx-new.json dfx.json
             echo An update is available for dfx.
+            git diff
             echo "updated=1" >> "$GITHUB_OUTPUT"
           else
             echo "updated=0" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/update-dfx.yml
+++ b/.github/workflows/update-dfx.yml
@@ -45,7 +45,9 @@ jobs:
         with:
           token: ${{ secrets.GIX_SNSDEMO_BOT_GH_TOKEN }}
           base: main
-          add-paths: dfx.json
+          add-paths: |
+            dfx.json
+            dfx.json.original
           commit-message: Update dfx version
           committer: GitHub <noreply@github.com>
           author: gix-bot <gix-bot@users.noreply.github.com>

--- a/.github/workflows/update-dfx.yml
+++ b/.github/workflows/update-dfx.yml
@@ -1,6 +1,6 @@
 # A GitHub Actions workflow that regularly checks for a new dfx
 # and creates a PR on new versions.
-name: Rust Update
+name: Update dfx
 on:
   schedule:
     # check for new dfx versions weekly
@@ -12,13 +12,13 @@ on:
       # Development branch for this workflow:
       - "update-dfx"
 jobs:
-  rust-update:
+  update-dfx:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        # First, check rust GitHub releases for a new version. We assume that the
+        # First, check dfx GitHub releases for a new version. We assume that the
         # latest version's tag name is the version.
-      - name: Check new rust version
+      - name: Check new dfx version
         id: update
         run: |
           current_dfx_version="$(jq -r .dfx dfx.json)"
@@ -35,7 +35,7 @@ jobs:
           else
             echo "updated=0" >> "$GITHUB_OUTPUT"
           fi
-        # If the rust-toolchain was updated, create a PR.
+        # If a newer dfx is available, create a PR.
       - name: Create Pull Request
         if: ${{ steps.update.outputs.updated == '1' }}
         uses: peter-evans/create-pull-request@v4

--- a/.github/workflows/update-dfx.yml
+++ b/.github/workflows/update-dfx.yml
@@ -1,0 +1,57 @@
+# A GitHub Actions workflow that regularly checks for a new dfx
+# and creates a PR on new versions.
+name: Rust Update
+on:
+  schedule:
+    # check for new dfx versions weekly
+    - cron: '30 3 * * FRI'
+  workflow_dispatch:
+  push:
+    branches:
+      - "update-dfx"
+jobs:
+  rust-update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        # First, check rust GitHub releases for a new version. We assume that the
+        # latest version's tag name is the version.
+      - name: Check new rust version
+        id: update
+        run: |
+          current_dfx_version="$(jq -r .dfx dfx.json)"
+          echo "Current dfx version: '$current_dfx_version'"
+          latest_dfx_version="$(curl -sSL https://sdk.dfinity.org/manifest.json | jq -r .tags.latest)"
+          echo "Latest dfx version: '$latest_dfx_version'"
+
+          if [ "$current_dfx_version" != "$latest_dfx_version" ]
+          then
+            version="$latest_dfx_version" jq '.dfx=(.env.version)' dfx.json > dfx-new.json
+            mv dfx-new.json dfx.json
+            echo An update is available for dfx.
+            echo "updated=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "updated=0" >> "$GITHUB_OUTPUT"
+          fi
+        # If the rust-toolchain was updated, create a PR.
+      - name: Create Pull Request
+        if: ${{ steps.update.outputs.updated == '1' }}
+        uses: peter-evans/create-pull-request@v4
+        with:
+          token: ${{ secrets.GIX_SNSDEMO_BOT_GH_TOKEN }}
+          base: main
+          add-paths: ./dfx.json
+          commit-message: Update dfx version
+          committer: GitHub <noreply@github.com>
+          author: gix-bot <gix-bot@users.noreply.github.com>
+          branch: bot-rust-update
+          delete-branch: true
+          title: 'Update dfx version'
+          # Since the this is a scheduled job, a failure won't be shown on any
+          # PR status. To notify the team, we send a message to our Slack channel on failure.
+      - name: Notify Slack on failure
+        uses: ./.github/actions/slack
+        if: ${{ failure() }}
+        with:
+          WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          MESSAGE: "Dfx update failed"

--- a/.github/workflows/update-dfx.yml
+++ b/.github/workflows/update-dfx.yml
@@ -28,7 +28,7 @@ jobs:
 
           if [ "$current_dfx_version" != "$latest_dfx_version" ]
           then
-            version="$latest_dfx_version" jq '.dfx=(.env.version)' dfx.json > dfx-new.json
+            version="$latest_dfx_version" jq '.dfx=(env.version)' dfx.json > dfx-new.json
             mv dfx-new.json dfx.json
             echo An update is available for dfx.
             git diff


### PR DESCRIPTION
# Motivation
We would like to automate chores, such as updating dfx, IC commit and so on.  And we now have the requisite permissions to do so in the snsdemo.

Note: Updates create a PR, so a human can decide whether a  given update is appropriate.

Let's start with dfx.

# Changes
- Add a github workflow that checks for dfx updates and, on finding one, creates a corresponding PR.

# Testing
- This action generated this PR: https://github.com/dfinity/snsdemo/pull/212