### PR TITLE
Create more SNS token for the faucet

### DIFF
--- a/bin/dfx-sns-sale-propose
+++ b/bin/dfx-sns-sale-propose
@@ -21,7 +21,7 @@ export DFX_NEURON_ID DFX_IDENTITY_PEM DFX_NNS_URL
 # The due date of the sale must be greater than 1 day at the time of NNS proposal execution
 SWAP_DUE_TIMESTAMP="$(perl -e 'print time() + 90 * 24 * 3600')"
 SNS_SWAP="$(dfx canister id sns_swap --network "$DFX_NETWORK")"
-SNS_TOKENS_E8s=314100000000
+SNS_TOKENS_E8s=1000314100000000
 TOKEN_SYMBOL="$(awk '/token_symbol:/{print $2}' sns.yml || echo SOMETHING)"
 PROPOSAL_TITLE="Proposal to create an SNS-DAO for $TOKEN_SYMBOL"
 set ic-admin \
@@ -31,9 +31,9 @@ set ic-admin \
   --proposer "$DFX_NEURON_ID" \
   --min-participants 1 \
   --min-icp-e8s 5000000000 \
-  --max-icp-e8s 314100000000 \
+  --max-icp-e8s 1000314100000000 \
   --min-participant-icp-e8s 10000000 \
-  --max-participant-icp-e8s 314100000000 \
+  --max-participant-icp-e8s 1000314100000000 \
   --swap-due-timestamp-seconds "$SWAP_DUE_TIMESTAMP" \
   --sns-token-e8s "$SNS_TOKENS_E8s" \
   --target-swap-canister-id "$SNS_SWAP" \

--- a/bin/dfx-sns-sale-propose
+++ b/bin/dfx-sns-sale-propose
@@ -30,7 +30,7 @@ set ic-admin \
   propose-to-open-sns-token-swap \
   --proposer "$DFX_NEURON_ID" \
   --min-participants 1 \
-  --min-icp-e8s 200000000000 \
+  --min-icp-e8s 5000000000 \
   --max-icp-e8s 314100000000 \
   --min-participant-icp-e8s 10000000 \
   --max-participant-icp-e8s 314100000000 \

--- a/bin/dfx-sns-sale-propose
+++ b/bin/dfx-sns-sale-propose
@@ -30,10 +30,10 @@ set ic-admin \
   propose-to-open-sns-token-swap \
   --proposer "$DFX_NEURON_ID" \
   --min-participants 1 \
-  --min-icp-e8s 5000000000 \
-  --max-icp-e8s 1000314100000000 \
+  --min-icp-e8s 200000000000 \
+  --max-icp-e8s 314100000000 \
   --min-participant-icp-e8s 10000000 \
-  --max-participant-icp-e8s 1000314100000000 \
+  --max-participant-icp-e8s 314100000000 \
   --swap-due-timestamp-seconds "$SWAP_DUE_TIMESTAMP" \
   --sns-token-e8s "$SNS_TOKENS_E8s" \
   --target-swap-canister-id "$SNS_SWAP" \

--- a/bin/sns_init.yml
+++ b/bin/sns_init.yml
@@ -261,8 +261,8 @@ initial_token_distribution:
     treasury_distribution:
       total_e8s: 293700000000
     swap_distribution:
-      total_e8s: 314100000000
-      initial_swap_amount_e8s: 314100000000
+      total_e8s: 1000314100000000
+      initial_swap_amount_e8s: 1000314100000000
     airdrop_distribution:
       airdrop_neurons:
         - controller: x4vjn-rrapj-c2kqe-a6m2b-7pzdl-ntmc4-riutz-5bylw-2q2bh-ds5h2-lae


### PR DESCRIPTION
# Motivation

When we create an snsdemo snapshot, we send tokens to the faucet address so you can use the "Get Tokens" button to get tokens.
Currently we only create 3141 tokens and only half of that can be disbursed.

# Changes

1. Create 10'003'141 tokens instead of 3'141 so we can use the faucet for longer before it runs dry.

# Tested

Manually ran the script and tried to get 4'000'000 SNS tokens.