### PR TITLE
Use sns-governance-canister_test.wasm

### DIFF
--- a/bin/sns_dfx.json
+++ b/bin/sns_dfx.json
@@ -5,7 +5,7 @@
             "nns_sns_wasm_name": "governance"
         },
         "build": "",
-        "wasm": "sns-governance-canister.wasm",
+        "wasm": "sns-governance-canister_test.wasm",
         "candid": "../governance/canister/governance.did",
         "type": "custom"
       },


### PR DESCRIPTION
# Motivation

We want to be able to call [mint_tokens](https://github.com/dfinity/ic/blob/9e8bb53e3ad64dcb7502af9c7ef98bba7a5c6b6e/rs/sns/governance/canister/governance_test.did#L441) when running out of tokens for testing.

# Changes

Download and install `sns-governance-canister_test.wasm` instead of `sns-governance-canister.wasm`.

# Tested

With the change:
```
$ dfx canister call sns_governance mint_tokens '(record { recipient = opt record { owner = opt principal "6zezr-ldzpc-56dze-q6nfp-6rcac-wcrmt-qrlnn-c7q7i-pzwx4-eyaz2-7qe"}; amount_e8s = 1000000000 : nat64; })'
(record {})
```

Without the change:
```
dfx canister call sns_governance mint_tokens '(record { recipient = opt record { owner = opt principal "6zezr-ldzpc-56dze-q6nfp-6rcac-wcrmt-qrlnn-c7q7i-pzwx4-eyaz2-7qe"}; amount_e8s = 1000000000 : nat64; })'
Error: Failed update call.
Caused by: Failed update call.
  The replica returned a replica error: Replica Error: reject code DestinationInvalid, reject message Canister be2us-64aaa-aaaaa-qaabq-cai has no update method 'mint_tokens', error code None
```