### PR TITLE
Small config changes for ckBTC

### DIFF
--- a/bin/dfx-ckbtc-deploy
+++ b/bin/dfx-ckbtc-deploy
@@ -47,7 +47,7 @@ deploy_ckbtc() {
   # echo "Step 2: deploying minter canister..."
   dfx deploy "${LOCAL_PREFIX}minter" --network "$DFX_NETWORK" --argument "(variant {
   Init = record {
-       btc_network = variant { Regtest };
+       btc_network = variant { Mainnet };
        ledger_id = principal \"$LEDGERID\";
        ecdsa_key_name = \"dfx_test_key\";
        retrieve_btc_min_amount = 13_333;
@@ -66,7 +66,8 @@ deploy_ckbtc() {
      token_symbol = \"ckBTC\";
      token_name = \"Token ckBTC\";
      minting_account = record { owner = principal \"$MINTERID\" };
-     transfer_fee = 11_500;
+     transfer_fee = 10;
+     max_memo_length = opt 64;
      metadata = vec {};
      initial_balances = vec { record { record { owner = principal \"$PRINCIPAL\"; }; 10_000_000; }; };
      archive_options = record {


### PR DESCRIPTION
# Motivation

We want to be able to test ckBTC locally and on CI.
The ckBTC minter makes transactions with a memo that is between 47 or 48 bytes ([context](https://docs.google.com/document/d/1rmOWTL7_MrkiUHVUlX1UP7_cqB97VSNFEcedHiF5cIc/edit)).
The BTC address generated by the minter depend on the network and the NNS dapp frontend code expects mainnet addresses for mainnet BTC so we should configure the minter for mainnet BTC for consistency.

# Changes

1. Set the ckbtc_minter `btc_network` to `Mainnet` in the init args.
2. Set the ckbtc_ledger `max_memo_length` to 64 in the init args.
3. Drive-by: Set a more realistic `transfer_fee` of 10 (same as mainnet) instead of 11_500.

These changes are necessary but not sufficient to test ckBTC.
Future required changes are:

1. Install KYT canister
2. Set a maintainer for the KYT canister
3. Set a (fake) API key for the KYT canister.
4. Configure the KYT canister to all transactions.
5. Register the KYT canister ID with the ckbtc_minter
6. Install mock bitcoin canister

# Tested

Created a snapshot and ran e2e tests against it.