### PR TITLE
Install KYT as part of ckBTC

### DIFF
--- a/bin/dfx-ckbtc-deploy
+++ b/bin/dfx-ckbtc-deploy
@@ -35,14 +35,32 @@ source "$(clap.build)"
 } >&2
 
 deploy_ckbtc() {
+  # We create some canisters ahead of time because we need to know their IDs
+  # before deploying. Remaining canisters will be created when deployed.
+  dfx canister create "${LOCAL_PREFIX}kyt" --network "$DFX_NETWORK" || echo "${LOCAL_PREFIX}kyt canister already exists"
   dfx canister create "${LOCAL_PREFIX}ledger" --network "$DFX_NETWORK" || echo "${LOCAL_PREFIX}ledger canister already exists"
   dfx canister create "${LOCAL_PREFIX}minter" --network "$DFX_NETWORK" || echo "${LOCAL_PREFIX}minter canister already exists"
 
+  KYT_ID="$(dfx canister id "${LOCAL_PREFIX}kyt" --network "$DFX_NETWORK")"
+  echo "$KYT_ID"
   MINTERID="$(dfx canister id "${LOCAL_PREFIX}minter" --network "$DFX_NETWORK")"
   echo "$MINTERID"
   LEDGERID="$(dfx canister id "${LOCAL_PREFIX}ledger" --network "$DFX_NETWORK")"
   echo "$LEDGERID"
-  KYT_PRINCIPAL="ymphz-l4rr5-iqzdh-wdp3p-wpfo7-getsa-xrafl-yfxtv-kxjmk-xrn4r-iae" # Placeholder
+
+  # echo "Step 1: deploying kyt canister..."
+  DFX_IDENTITY_PRINCIPAL="$(dfx identity get-principal)"
+  dfx deploy "${LOCAL_PREFIX}kyt" --network "$DFX_NETWORK" --argument "(variant {
+  InitArg = record {
+      minter_id = principal \"$MINTERID\";
+      maintainers = vec { principal \"$DFX_IDENTITY_PRINCIPAL\" };
+      mode = variant { AcceptAll };
+  }
+})" --mode="${DFX_MODE}" ${DFX_YES:+--yes} --upgrade-unchanged
+
+  # We use mode AcceptAll so the API key is not used, but without API key the
+  # KYT canister will refuse to accept any UTXOs.
+  dfx canister call ${LOCAL_PREFIX}kyt --network "$DFX_NETWORK" set_api_key '( record { api_key = "placeholder" } )'
 
   # echo "Step 2: deploying minter canister..."
   dfx deploy "${LOCAL_PREFIX}minter" --network "$DFX_NETWORK" --argument "(variant {
@@ -55,12 +73,11 @@ deploy_ckbtc() {
        min_confirmations = opt 12;
        mode = variant { GeneralAvailability };
        kyt_fee = opt 13_333;
-       kyt_principal = opt principal \"$KYT_PRINCIPAL\";
+       kyt_principal = opt principal \"$KYT_ID\";
    }
 })" --mode="${DFX_MODE}" ${DFX_YES:+--yes} --upgrade-unchanged
 
   echo "Step 3: deploying ledger canister..."
-  PRINCIPAL="$(dfx identity get-principal)"
   dfx deploy "${LOCAL_PREFIX}ledger" --network "$DFX_NETWORK" --argument "(variant {
   Init = record {
      token_symbol = \"ckBTC\";
@@ -69,11 +86,11 @@ deploy_ckbtc() {
      transfer_fee = 10;
      max_memo_length = opt 64;
      metadata = vec {};
-     initial_balances = vec { record { record { owner = principal \"$PRINCIPAL\"; }; 10_000_000; }; };
+     initial_balances = vec { record { record { owner = principal \"$DFX_IDENTITY_PRINCIPAL\"; }; 10_000_000; }; };
      archive_options = record {
          num_blocks_to_archive = 10_000;
          trigger_threshold = 20_000;
-         controller_id = principal \"$PRINCIPAL\";
+         controller_id = principal \"$DFX_IDENTITY_PRINCIPAL\";
          cycles_for_archive_creation = opt 4_000_000_000_000;
      };
  }
@@ -103,9 +120,9 @@ deploy_ckbtc() {
 }
 
 check_ckbtc_deployment() {
-  for canister in "${LOCAL_PREFIX}ledger" "${LOCAL_PREFIX}minter"; do
+  for canister in kyt ledger minter index; do
     : "Verify that the deployed canister matches the local wasm"
-    dfx-canister-check-wasm-hash --canister "$canister" --network "$DFX_NETWORK"
+    dfx-canister-check-wasm-hash --canister "${LOCAL_PREFIX}$canister" --network "$DFX_NETWORK"
   done
 }
 

--- a/bin/dfx-ckbtc-deploy
+++ b/bin/dfx-ckbtc-deploy
@@ -60,7 +60,7 @@ deploy_ckbtc() {
 
   # We use mode AcceptAll so the API key is not used, but without API key the
   # KYT canister will refuse to accept any UTXOs.
-  dfx canister call ${LOCAL_PREFIX}kyt --network "$DFX_NETWORK" set_api_key '( record { api_key = "placeholder" } )'
+  dfx canister call "${LOCAL_PREFIX}kyt" --network "$DFX_NETWORK" set_api_key '( record { api_key = "placeholder" } )'
 
   # echo "Step 2: deploying minter canister..."
   dfx deploy "${LOCAL_PREFIX}minter" --network "$DFX_NETWORK" --argument "(variant {

--- a/bin/dfx-ckbtc-deploy.test
+++ b/bin/dfx-ckbtc-deploy.test
@@ -45,6 +45,7 @@ PATH="$SOURCE_DIR:$PATH"
   dfx start --clean --background
   git checkout dfx.json
   dfx-ckbtc-import
+  dfx canister create "ckbtc_kyt" --no-wallet
   dfx canister create "ckbtc_ledger" --no-wallet
   dfx canister create "ckbtc_minter" --no-wallet
   error_log="$(mktemp ,test_log.XXXXXXXX)"

--- a/bin/dfx-ckbtc-deploy.test
+++ b/bin/dfx-ckbtc-deploy.test
@@ -52,7 +52,7 @@ PATH="$SOURCE_DIR:$PATH"
   if dfx-ckbtc-deploy --check 2>"$error_log"; then
     echo "ERROR: Should fail if ckbtc canisters have the incorrect or no hash"
   fi
-  grep 'ERROR: Deployed ckbtc_ledger hash does not match.' "$error_log" || {
+  grep 'ERROR: Deployed ckbtc_kyt hash does not match.' "$error_log" || {
     echo "ERROR: The check should complain about missing canisters."
     echo "Actual error output:"
     sed 's/^/    /g' "$error_log"

--- a/bin/dfx-ckbtc-import
+++ b/bin/dfx-ckbtc-import
@@ -36,7 +36,8 @@ ckbtc_import() {
     WASM_DIR="${WASM_DIR:-}" \
     CANDID_DIR="${CANDID_DIR:-}" \
     jq -s '{canisters:
-      { "\(env.LOCAL_PREFIX)ledger": { build: "true", candid: "\(env.CANDID_DIR)/\(env.LOCAL_PREFIX)ledger.did", wasm: "\(env.WASM_DIR)/\(env.LOCAL_PREFIX)ledger.wasm", type: "custom", remote: { id: {mainnet: "mxzaz-hqaaa-aaaar-qaada-cai"} }}
+      { "\(env.LOCAL_PREFIX)kyt" : { build: "true", candid: "\(env.CANDID_DIR)/\(env.LOCAL_PREFIX)kyt.did",  wasm: "\(env.WASM_DIR)/\(env.LOCAL_PREFIX)kyt.wasm",  type: "custom", remote: { id: {mainnet: "pjihx-aaaaa-aaaar-qaaka-cai"} }}
+      , "\(env.LOCAL_PREFIX)ledger": { build: "true", candid: "\(env.CANDID_DIR)/\(env.LOCAL_PREFIX)ledger.did", wasm: "\(env.WASM_DIR)/\(env.LOCAL_PREFIX)ledger.wasm", type: "custom", remote: { id: {mainnet: "mxzaz-hqaaa-aaaar-qaada-cai"} }}
       , "\(env.LOCAL_PREFIX)minter": { build: "true", candid: "\(env.CANDID_DIR)/\(env.LOCAL_PREFIX)minter.did", wasm: "\(env.WASM_DIR)/\(env.LOCAL_PREFIX)minter.wasm", type: "custom", remote: { id: {} }}
       , "\(env.LOCAL_PREFIX)index" : { build: "true", candid: "\(env.CANDID_DIR)/\(env.LOCAL_PREFIX)index.did",  wasm: "\(env.WASM_DIR)/\(env.LOCAL_PREFIX)index.wasm",  type: "custom", remote: { id: {mainnet: "n5wcd-faaaa-aaaar-qaaea-cai"} }}
       }} * .[0]
@@ -58,6 +59,7 @@ ckbtc_import() {
       gunzip "${local_path}.gz"
     fi
   }
+  get_wasm ic-ckbtc-kyt.wasm "${LOCAL_PREFIX}kyt"
   get_wasm ic-ckbtc-minter.wasm "${LOCAL_PREFIX}minter"
   get_wasm ic-icrc1-ledger.wasm "${LOCAL_PREFIX}ledger"
   get_wasm ic-icrc1-index.wasm "${LOCAL_PREFIX}index"
@@ -73,6 +75,7 @@ ckbtc_import() {
     echo "Getting  $local_path from $url..."
     curl -sSLf --retry 5 "$url" -o "$local_path"
   }
+  get_did rs/bitcoin/ckbtc/kyt/kyt.did "${LOCAL_PREFIX}kyt"
   get_did rs/bitcoin/ckbtc/minter/ckbtc_minter.did "${LOCAL_PREFIX}minter"
   get_did rs/rosetta-api/icrc1/ledger/ledger.did "${LOCAL_PREFIX}ledger"
   get_did rs/rosetta-api/icrc1/index/index.did "${LOCAL_PREFIX}index"
@@ -83,7 +86,7 @@ ckbtc_import() {
 # Checks whether ckbtc canisters have already been installed.
 ckbtc_import_check() {
   : Verify that all file are present and correct
-  for canister in minter ledger index; do
+  for canister in kyt minter ledger index; do
     : "Check that the config is in dfx.json:"
     canister_config="$(n="$LOCAL_PREFIX$canister" jq '.canisters[env.n]' dfx.json)"
     [[ "$canister_config" != "null" ]] || {


### PR DESCRIPTION
# Motivation

We want to be able to test ckBTC locally and on CI.
The ckBTC minter calls the KYT (know your transaction?) canister to check if the tokens aren't "tainted".
So we need a KYT canister installed.

# Changes

1. In `bin/dfx-ckbtc-import`, add entries to `dfx.json`, download WASM and download candid for kyt canister. Same as is done for the minter, ledger and index canister.
2. In `bin/dfx-ckbtc-deploy`, create kyt canister, deploy kyt, and set an API key on the canister.
3. Drive-by: Include `index` in the `check_ckbtc_deployment()`. It seems like it might have been forgotten and it doesn't hurt to check.

This is necessary but not sufficient to test ckBTC. We still need to install a (mock) bitcoin canister in a future PR.

# Tested

1. Updated `bin/dfx-ckbtc-deploy.test` in a way consistent with the existing code.
2. Manually ran a snapshot, install a mock bitcoin canister on top of it and tested that I was able to (mock) send BTC.