### PR TITLE
Install mock bitcoin canister

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -100,6 +100,13 @@ jobs:
           git clean -dfx
           bin/dfx-ckbtc-deploy.test
           git clean -dfx
+      - name: Install mock bitcoin canister works
+        run: |
+          set -euxo pipefail
+          echo "This modifies files, so make sure the state is clean before and after"
+          git clean -dfx
+          bin/dfx-software-mock-bitcoin-install.test
+          git clean -dfx
   nns-dapp-canister-checks:
     needs: formatting
     name: NNS dapp tools

--- a/bin/dfx-software-mock-bitcoin-install
+++ b/bin/dfx-software-mock-bitcoin-install
@@ -30,9 +30,12 @@ if [[ "${DFX_IC_COMMIT}" == "pinned" ]]; then
   DFX_IC_COMMIT="$(dfx-software-ic-current)"
 fi
 
+WASM_DIR="wasms"
 WASM_FILE="bitcoin-mock-canister.wasm.gz"
-WASM_PATH="wasms/${WASM_FILE}"
+WASM_PATH="${WASM_DIR}/${WASM_FILE}"
 WASM_URL="https://download.dfinity.systems/ic/${DFX_IC_COMMIT}/canisters/${WASM_FILE}"
+
+mkdir -p "${WASM_DIR}"
 
 echo "Downloading mock bitcoin wasm from ${WASM_URL}"
 curl --retry 5 --fail --silent --show-error --location \

--- a/bin/dfx-software-mock-bitcoin-install
+++ b/bin/dfx-software-mock-bitcoin-install
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+PATH="$SOURCE_DIR:$PATH"
+
+print_help() {
+  cat <<-EOF
+
+	Fetches and installs the mock bitcoin canister:
+	* Downloads the wasm.
+	* Adds the bitcoin canister to dfx.json, if not already present.
+	* Deploys the downloaded wasm to the specified network.
+	EOF
+}
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/clap.bash"
+# Define options
+clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
+clap.define short=c long=ic_commit desc="Commit of the IC repo to download canisters from" variable=DFX_IC_COMMIT default="pinned"
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+
+# The Bitcoin canister is accessed through the virtual management canister
+# and its ID is hard-coded in the execution environment, here:
+# https://github.com/dfinity/ic/blob/bb093eeca3d25b10f5eaa4e5843811c3201c941c/rs/config/src/execution_environment.rs#L100
+HARD_CODED_BITCOIN_CANISTER_ID="ghsi2-tqaaa-aaaan-aaaca-cai"
+
+if [[ "${DFX_IC_COMMIT}" == "pinned" ]]; then
+  DFX_IC_COMMIT="$(dfx-software-ic-current)"
+fi
+
+WASM_FILE="bitcoin-mock-canister.wasm.gz"
+WASM_PATH="wasms/${WASM_FILE}"
+WASM_URL="https://download.dfinity.systems/ic/${DFX_IC_COMMIT}/canisters/${WASM_FILE}"
+
+echo "Downloading mock bitcoin wasm from ${WASM_URL}"
+curl --retry 5 --fail --silent --show-error --location \
+  "${WASM_URL}" >"${WASM_PATH}"
+
+echo "Add an entry for 'bitcoin' in dfx.json if there isn't one already."
+if ! jq -e '.canisters.bitcoin' dfx.json >/dev/null; then
+  echo "Adding bitcoin to dfx.json..."
+  jq -s '.[0] * .[1]' <(echo '{"canisters": { "bitcoin": { "type": "custom", "candid": "candid/bitcoin_mock.did", "wasm": "'"${WASM_PATH}"'", "build": "true" }}}') dfx.json | sponge dfx.json
+fi
+
+if ! dfx canister create bitcoin --network "${DFX_NETWORK}" --specified-id "$HARD_CODED_BITCOIN_CANISTER_ID"; then 
+  echo "Failed to create bitcoin canister." >&2
+  exit 1
+fi
+
+dfx canister install bitcoin --wasm "$WASM_PATH" --upgrade-unchanged --mode reinstall --yes --network "${DFX_NETWORK}" --argument '(variant { mainnet })'
+
+dfx-canister-check-wasm-hash --canister bitcoin --network "$DFX_NETWORK" --wasm "${WASM_PATH}"
+
+echo "Installed mock bitcoin canister."

--- a/bin/dfx-software-mock-bitcoin-install
+++ b/bin/dfx-software-mock-bitcoin-install
@@ -44,7 +44,7 @@ if ! jq -e '.canisters.bitcoin' dfx.json >/dev/null; then
   jq -s '.[0] * .[1]' <(echo '{"canisters": { "bitcoin": { "type": "custom", "candid": "candid/bitcoin_mock.did", "wasm": "'"${WASM_PATH}"'", "build": "true" }}}') dfx.json | sponge dfx.json
 fi
 
-if ! dfx canister create bitcoin --network "${DFX_NETWORK}" --specified-id "$HARD_CODED_BITCOIN_CANISTER_ID"; then 
+if ! dfx canister create bitcoin --network "${DFX_NETWORK}" --specified-id "$HARD_CODED_BITCOIN_CANISTER_ID"; then
   echo "Failed to create bitcoin canister." >&2
   exit 1
 fi

--- a/bin/dfx-software-mock-bitcoin-install.test
+++ b/bin/dfx-software-mock-bitcoin-install.test
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+PATH="$SOURCE_DIR:$PATH"
+
+# The Bitcoin canister is accessed through the virtual management canister
+# and its ID is hard-coded in the execution environment, here:
+# https://github.com/dfinity/ic/blob/bb093eeca3d25b10f5eaa4e5843811c3201c941c/rs/config/src/execution_environment.rs#L100
+HARD_CODED_BITCOIN_CANISTER_ID="ghsi2-tqaaa-aaaan-aaaca-cai"
+
+git checkout dfx.json
+dfx-network-stop
+dfx start --clean --background
+
+trap 'dfx-network-stop' EXIT
+
+if dfx canister metadata "$HARD_CODED_BITCOIN_CANISTER_ID" --network local candid:service; then
+  echo "ERROR: bitcoin canister should not exist before installing."
+  exit 1
+fi
+
+dfx-software-mock-bitcoin-install --network local
+
+# push_utxo_to_address is known method on the mock bitcoin canister.
+if ! dfx canister metadata "$HARD_CODED_BITCOIN_CANISTER_ID" --network local candid:service | grep push_utxo_to_address; then
+  echo "ERROR: mock bitcoin canister should have been installed."
+  exit 1
+fi
+
+echo "PASSED: dfx-software-mock-bitcoin-install.test"

--- a/bin/dfx-stock-deploy
+++ b/bin/dfx-stock-deploy
@@ -27,8 +27,14 @@ source "$(clap.build)"
 set -x
 cd "$(dirname "$(realpath "$0")")/.."
 
+if [[ "${DFX_IC_COMMIT:-}" == "latest" ]]; then
+  DFX_IC_COMMIT="$(dfx-software ic latest --ic_dir "$IC_REPO_DIR")"
+fi
+
 : Set up SNS state and create one finalized SNS
 dfx-sns-demo --network "$DFX_NETWORK" --ic_commit "$DFX_IC_COMMIT" --ic_dir "$IC_REPO_DIR" --nd_dir "$ND_REPO_DIR"
+
+dfx-software-mock-bitcoin-install --network "$DFX_NETWORK" --ic_commit "$DFX_IC_COMMIT"
 
 : Add 1 open SNS project.
 dfx-sns-demo-mksns --network "$DFX_NETWORK" --confirmation_text "I confirm the confirmation text"


### PR DESCRIPTION
# Motivation

We want to be able to test ckBTC locally and on CI.
The ckBTC minter calls the bitcoin canister to check if there are new BTC sent to the user's receiving address.
By using a mock bitcoin canister we can fake receive BTC.

# Changes

1. Add script `bin/dfx-software-mock-bitcoin-install` to download, import and install the mock bitcoin canister.
2. Add script `bin/dfx-software-mock-bitcoin-install.test` which tests that the script installs the mock bitcoin canister at the hard-coded canister ID.
3. Run the test on CI.
4. Find "latest" IC commit in `bin/dfx-stock-deploy` in avoid having to find it multiple times.

# Tested

Created and used a snapshot manually to receive mock BTC locally.
Add a test to CI
