### PR TITLE
Enable ICRC-2 on ckbtc_ledger

### DIFF
--- a/bin/dfx-ckbtc-deploy
+++ b/bin/dfx-ckbtc-deploy
@@ -69,7 +69,7 @@ deploy_ckbtc() {
        ledger_id = principal \"$LEDGERID\";
        ecdsa_key_name = \"dfx_test_key\";
        retrieve_btc_min_amount = 13_333;
-       max_time_in_queue_nanos = 420_000_000_000;
+       max_time_in_queue_nanos = 10_000_000_000;
        min_confirmations = opt 12;
        mode = variant { GeneralAvailability };
        kyt_fee = opt 13_333;
@@ -92,6 +92,9 @@ deploy_ckbtc() {
          trigger_threshold = 20_000;
          controller_id = principal \"$DFX_IDENTITY_PRINCIPAL\";
          cycles_for_archive_creation = opt 4_000_000_000_000;
+     };
+     feature_flags = opt record {
+         icrc2 = true;
      };
  }
 })" --mode="$DFX_MODE" ${DFX_YES:+--yes} --upgrade-unchanged


### PR DESCRIPTION
# Motivation

We want to use ICRC-2 for BTC withdrawal.
The ICRC-1 ledger canister does not yet have ICRC-2 enabled by default.
It's behind a feature flag.

# Change

1. Enable the ICRC-2 feature flag when installing the `ckbtc_ledger` canister.
2. Drive-by: Reduce the time that the `ckbtc_minter` waits before sending out BTC. This is 20 minutes by default, for snsdemo it was set to 7 minutes, but I'm reducing it to 10 seconds. This makes it easier to verify that a BTC withdrawal actually resulted in a call to the bitcoin canister.

# Tested

Created a snapshot and ran it to manually make a mock BTC deposit (in the NNS-dapp UI) and ICRC-2 withdrawal (with `dfx canister call`s).