### PR TITLE
Don't skip downloading ckBTC wasms.

### DIFF
--- a/bin/dfx-ckbtc-import
+++ b/bin/dfx-ckbtc-import
@@ -52,8 +52,7 @@ ckbtc_import() {
     local_path="$(c="$local_name" jq -re '.canisters[env.c].wasm' dfx.json)"
     url="https://download.dfinity.systems/ic/$DFX_IC_COMMIT/canisters/${remote_name}.gz"
     echo "Getting  $local_path from $url..."
-    curl -sSL "$url" -o "${local_path}.gz"
-    gunzip "${local_path}.gz"
+    curl -fsSL "$url" | gunzip > "${local_path}"
   }
   get_wasm ic-ckbtc-kyt.wasm "${LOCAL_PREFIX}kyt"
   get_wasm ic-ckbtc-minter.wasm "${LOCAL_PREFIX}minter"

--- a/bin/dfx-ckbtc-import
+++ b/bin/dfx-ckbtc-import
@@ -52,7 +52,7 @@ ckbtc_import() {
     local_path="$(c="$local_name" jq -re '.canisters[env.c].wasm' dfx.json)"
     url="https://download.dfinity.systems/ic/$DFX_IC_COMMIT/canisters/${remote_name}.gz"
     echo "Getting  $local_path from $url..."
-    curl -fsSL "$url" | gunzip > "${local_path}"
+    curl -fsSL "$url" | gunzip >"${local_path}"
   }
   get_wasm ic-ckbtc-kyt.wasm "${LOCAL_PREFIX}kyt"
   get_wasm ic-ckbtc-minter.wasm "${LOCAL_PREFIX}minter"

--- a/bin/dfx-ckbtc-import
+++ b/bin/dfx-ckbtc-import
@@ -50,14 +50,10 @@ ckbtc_import() {
     remote_name="$1"
     local_name="$2"
     local_path="$(c="$local_name" jq -re '.canisters[env.c].wasm' dfx.json)"
-    if test -e "$local_path"; then
-      echo "Skipping $local_path as it already exists"
-    else
-      url="https://download.dfinity.systems/ic/$DFX_IC_COMMIT/canisters/${remote_name}.gz"
-      echo "Getting  $local_path from $url..."
-      curl -sSL "$url" -o "${local_path}.gz"
-      gunzip "${local_path}.gz"
-    fi
+    url="https://download.dfinity.systems/ic/$DFX_IC_COMMIT/canisters/${remote_name}.gz"
+    echo "Getting  $local_path from $url..."
+    curl -sSL "$url" -o "${local_path}.gz"
+    gunzip "${local_path}.gz"
   }
   get_wasm ic-ckbtc-kyt.wasm "${LOCAL_PREFIX}kyt"
   get_wasm ic-ckbtc-minter.wasm "${LOCAL_PREFIX}minter"


### PR DESCRIPTION
# Motivation

We don't know the version of the existing wasms and we should make sure the installed ckBTC wasms match the specified IC commit.

# Changes

1. Remove the code that skips downloading ckBTC wasms if the file already exists.
2. Write output from `curl` with `>` instead of `-o` to directly overwrite existing files.

# Tests

Manually created a stock snapshot in a directory that had pre-existing wasms.