### PR TITLE
Make number of parallel SNSes configurable

### DIFF
--- a/bin/dfx-snapshot-stock-make
+++ b/bin/dfx-snapshot-stock-make
@@ -16,6 +16,7 @@ source "$SOURCE_DIR/clap.bash"
 clap.define short=s long=snapshot desc="The file to save to" variable=DFX_SNAPSHOT_FILE default="stock-snsdemo-snapshot.tar.xz"
 clap.define short=c long=ic_commit desc="The IC commit to use" variable=DFX_IC_COMMIT default="$(dfx-software ic current)"
 clap.define short=x long=ic_dir desc="Directory containing the ic source code; needed for deployments to static testnets" variable=IC_REPO_DIR default="$HOME/dfn/ic"
+clap.define long=parallel_sns_count desc="Number of additional SNSes to create in parallel after dfx-sns-demo finishes" variable=PARALLEL_SNS_COUNT default="10"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
@@ -31,10 +32,11 @@ onSetupFailure() {
 trap onSetupFailure EXIT
 
 : Create stock state
-dfx-stock-deploy --ic_commit "$DFX_IC_COMMIT" --ic_dir "$IC_REPO_DIR"
+dfx-stock-deploy --ic_commit "$DFX_IC_COMMIT" --ic_dir "$IC_REPO_DIR" --parallel_sns_count "$PARALLEL_SNS_COUNT"
 
 : "Wait for aggregator to get all SNSs"
-dfx-sns-aggregator-wait --num_sns 12
+# 2 SNSes were created by dfx-sns-demo.
+dfx-sns-aggregator-wait --num_sns "$((2 + PARALLEL_SNS_COUNT))"
 
 : "Wait for a checkpoint"
 dfx-network-wait-for-checkpoint --timeout 600

--- a/bin/dfx-sns-aggregator-wait
+++ b/bin/dfx-sns-aggregator-wait
@@ -70,7 +70,7 @@ get_sns_count() {
     {
       aggregator_url="http://$(dfx canister id sns_aggregator).localhost:8080/v1/sns/list/page/$page/slow.json"
       curl -fsS "$aggregator_url" | jq length
-    } 2>/dev/null || true
+    } || true
   done | awk '{i+=$1}END{print i}'
 }
 

--- a/bin/dfx-stock-deploy
+++ b/bin/dfx-stock-deploy
@@ -22,6 +22,7 @@ clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETW
 clap.define short=c long=ic_commit desc="The IC commit to use" variable=DFX_IC_COMMIT default="$(dfx-software ic current)"
 clap.define short=x long=ic_dir desc="Directory containing the ic source code; needed for deployments to static testnets" variable=IC_REPO_DIR default="$HOME/dfn/ic"
 clap.define short=y long=nd_dir desc="Directory containing the nns-dapp source code; needed for deployments to static testnets" variable=ND_REPO_DIR default="$HOME/dfn/nns-dapp"
+clap.define long=parallel_sns_count desc="Number of additional SNSes to create in parallel after dfx-sns-demo finishes" variable=PARALLEL_SNS_COUNT default="10"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 set -x
@@ -39,8 +40,10 @@ dfx-software-mock-bitcoin-install --network "$DFX_NETWORK" --ic_commit "$DFX_IC_
 : Add 1 open SNS project.
 dfx-sns-demo-mksns --network "$DFX_NETWORK" --confirmation_text "I confirm the confirmation text"
 
-: Add 10 more finalized SNS projects.
-dfx-sns-demo-mksns-parallel --network "$DFX_NETWORK" --num_sns 10 --majority snsdemo8
+: Add some more finalized SNS projects.
+if [ "${PARELLEL_SNS_COUNT:-0}" -gt 0 ]; then
+  dfx-sns-demo-mksns-parallel --network "$DFX_NETWORK" --num_sns "$PARALLEL_SNS_COUNT" --majority snsdemo8
+fi
 
 : Set up ckbtc canisters
 dfx-ckbtc-import --prefix ckbtc_

--- a/bin/dfx-stock-deploy
+++ b/bin/dfx-stock-deploy
@@ -41,7 +41,7 @@ dfx-software-mock-bitcoin-install --network "$DFX_NETWORK" --ic_commit "$DFX_IC_
 dfx-sns-demo-mksns --network "$DFX_NETWORK" --confirmation_text "I confirm the confirmation text"
 
 : Add some more finalized SNS projects.
-if [ "${PARELLEL_SNS_COUNT:-0}" -gt 0 ]; then
+if [ "${PARALLEL_SNS_COUNT:-0}" -gt 0 ]; then
   dfx-sns-demo-mksns-parallel --network "$DFX_NETWORK" --num_sns "$PARALLEL_SNS_COUNT" --majority snsdemo8
 fi
 


### PR DESCRIPTION
# Motivation

When making changes to the snapshot setup or if you just don't need 12 SNSes, it can be useful to configure the number of SNSes included in the snapshot to make it faster.

# Changes

1. Add flag `--parallel_sns_count` to `bin/dfx-snapshot-stock-make` and `bin/dfx-stock-deploy`. Note that `dfx-sns-demo` always creates 2 SNSes so the flag controls the number of additional SNSes (which are created in parallel) created after that.
2. Unrelated-ish: Don't hide errors when trying to count the number of SNSes.

# Tested

Manually tested with `--parallel_sns_count 3` and `--parallel_sns_count 0`.