### PR TITLE
feat: Make snapshots weekly

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -2,6 +2,8 @@ name: Create a snapshot image
 on:
   push:
   workflow_dispatch:
+  schedule:
+    - cron: '30 3 * * WED'
 env:
   GH_TOKEN: ${{ github.token }}
   TEST_RELEASE_PROCESS: false # Set to true if you wish to exercise github triggers without spending time creating real artefacts.
@@ -15,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Create snapshot
         id: snapshot
         run: |
@@ -35,6 +39,18 @@ jobs:
         run: bin/dfx-stock-test
       - name: Stop dfx
         run: dfx stop
+      - name: Tag if run on a schedule
+        if: ${{ github.event_name == 'schedule' }}
+        id: tag
+        run: |
+          tag_name="$(date +release-%Y-%m-%d)"
+          if git tag -l "${tag_name}"
+          then
+          echo "There is already a tag for today's release: ${tag_name}"
+          else
+            git tag "${tag_name}"
+            git push origin "refs/tags/${tag_name}"
+          fi
       - name: Release if applicable
         run: |
           set -x


### PR DESCRIPTION
# Motivation
We wish to automate updates.  There are workflows to update the snsdemo automatically, however there is not (yet) a workflow to make releases regularly, so the nns-dapp does not benefit much from this automated schedule.

As an additional motivation, SNSs now have a shorter maximum time in the open state, so if we wish a snapshot to contain open SNSs we need to update reasonably frequently.

# Changes
- Run the snapshot workflow periodically

# Tests
Unfortunately schedules can only be run on schedule!