### PR TITLE
feat: Use static

### DIFF
--- a/bin/dfx-software-ic-install-executable
+++ b/bin/dfx-software-ic-install-executable
@@ -15,7 +15,7 @@ clap.define short=b long=bin desc="Diectory in which to install the executeble" 
 source "$(clap.build)"
 
 install_linux() {
-  URL="https://download.dfinity.systems/ic/${DFX_IC_COMMIT}/binaries/x86_64-linux/${EXEC_NAME}.gz"
+  URL="https://download.dfinity.systems/ic/${DFX_IC_COMMIT}/openssl-static-binaries/x86_64-linux/${EXEC_NAME}.gz"
   echo "Downloading $URL"
   curl -fL "$URL" | gunzip | install -m 755 /dev/stdin "$USER_BIN/$EXEC_NAME"
 }


### PR DESCRIPTION
# Motivation
Native builds of `ic-admin` do not work on the `DevEnv` linux machines, even though they run Ubuntu 22.04.

# Changes
- Use utilities that have been built with statically linked openssl

# Tests
See CI
