### PR TITLE
Update IC commit

### DIFF
--- a/bin/versions.bash
+++ b/bin/versions.bash
@@ -2,7 +2,7 @@
 # shellcheck disable=SC2034 # Variables are expected to be unused in this file
 # Release from 2023-05-30 which includes geo restriction fields
 SNS_AGGREGATOR_RELEASE=proposal-123011-agg
-DFX_IC_COMMIT=2e3589427cd9648d4edaebc1b96b5daf8fdd94d8
+DFX_IC_COMMIT=9d81e96b8e31269866d57617f4babf52e9944074
 INTERNET_IDENTITY_RELEASE=release-2023-10-27
 NNS_DAPP_RELEASE=proposal-121690
 DIDC_VERSION=2023-07-25


### PR DESCRIPTION
# Motivation
Static builds of ic-admin were broken, apparently from Oct 19 onwards, but in the latest published commit the static build seems to be fine:

```
max@devenv-max:~$ curl https://download.dfinity.systems/ic/9d81e96b8e31269866d57617f4babf52e9944074/openssl-static-binaries/x86_64-linux/ic-admin.gz | gunzip | install -m 755 /dev/stdin ~/.local/ic-admin
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 10.0M  100 10.0M    0     0  20.2M      0 --:--:-- --:--:-- --:--:-- 20.1M
max@devenv-max:~$ ~/.local/ic-admin --version
ic-admin 1.0
```
I can confirm that this did not previously work:
```
max@devenv-max:~$ curl https://download.dfinity.systems/ic/2e3589427cd9648d4edaebc1b96b5daf8fdd94d8/openssl-static-binaries/x86_64-linux/ic-admin.gz | gunzip | install -m 755 /dev/stdin ~/.local/ic-admin
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 8797k  100 8797k    0     0  15.1M      0 --:--:-- --:--:-- --:--:-- 15.1M
max@devenv-max:~$ 
max@devenv-max:~$ ~/.local/ic-admin --version
/home/max/.local/ic-admin: error while loading shared libraries: libssl.so.1.1: cannot open shared object file: No such file or directory
max@devenv-max:~$ 
```

# Changes
- Update the commit of the IC repo used in the demo.