### PR TITLE
Create dfx entry if needed

### DIFF
--- a/bin/dfx-nns-import
+++ b/bin/dfx-nns-import
@@ -45,9 +45,17 @@ export DFX_NETWORK
 # works as long as the .did files are not moved in the ic repo.
 DFX_IC_COMMIT="$DFX_IC_COMMIT" dfx nns import --network-mapping "$DFX_NETWORK=mainnet"
 
-# Update the II candid
-# Note: We need to get the correct .did file for II, as `dfx nns install` provides only an old, essentially empty, file.
-curl -sSL --fail --retry 5 "https://raw.githubusercontent.com/dfinity/internet-identity/${INTERNET_IDENTITY_RELEASE}/src/internet_identity/internet_identity.did" -o "$(jq -r .canisters.internet_identity.candid dfx.json)"
+# Install II candid
+# Note:
+# - In `dfx v0.14` `dfx nns import` provides the candid for II, but we update the canister and have to update the candid to  match.
+# - In `dfx v0.15.1` `dfx nns import` no longer provides a candid for II and doesn't create an entry for the candid path in `dfx.json`.  This is possibly a bug.
+II_CANDID_PATH="$(jq -r .canisters.internet_identity.candid dfx.json)"
+test -n "${II_CANDID_PATH:-}" || {
+  II_CANDID_PATH="candid/internet_identity.did"
+  mkdir -p "$(dirname "$II_CANDID_PATH")"
+  II_CANDID_PATH="$II_CANDID_PATH" jq '.canisters.internet_identity.candid = (env.II_CANDID_PATH)' dfx.json | sponge dfx.json
+}
+curl -sSL --fail --retry 5 "https://raw.githubusercontent.com/dfinity/internet-identity/${INTERNET_IDENTITY_RELEASE}/src/internet_identity/internet_identity.did" -o "$II_CANDID_PATH"
 
 # Provide the correct frontend canister IDs
 set_remote() {

--- a/bin/dfx-nns-import
+++ b/bin/dfx-nns-import
@@ -49,12 +49,24 @@ DFX_IC_COMMIT="$DFX_IC_COMMIT" dfx nns import --network-mapping "$DFX_NETWORK=ma
 # Note:
 # - In `dfx v0.14` `dfx nns import` provides the candid for II, but we update the canister and have to update the candid to  match.
 # - In `dfx v0.15.1` `dfx nns import` no longer provides a candid for II and doesn't create an entry for the candid path in `dfx.json`.  This is possibly a bug.
+
+# ... Make sure that there is an entry for the `internet_identity` cainster in `dfx.json`
+jq -e .canisters.internet_identity dfx.json >/dev/null || {
+  jq '.canisters.internet_identity = {
+      "build": "",
+      "candid": "candid/internet_identity.did",
+      "type": "custom",
+      "wasm": ""
+    }'
+}
+# ... Make sure that the internet_identity candid path is declared
 II_CANDID_PATH="$(jq -r .canisters.internet_identity.candid dfx.json)"
 test -n "${II_CANDID_PATH:-}" || {
   II_CANDID_PATH="candid/internet_identity.did"
   mkdir -p "$(dirname "$II_CANDID_PATH")"
   II_CANDID_PATH="$II_CANDID_PATH" jq '.canisters.internet_identity.candid = (env.II_CANDID_PATH)' dfx.json | sponge dfx.json
 }
+# ... Get the updated candid
 curl -sSL --fail --retry 5 "https://raw.githubusercontent.com/dfinity/internet-identity/${INTERNET_IDENTITY_RELEASE}/src/internet_identity/internet_identity.did" -o "$II_CANDID_PATH"
 
 # Provide the correct frontend canister IDs


### PR DESCRIPTION
# Motivation
`dfx nns import` is supposed to create entries for all the NNS canisters in the local `dfx.json`.  Unfortunately with `dfx v0.15.1` the II candid is not installed and the canister is missing from `dfx.json`.  We replace the candid file with a newer version anyway, that is not a problem, but we _do_ need the entry in `dfx.json`.

Note: I tested the behaviour of `dfx nns import` for versions `0.14.4` and `0.15.1` in clean new projects (created with `dfx new PROJECT_NAME`).  This behaviour is in no way specific to the use in the snsdemo repository.

# Changes
- When updating the II candid, ensure that the path to the candid file is also listed in `dfx.json`.

# Tests
- For `dfx 0.14.4` see the CI for this PR.
- For `dfx 0.15.1` see the CI for the PR that updates dfx to `0.15.1`.