### PR TITLE
Make the current user a controller of the II and nns-dapp

### DIFF
--- a/bin/dfx-nns-install
+++ b/bin/dfx-nns-install
@@ -61,3 +61,19 @@ curl --fail --location "$NEW_LIFELINE_WASM_URL" -o "$OLD_LIFELINE_FILE" || true
 
 export DFX_IC_COMMIT
 dfx nns install
+
+
+# As of dfx 0.15, the current user is no longer a controller of the internet_identity and nns-dapp canisters.
+# The current user needs to be added explicitly.
+CURRENT_PRINCIPAL="$(dfx identity get-principal)"
+# ... `dfx nns install` does not populate canister IDs in `dfx.json` so we need to provide the canister IDs ourselves.
+II_CANISTER_ID=qhbym-qaaaa-aaaaa-aaafq-cai
+ND_CANISTER_ID=qsgjb-riaaa-aaaaa-aaaga-cai
+for canister in "$II_CANISTER_ID" "$ND_CANISTER_ID"; do
+  # If the current user is not already a controller...
+  dfx canister info "$canister" | awk '($1 == "Controllers:")' | grep -w "$CURRENT_PRINCIPAL" || {
+    # ... this is presumably dfx v0.15.1 or later and the anonymous user is a controller
+    # and can add the current user:
+    dfx canister update-settings "$canister" --add-controller "$CURRENT_PRINCIPAL" --identity anonymous
+  }
+done

--- a/bin/dfx-nns-install
+++ b/bin/dfx-nns-install
@@ -62,7 +62,6 @@ curl --fail --location "$NEW_LIFELINE_WASM_URL" -o "$OLD_LIFELINE_FILE" || true
 export DFX_IC_COMMIT
 dfx nns install
 
-
 # As of dfx 0.15, the current user is no longer a controller of the internet_identity and nns-dapp canisters.
 # The current user needs to be added explicitly.
 CURRENT_PRINCIPAL="$(dfx identity get-principal)"


### PR DESCRIPTION
# Motivation
In `dfx v0.14.4`, `dfx nns deploy` would create the `internet_identity` and `nns-dapp` canisters with the current user as the controller.  In `dfx v0.15.1` the anonymous user is the controller, which is a breaking change.

# Changes
- Check whether the current user is a controller and if not, use the anonymous user to add the current user as a controller.

# Tests
- For `dfx v0.14.4` see CI in the current PR.
- For `dfx v0.15.1` see [the PR that updates `dfx` to `v0.51.1`](https://github.com/dfinity/snsdemo/pull/262).