### PR TITLE
Fix dfx-nns-import

### DIFF
--- a/bin/dfx-nns-import
+++ b/bin/dfx-nns-import
@@ -51,14 +51,12 @@ DFX_IC_COMMIT="$DFX_IC_COMMIT" dfx nns import --network-mapping "$DFX_NETWORK=ma
 # - In `dfx v0.15.1` `dfx nns import` no longer provides a candid for II and doesn't create an entry for the candid path in `dfx.json`.  This is possibly a bug.
 
 # ... Make sure that there is an entry for the `internet_identity` cainster in `dfx.json`
-jq -e .canisters.internet_identity dfx.json >/dev/null || {
-  jq '.canisters.internet_identity = {
-      "build": "",
-      "candid": "candid/internet_identity.did",
-      "type": "custom",
-      "wasm": ""
-    }'
-}
+jq '.canisters.internet_identity //= {
+    "build": "",
+    "candid": "candid/internet_identity.did",
+    "type": "custom",
+    "wasm": ""
+  }' dfx.json | sponge dfx.json
 # ... Make sure that the internet_identity candid path is declared
 II_CANDID_PATH="$(jq -r .canisters.internet_identity.candid dfx.json)"
 test -n "${II_CANDID_PATH:-}" || {


### PR DESCRIPTION
# Motivation

In `dfx-nns-import` on [this line](https://github.com/dfinity/snsdemo/blob/24dc8ca57747853201895a496e9bceabf4fb4277/bin/dfx-nns-import#L55), `jq` waits for input.
The comment says an entry for `internet_identity` is added to `dfx.json` but that line doesn't do anything with `dfx.json`.
This code was added in https://github.com/dfinity/snsdemo/pull/269 and apparently not tested manually.
On CI the user input is apparently automatically closed so the script is able to continue.
It will then rely on the fallback on line 64 to still get internet_identity candid.

# Changes

Actually update `dfx.json` instead of waiting for user input.
`//` is the alternative operator: https://jqlang.github.io/jq/manual/#alternative-operator
So `//=` only assigns if there isn't already a value.