### PR TITLE
Fix: short form was repeated

### DIFF
--- a/bin/dfx-software-didc-version
+++ b/bin/dfx-software-didc-version
@@ -16,6 +16,7 @@ source "$SOURCE_DIR/clap.bash"
 # Define options
 clap.define short=p long=pinned desc="Get the pinned version from versions.bash" variable=GET_PINNED nargs=0
 clap.define short=l long=latest desc="Get the latest version" variable=GET_LATEST nargs=0
+clap.define short=v long=version desc="Get a named version.  Common options: pinned latest" variable=STRATEGY
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 

--- a/bin/dfx-software-internet-identity-version
+++ b/bin/dfx-software-internet-identity-version
@@ -15,6 +15,7 @@ clap.define short=n long=network desc="Get the version deployed on the given net
 clap.define short=c long=canister desc="Get the version deployed to the given canster of the specified network" variable=CANISTER
 clap.define short=m long=mainnet desc="Get the version deployed in production" variable=GET_MAINNET nargs=0
 clap.define short=h long=hash desc="Get the version of a given hash" variable=GET_HASH
+clap.define short=v long=version desc="Get a named version.  Common options: pinned latest mainnet" variable=STRATEGY
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 

--- a/bin/dfx-software-internet-identity-version
+++ b/bin/dfx-software-internet-identity-version
@@ -9,7 +9,7 @@ export DFX_NETWORK=""
 # Source the clap.bash file ---------------------------------------------------
 source "$SOURCE_DIR/clap.bash"
 # Define options
-clap.define short=l long=pinned desc="Get the pinned version from versions.bash" variable=GET_PINNED nargs=0
+clap.define short=p long=pinned desc="Get the pinned version from versions.bash" variable=GET_PINNED nargs=0
 clap.define short=l long=latest desc="Get the latest version" variable=GET_LATEST nargs=0
 clap.define short=n long=network desc="Get the version deployed on the given network" variable=DFX_NETWORK default=""
 clap.define short=c long=canister desc="Get the version deployed to the given canster of the specified network" variable=CANISTER

--- a/bin/dfx-software-nns-dapp-version
+++ b/bin/dfx-software-nns-dapp-version
@@ -18,7 +18,7 @@ print_help() {
 # Source the clap.bash file ---------------------------------------------------
 source "$SOURCE_DIR/clap.bash"
 # Define options
-clap.define short=l long=pinned desc="Get the pinned version from versions.bash (default)" variable=GET_PINNED nargs=0
+clap.define short=p long=pinned desc="Get the pinned version from versions.bash (default)" variable=GET_PINNED nargs=0
 clap.define short=l long=latest desc="Get the latest version" variable=GET_LATEST nargs=0
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"

--- a/bin/dfx-software-nns-dapp-version
+++ b/bin/dfx-software-nns-dapp-version
@@ -20,6 +20,7 @@ source "$SOURCE_DIR/clap.bash"
 # Define options
 clap.define short=p long=pinned desc="Get the pinned version from versions.bash (default)" variable=GET_PINNED nargs=0
 clap.define short=l long=latest desc="Get the latest version" variable=GET_LATEST nargs=0
+clap.define short=v long=version desc="Get a named version.  Common options: pinned latest" variable=STRATEGY
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 

--- a/bin/dfx-software-sns-aggregator-version
+++ b/bin/dfx-software-sns-aggregator-version
@@ -18,7 +18,7 @@ print_help() {
 # Source the clap.bash file ---------------------------------------------------
 source "$SOURCE_DIR/clap.bash"
 # Define options
-clap.define short=l long=pinned desc="Get the pinned version from versions.bash (default)" variable=GET_PINNED nargs=0
+clap.define short=p long=pinned desc="Get the pinned version from versions.bash (default)" variable=GET_PINNED nargs=0
 clap.define short=l long=latest desc="Get the latest version" variable=GET_LATEST nargs=0
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"

--- a/bin/dfx-software-sns-aggregator-version
+++ b/bin/dfx-software-sns-aggregator-version
@@ -20,6 +20,7 @@ source "$SOURCE_DIR/clap.bash"
 # Define options
 clap.define short=p long=pinned desc="Get the pinned version from versions.bash (default)" variable=GET_PINNED nargs=0
 clap.define short=l long=latest desc="Get the latest version" variable=GET_LATEST nargs=0
+clap.define short=v long=version desc="Get a named version.  Common options: pinned latest" variable=STRATEGY
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 


### PR DESCRIPTION
# Motivation
The flag `-l` was ambiguous in some `bin/dfx-software-.*-version` commands, with several options having the same short form.

There is a risk of "just changing the flag" but in a way that makes the flags inconsistent or confusing so I reviewed all these flags. This convention seems to make sense and is mostly consistent with what we already have:

* `-l --latest` The latest release.
* `-m --mainnet` The version deployed on mainnet.
* `-p --pinned` The version in bin/versions.bash
* `-v --version` A named release, such as "latest".  Enables passing through a version from one command to the next by name rather than with lots of different flags.

# Changes
* Change the short form for "pinned" to not conflict.
* Implement the above convention consistently.

# Tests
I have searched for usages of `dfx-software-.*-version` and found that all uses in `snsdemo` and `nns-dapp` use the long form, so changing the short flags will not affect CI.  It may affect command line usage - that is where I personally use short flags most frequently.