### PR TITLE
Avoid using decimal comma on machines with different locale

### DIFF
--- a/bin/dfx-sns-transfer-to-faucet
+++ b/bin/dfx-sns-transfer-to-faucet
@@ -32,7 +32,7 @@ FEE_E8S="$(dfx canister call "$LEDGER_CANISTER_ID" icrc1_fee '(record
 
 from_e8s() {
   amount_e8s="$1"
-  amount="$(awk "BEGIN {printf \"%.8f\", $amount_e8s * 0.00000001}")"
+  amount="$(LC_NUMERIC="C" awk "BEGIN {printf \"%.8f\", $amount_e8s * 0.00000001}")"
   echo "$amount"
 }
 


### PR DESCRIPTION
# Motivation

This error was reported:
```
/Users/daviddalbusco/.config/dfx/identity/snsdemo8/identity.pem transfer --amount 5001570,49997000 --fee 0,00001000 jg6qm-uw64t-m6ppo-oluwn-ogr5j-dc5pm-lgy2p-eh6px-hebcd-5v73i-nqe
error: Invalid value "5001570,49997000" for '--amount <AMOUNT>': Failed to parse tokens as unsigned integer
```
which seems to happen because a `awk` output a decimal comma instead of a decimal point.

This PR might fix it for the line where the error happened but I'm not sure (actually I would expect it) if there are other places that would have the same problem.