### PR TITLE
Scripts to deploy generic token

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -104,6 +104,20 @@ jobs:
           git clean -dfx
           bin/dfx-ckbtc-deploy.test
           git clean -dfx
+      - name: Import token works
+        run: |
+          set -euxo pipefail
+          echo "This modifies files, so make sure the state is clean before and after"
+          git clean -dfx
+          bin/dfx-token-import.test
+          git clean -dfx
+      - name: Deploy token works
+        run: |
+          set -euxo pipefail
+          echo "This modifies files, so make sure the state is clean before and after"
+          git clean -dfx
+          bin/dfx-token-deploy.test
+          git clean -dfx
       - name: Install mock bitcoin canister works
         run: |
           set -euxo pipefail

--- a/bin/dfx-ckbtc-deploy
+++ b/bin/dfx-ckbtc-deploy
@@ -25,6 +25,10 @@ clap.define short=m long=mode desc="Canister install mode." variable=DFX_MODE de
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
+# TODO: Consider using ./bin/dfx-token-deploy for the ledger and index
+# canisters. KYT and minter are custom canisters, so they still need to be done
+# here.
+
 : Check preconditions. This is always run.
 "${SOURCE_DIR}/dfx-ckbtc-import" --check --prefix "$LOCAL_PREFIX" || {
   echo "ERROR: ckbtc canister data and files are not all present and correct."

--- a/bin/dfx-ckbtc-import
+++ b/bin/dfx-ckbtc-import
@@ -23,6 +23,10 @@ clap.define long=candid_dir desc="Where to store the imported candid files" vari
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
+# TODO: Consider using ./bin/dfx-token-import for the ledger and index
+# canisters. KYT and minter are custom canisters, so they still need to be done
+# here.
+
 # Imports wasm, candid and populate dfx.json
 ckbtc_import() {
   test -e dfx.json || {

--- a/bin/dfx-token-deploy
+++ b/bin/dfx-token-deploy
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Original source: https://github.com/dfinity/ckBTC-Minter-Frontend/blob/master/local_deploy.sh
+# Via:             https://github.com/dfinity/nns-dapp/blob/main/scripts/ckbtc/deploy-ckbtc
+set -euo pipefail
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+PATH="$SOURCE_DIR:$PATH"
+. "$SOURCE_DIR/versions.bash"
+
+print_help() {
+  cat <<-EOF
+
+	Installs ckbtc canisters.
+
+	EOF
+}
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/clap.bash"
+# Define options
+clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
+clap.define short=p long=prefix desc="Prefix for the local canister names" variable=LOCAL_PREFIX default="ckbtc_"
+clap.define short=y long=yes desc="Deploy even if there are existing ckbtc canisters." variable=DFX_YES nargs=0
+clap.define short=c long=check desc="Check that the canisters are present and correct." variable=DFX_CHECK nargs=0
+clap.define short=m long=mode desc="Canister install mode." variable=DFX_MODE default="reinstall"
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+
+: Check preconditions. This is always run.
+"${SOURCE_DIR}/dfx-ckbtc-import" --check --prefix "$LOCAL_PREFIX" || {
+  echo "ERROR: ckbtc canister data and files are not all present and correct."
+  echo "       Please run:"
+  echo "       dfx-ckbtc-import --prefix '$LOCAL_PREFIX'"
+  echo
+  exit 1
+} >&2
+
+deploy_ckbtc() {
+  # We create some canisters ahead of time because we need to know their IDs
+  # before deploying. Remaining canisters will be created when deployed.
+  dfx canister create "${LOCAL_PREFIX}kyt" --network "$DFX_NETWORK" || echo "${LOCAL_PREFIX}kyt canister already exists"
+  dfx canister create "${LOCAL_PREFIX}ledger" --network "$DFX_NETWORK" || echo "${LOCAL_PREFIX}ledger canister already exists"
+  dfx canister create "${LOCAL_PREFIX}minter" --network "$DFX_NETWORK" || echo "${LOCAL_PREFIX}minter canister already exists"
+
+  KYT_ID="$(dfx canister id "${LOCAL_PREFIX}kyt" --network "$DFX_NETWORK")"
+  echo "$KYT_ID"
+  MINTERID="$(dfx canister id "${LOCAL_PREFIX}minter" --network "$DFX_NETWORK")"
+  echo "$MINTERID"
+  LEDGERID="$(dfx canister id "${LOCAL_PREFIX}ledger" --network "$DFX_NETWORK")"
+  echo "$LEDGERID"
+
+  # echo "Step 1: deploying kyt canister..."
+  DFX_IDENTITY_PRINCIPAL="$(dfx identity get-principal)"
+  dfx deploy "${LOCAL_PREFIX}kyt" --network "$DFX_NETWORK" --argument "(variant {
+  InitArg = record {
+      minter_id = principal \"$MINTERID\";
+      maintainers = vec { principal \"$DFX_IDENTITY_PRINCIPAL\" };
+      mode = variant { AcceptAll };
+  }
+})" --mode="${DFX_MODE}" ${DFX_YES:+--yes} --upgrade-unchanged
+
+  # We use mode AcceptAll so the API key is not used, but without API key the
+  # KYT canister will refuse to accept any UTXOs.
+  dfx canister call "${LOCAL_PREFIX}kyt" --network "$DFX_NETWORK" set_api_key '( record { api_key = "placeholder" } )'
+
+  # echo "Step 2: deploying minter canister..."
+  dfx deploy "${LOCAL_PREFIX}minter" --network "$DFX_NETWORK" --argument "(variant {
+  Init = record {
+       btc_network = variant { Mainnet };
+       ledger_id = principal \"$LEDGERID\";
+       ecdsa_key_name = \"dfx_test_key\";
+       retrieve_btc_min_amount = 13_333;
+       max_time_in_queue_nanos = 10_000_000_000;
+       min_confirmations = opt 12;
+       mode = variant { GeneralAvailability };
+       kyt_fee = opt 13_333;
+       kyt_principal = opt principal \"$KYT_ID\";
+   }
+})" --mode="${DFX_MODE}" ${DFX_YES:+--yes} --upgrade-unchanged
+
+  echo "Step 3: deploying ledger canister..."
+  dfx deploy "${LOCAL_PREFIX}ledger" --network "$DFX_NETWORK" --argument "(variant {
+  Init = record {
+     token_symbol = \"ckBTC\";
+     token_name = \"Token ckBTC\";
+     minting_account = record { owner = principal \"$MINTERID\" };
+     transfer_fee = 10;
+     max_memo_length = opt 64;
+     metadata = vec {};
+     initial_balances = vec { record { record { owner = principal \"$DFX_IDENTITY_PRINCIPAL\"; }; 10_000_000; }; };
+     archive_options = record {
+         num_blocks_to_archive = 10_000;
+         trigger_threshold = 20_000;
+         controller_id = principal \"$DFX_IDENTITY_PRINCIPAL\";
+         cycles_for_archive_creation = opt 4_000_000_000_000;
+     };
+     feature_flags = opt record {
+         icrc2 = true;
+     };
+ }
+})" --mode="$DFX_MODE" ${DFX_YES:+--yes} --upgrade-unchanged
+
+  echo "Step 4: deploying index canister..."
+  dfx deploy "${LOCAL_PREFIX}index" --network "$DFX_NETWORK" --argument "(record { ledger_id = principal \"$LEDGERID\" })" --mode="${DFX_MODE}" ${DFX_YES:+--yes} --upgrade-unchanged
+
+  # Example to mint ckBTC
+
+  # BTCADDRESS="$(dfx canister call "${LOCAL_PREFIX}minter" get_btc_address '(record {subaccount=null;})')"
+  # dfx canister call "${LOCAL_PREFIX}minter" update_balance '(record {subaccount=null;})'
+  # WITHDRAWALADDRESS="$(dfx canister call "${LOCAL_PREFIX}minter" get_withdrawal_account)"
+  # echo $BTCADDRESS
+  # echo $WITHDRAWALADDRESS
+  #
+  # cleaned_output=$(echo $WITHDRAWALADDRESS | sed -re 's/^\(|, \)$//g')
+  #
+  # dfx canister call "${LOCAL_PREFIX}ledger" icrc1_transfer "(record {from=null; to=$cleaned_output; amount=1000000; fee=null; memo=null; created_at_time=null;})"
+  #
+  # Execute the command to get the input string and save the result
+  # dfx canister call "${LOCAL_PREFIX}minter" retrieve_btc '(record {fee = null; address="bcrt1qu9za0uzzd3kjjecgv7waqq0ynn8dl8l538q0xl"; amount=10000})'
+
+  echo "Step 5: transfer ckBTC to principal..."
+  # record { owner= principal “”;}
+  dfx canister call "${LOCAL_PREFIX}ledger" --network "$DFX_NETWORK" icrc1_transfer "(record {from=null; to=record { owner= principal \"73avq-yvrvj-kuzxq-kttlj-nkaz4-tecy6-biuud-3ymeg-guvci-naire-uqe\";}; amount=1000000; fee=null; memo=null; created_at_time=null;})"
+}
+
+check_ckbtc_deployment() {
+  for canister in kyt ledger minter index; do
+    : "Verify that the deployed canister matches the local wasm"
+    dfx-canister-check-wasm-hash --canister "${LOCAL_PREFIX}$canister" --network "$DFX_NETWORK"
+  done
+}
+
+[[ "${DFX_CHECK:-}" == "true" ]] || deploy_ckbtc
+check_ckbtc_deployment

--- a/bin/dfx-token-deploy
+++ b/bin/dfx-token-deploy
@@ -9,7 +9,7 @@ PATH="$SOURCE_DIR:$PATH"
 print_help() {
   cat <<-EOF
 
-	Installs ckbtc canisters.
+	Installs ledger and index canisters for a given token.
 
 	EOF
 }
@@ -18,71 +18,38 @@ print_help() {
 source "$SOURCE_DIR/clap.bash"
 # Define options
 clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
-clap.define short=p long=prefix desc="Prefix for the local canister names" variable=LOCAL_PREFIX default="ckbtc_"
-clap.define short=y long=yes desc="Deploy even if there are existing ckbtc canisters." variable=DFX_YES nargs=0
+clap.define short=p long=prefix desc="Prefix for the local canister names" variable=LOCAL_PREFIX default="mytoken_"
+clap.define long=token desc="The token name/symbol" variable=TOKEN default="MyToken"
+clap.define short=y long=yes desc="Deploy even if there are existing canisters." variable=DFX_YES nargs=0
 clap.define short=c long=check desc="Check that the canisters are present and correct." variable=DFX_CHECK nargs=0
 clap.define short=m long=mode desc="Canister install mode." variable=DFX_MODE default="reinstall"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
 : Check preconditions. This is always run.
-"${SOURCE_DIR}/dfx-ckbtc-import" --check --prefix "$LOCAL_PREFIX" || {
-  echo "ERROR: ckbtc canister data and files are not all present and correct."
+"${SOURCE_DIR}/dfx-token-import" --check --prefix "$LOCAL_PREFIX" || {
+  echo "ERROR: $TOKEN canister data and files are not all present and correct."
   echo "       Please run:"
-  echo "       dfx-ckbtc-import --prefix '$LOCAL_PREFIX'"
+  echo "       dfx-token-import --prefix '$LOCAL_PREFIX'"
   echo
   exit 1
 } >&2
 
-deploy_ckbtc() {
+deploy_token() {
   # We create some canisters ahead of time because we need to know their IDs
   # before deploying. Remaining canisters will be created when deployed.
-  dfx canister create "${LOCAL_PREFIX}kyt" --network "$DFX_NETWORK" || echo "${LOCAL_PREFIX}kyt canister already exists"
   dfx canister create "${LOCAL_PREFIX}ledger" --network "$DFX_NETWORK" || echo "${LOCAL_PREFIX}ledger canister already exists"
-  dfx canister create "${LOCAL_PREFIX}minter" --network "$DFX_NETWORK" || echo "${LOCAL_PREFIX}minter canister already exists"
 
-  KYT_ID="$(dfx canister id "${LOCAL_PREFIX}kyt" --network "$DFX_NETWORK")"
-  echo "$KYT_ID"
-  MINTERID="$(dfx canister id "${LOCAL_PREFIX}minter" --network "$DFX_NETWORK")"
-  echo "$MINTERID"
   LEDGERID="$(dfx canister id "${LOCAL_PREFIX}ledger" --network "$DFX_NETWORK")"
   echo "$LEDGERID"
 
-  # echo "Step 1: deploying kyt canister..."
+  echo "Step 1: deploying ledger canister..."
   DFX_IDENTITY_PRINCIPAL="$(dfx identity get-principal)"
-  dfx deploy "${LOCAL_PREFIX}kyt" --network "$DFX_NETWORK" --argument "(variant {
-  InitArg = record {
-      minter_id = principal \"$MINTERID\";
-      maintainers = vec { principal \"$DFX_IDENTITY_PRINCIPAL\" };
-      mode = variant { AcceptAll };
-  }
-})" --mode="${DFX_MODE}" ${DFX_YES:+--yes} --upgrade-unchanged
-
-  # We use mode AcceptAll so the API key is not used, but without API key the
-  # KYT canister will refuse to accept any UTXOs.
-  dfx canister call "${LOCAL_PREFIX}kyt" --network "$DFX_NETWORK" set_api_key '( record { api_key = "placeholder" } )'
-
-  # echo "Step 2: deploying minter canister..."
-  dfx deploy "${LOCAL_PREFIX}minter" --network "$DFX_NETWORK" --argument "(variant {
-  Init = record {
-       btc_network = variant { Mainnet };
-       ledger_id = principal \"$LEDGERID\";
-       ecdsa_key_name = \"dfx_test_key\";
-       retrieve_btc_min_amount = 13_333;
-       max_time_in_queue_nanos = 10_000_000_000;
-       min_confirmations = opt 12;
-       mode = variant { GeneralAvailability };
-       kyt_fee = opt 13_333;
-       kyt_principal = opt principal \"$KYT_ID\";
-   }
-})" --mode="${DFX_MODE}" ${DFX_YES:+--yes} --upgrade-unchanged
-
-  echo "Step 3: deploying ledger canister..."
   dfx deploy "${LOCAL_PREFIX}ledger" --network "$DFX_NETWORK" --argument "(variant {
   Init = record {
-     token_symbol = \"ckBTC\";
-     token_name = \"Token ckBTC\";
-     minting_account = record { owner = principal \"$MINTERID\" };
+     token_symbol = \"$TOKEN\";
+     token_name = \"Token $TOKEN\";
+     minting_account = record { owner = principal \"$DFX_IDENTITY_PRINCIPAL\" };
      transfer_fee = 10;
      max_memo_length = opt 64;
      metadata = vec {};
@@ -99,35 +66,16 @@ deploy_ckbtc() {
  }
 })" --mode="$DFX_MODE" ${DFX_YES:+--yes} --upgrade-unchanged
 
-  echo "Step 4: deploying index canister..."
+  echo "Step 2: deploying index canister..."
   dfx deploy "${LOCAL_PREFIX}index" --network "$DFX_NETWORK" --argument "(record { ledger_id = principal \"$LEDGERID\" })" --mode="${DFX_MODE}" ${DFX_YES:+--yes} --upgrade-unchanged
-
-  # Example to mint ckBTC
-
-  # BTCADDRESS="$(dfx canister call "${LOCAL_PREFIX}minter" get_btc_address '(record {subaccount=null;})')"
-  # dfx canister call "${LOCAL_PREFIX}minter" update_balance '(record {subaccount=null;})'
-  # WITHDRAWALADDRESS="$(dfx canister call "${LOCAL_PREFIX}minter" get_withdrawal_account)"
-  # echo $BTCADDRESS
-  # echo $WITHDRAWALADDRESS
-  #
-  # cleaned_output=$(echo $WITHDRAWALADDRESS | sed -re 's/^\(|, \)$//g')
-  #
-  # dfx canister call "${LOCAL_PREFIX}ledger" icrc1_transfer "(record {from=null; to=$cleaned_output; amount=1000000; fee=null; memo=null; created_at_time=null;})"
-  #
-  # Execute the command to get the input string and save the result
-  # dfx canister call "${LOCAL_PREFIX}minter" retrieve_btc '(record {fee = null; address="bcrt1qu9za0uzzd3kjjecgv7waqq0ynn8dl8l538q0xl"; amount=10000})'
-
-  echo "Step 5: transfer ckBTC to principal..."
-  # record { owner= principal “”;}
-  dfx canister call "${LOCAL_PREFIX}ledger" --network "$DFX_NETWORK" icrc1_transfer "(record {from=null; to=record { owner= principal \"73avq-yvrvj-kuzxq-kttlj-nkaz4-tecy6-biuud-3ymeg-guvci-naire-uqe\";}; amount=1000000; fee=null; memo=null; created_at_time=null;})"
 }
 
-check_ckbtc_deployment() {
-  for canister in kyt ledger minter index; do
+check_token_deployment() {
+  for canister in ledger index; do
     : "Verify that the deployed canister matches the local wasm"
     dfx-canister-check-wasm-hash --canister "${LOCAL_PREFIX}$canister" --network "$DFX_NETWORK"
   done
 }
 
-[[ "${DFX_CHECK:-}" == "true" ]] || deploy_ckbtc
-check_ckbtc_deployment
+[[ "${DFX_CHECK:-}" == "true" ]] || deploy_token
+check_token_deployment

--- a/bin/dfx-token-deploy.test
+++ b/bin/dfx-token-deploy.test
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+PATH="$SOURCE_DIR:$PATH"
+
+(
+  printf "\n\n===================================\n"
+  echo "Should fail if ckbtc canisters have not been imported"
+  git checkout dfx.json
+  error_log="$(mktemp ,test_log.XXXXXXXX)"
+  if dfx-ckbtc-deploy --check 2>"$error_log"; then
+    echo "ERROR: Should fail if ckbtc canisters are not in dfx.json"
+    exit 1
+  fi
+  grep 'ckbtc canister data and files are not all present and correct' "$error_log" || {
+    echo "The check should complain about ckbtc canisters missing in dfx.json"
+    exit 1
+  }
+  rm "$error_log"
+)
+(
+  printf "\n\n===================================\n"
+  echo "Should fail if ckbtc canisters have not been created"
+  dfx-network-stop
+  dfx start --clean --background
+  git checkout dfx.json
+  dfx-ckbtc-import
+  error_log="$(mktemp ,test_log.XXXXXXXX)"
+  if dfx-ckbtc-deploy --check 2>"$error_log"; then
+    echo "ERROR: Should fail if ckbtc canisters are not in dfx.json"
+  fi
+  grep 'Cannot find canister id' "$error_log" || {
+    echo "The check should complain about missing canisters:"
+    echo "Actual error log:"
+    cat "$error_log"
+    exit 1
+  }
+  rm "$error_log"
+  dfx-network-stop
+)
+(
+  printf "\n\n===================================\n"
+  echo "Should fail if ckbtc canisters have not been populated"
+  dfx-network-stop
+  dfx start --clean --background
+  git checkout dfx.json
+  dfx-ckbtc-import
+  dfx canister create "ckbtc_kyt" --no-wallet
+  dfx canister create "ckbtc_ledger" --no-wallet
+  dfx canister create "ckbtc_minter" --no-wallet
+  error_log="$(mktemp ,test_log.XXXXXXXX)"
+  if dfx-ckbtc-deploy --check 2>"$error_log"; then
+    echo "ERROR: Should fail if ckbtc canisters have the incorrect or no hash"
+  fi
+  grep 'ERROR: Deployed ckbtc_kyt hash does not match.' "$error_log" || {
+    echo "ERROR: The check should complain about missing canisters."
+    echo "Actual error output:"
+    sed 's/^/    /g' "$error_log"
+    exit 1
+  }
+  rm "$error_log"
+  dfx-network-stop
+)
+(
+  printf "\n\n===================================\n"
+  echo "Should succeed if canisters have been deployed"
+  dfx-network-stop
+  dfx start --clean --background
+  git checkout dfx.json
+  dfx-ckbtc-import
+  dfx-ckbtc-deploy --yes
+  dfx-ckbtc-deploy --check
+  dfx-network-stop
+)
+
+printf "\n\n\nckbtc tests passed.\n"

--- a/bin/dfx-token-deploy.test
+++ b/bin/dfx-token-deploy.test
@@ -5,29 +5,29 @@ PATH="$SOURCE_DIR:$PATH"
 
 (
   printf "\n\n===================================\n"
-  echo "Should fail if ckbtc canisters have not been imported"
+  echo "Should fail if token canisters have not been imported"
   git checkout dfx.json
   error_log="$(mktemp ,test_log.XXXXXXXX)"
-  if dfx-ckbtc-deploy --check 2>"$error_log"; then
-    echo "ERROR: Should fail if ckbtc canisters are not in dfx.json"
+  if dfx-token-deploy --check 2>"$error_log"; then
+    echo "ERROR: Should fail if token canisters are not in dfx.json"
     exit 1
   fi
-  grep 'ckbtc canister data and files are not all present and correct' "$error_log" || {
-    echo "The check should complain about ckbtc canisters missing in dfx.json"
+  grep 'MyToken canister data and files are not all present and correct' "$error_log" || {
+    echo "The check should complain about token canisters missing in dfx.json"
     exit 1
   }
   rm "$error_log"
 )
 (
   printf "\n\n===================================\n"
-  echo "Should fail if ckbtc canisters have not been created"
+  echo "Should fail if token canisters have not been created"
   dfx-network-stop
   dfx start --clean --background
   git checkout dfx.json
-  dfx-ckbtc-import
+  dfx-token-import
   error_log="$(mktemp ,test_log.XXXXXXXX)"
-  if dfx-ckbtc-deploy --check 2>"$error_log"; then
-    echo "ERROR: Should fail if ckbtc canisters are not in dfx.json"
+  if dfx-token-deploy --check 2>"$error_log"; then
+    echo "ERROR: Should fail if token canisters are not in dfx.json"
   fi
   grep 'Cannot find canister id' "$error_log" || {
     echo "The check should complain about missing canisters:"
@@ -40,19 +40,17 @@ PATH="$SOURCE_DIR:$PATH"
 )
 (
   printf "\n\n===================================\n"
-  echo "Should fail if ckbtc canisters have not been populated"
+  echo "Should fail if token canisters have not been populated"
   dfx-network-stop
   dfx start --clean --background
   git checkout dfx.json
-  dfx-ckbtc-import
-  dfx canister create "ckbtc_kyt" --no-wallet
-  dfx canister create "ckbtc_ledger" --no-wallet
-  dfx canister create "ckbtc_minter" --no-wallet
+  dfx-token-import
+  dfx canister create "mytoken_ledger" --no-wallet
   error_log="$(mktemp ,test_log.XXXXXXXX)"
-  if dfx-ckbtc-deploy --check 2>"$error_log"; then
-    echo "ERROR: Should fail if ckbtc canisters have the incorrect or no hash"
+  if dfx-token-deploy --check 2>"$error_log"; then
+    echo "ERROR: Should fail if token canisters have the incorrect or no hash"
   fi
-  grep 'ERROR: Deployed ckbtc_kyt hash does not match.' "$error_log" || {
+  grep 'ERROR: Deployed mytoken_ledger hash does not match.' "$error_log" || {
     echo "ERROR: The check should complain about missing canisters."
     echo "Actual error output:"
     sed 's/^/    /g' "$error_log"
@@ -67,10 +65,10 @@ PATH="$SOURCE_DIR:$PATH"
   dfx-network-stop
   dfx start --clean --background
   git checkout dfx.json
-  dfx-ckbtc-import
-  dfx-ckbtc-deploy --yes
-  dfx-ckbtc-deploy --check
+  dfx-token-import
+  dfx-token-deploy --yes
+  dfx-token-deploy --check
   dfx-network-stop
 )
 
-printf "\n\n\nckbtc tests passed.\n"
+printf "\n\n\ntoken tests passed.\n"

--- a/bin/dfx-token-import
+++ b/bin/dfx-token-import
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+PATH="$SOURCE_DIR:$PATH"
+. "$SOURCE_DIR/versions.bash"
+
+print_help() {
+  cat <<-EOF
+
+	Adds ckbtc canisters to the local dfx.json and populates the corresponding wasm and did files.
+
+	EOF
+}
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/clap.bash"
+# Define options
+clap.define short=c long=commit desc="Commit of the IC repo to download canisters from" variable=DFX_IC_COMMIT default="$DFX_IC_COMMIT"
+clap.define short=p long=prefix desc="Prefix for the local canister names" variable=LOCAL_PREFIX default="ckbtc_"
+clap.define long=check desc="Check whether the canisters have been imported" variable=DFX_CHECK nargs=0
+clap.define long=wasm_dir desc="Where to store the imported wasm files" variable=WASM_DIR default="wasms"        # Matches `dfx nns import`
+clap.define long=candid_dir desc="Where to store the imported candid files" variable=CANDID_DIR default="candid" # Matches `dfx nns import`
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+
+# Imports wasm, candid and populate dfx.json
+ckbtc_import() {
+  test -e dfx.json || {
+    echo "ERROR: No dfx.json found.  Please run this from inside a dfx project."
+    exit 1
+  } >&2
+
+  : Add any missing fields to dfx.json
+  # Note: The default values are placed first, so that they don't override any existing values.
+  LOCAL_PREFIX="${LOCAL_PREFIX:-}" \
+    WASM_DIR="${WASM_DIR:-}" \
+    CANDID_DIR="${CANDID_DIR:-}" \
+    jq -s '{canisters:
+      { "\(env.LOCAL_PREFIX)kyt" : { build: "true", candid: "\(env.CANDID_DIR)/\(env.LOCAL_PREFIX)kyt.did",  wasm: "\(env.WASM_DIR)/\(env.LOCAL_PREFIX)kyt.wasm",  type: "custom", remote: { id: {mainnet: "pjihx-aaaaa-aaaar-qaaka-cai"} }}
+      , "\(env.LOCAL_PREFIX)ledger": { build: "true", candid: "\(env.CANDID_DIR)/\(env.LOCAL_PREFIX)ledger.did", wasm: "\(env.WASM_DIR)/\(env.LOCAL_PREFIX)ledger.wasm", type: "custom", remote: { id: {mainnet: "mxzaz-hqaaa-aaaar-qaada-cai"} }}
+      , "\(env.LOCAL_PREFIX)minter": { build: "true", candid: "\(env.CANDID_DIR)/\(env.LOCAL_PREFIX)minter.did", wasm: "\(env.WASM_DIR)/\(env.LOCAL_PREFIX)minter.wasm", type: "custom", remote: { id: {} }}
+      , "\(env.LOCAL_PREFIX)index" : { build: "true", candid: "\(env.CANDID_DIR)/\(env.LOCAL_PREFIX)index.did",  wasm: "\(env.WASM_DIR)/\(env.LOCAL_PREFIX)index.wasm",  type: "custom", remote: { id: {mainnet: "n5wcd-faaaa-aaaar-qaaea-cai"} }}
+      }} * .[0]
+  ' dfx.json | sponge dfx.json
+
+  : Get the wasms
+  mkdir -p "$WASM_DIR"
+  get_wasm() {
+    local remote_name local_name local_path url
+    remote_name="$1"
+    local_name="$2"
+    local_path="$(c="$local_name" jq -re '.canisters[env.c].wasm' dfx.json)"
+    url="https://download.dfinity.systems/ic/$DFX_IC_COMMIT/canisters/${remote_name}.gz"
+    echo "Getting  $local_path from $url..."
+    curl -fsSL "$url" | gunzip >"${local_path}"
+  }
+  get_wasm ic-ckbtc-kyt.wasm "${LOCAL_PREFIX}kyt"
+  get_wasm ic-ckbtc-minter.wasm "${LOCAL_PREFIX}minter"
+  get_wasm ic-icrc1-ledger.wasm "${LOCAL_PREFIX}ledger"
+  get_wasm ic-icrc1-index.wasm "${LOCAL_PREFIX}index"
+
+  : Get the candid files
+  mkdir -p "$CANDID_DIR"
+  get_did() {
+    local remote_name local_name local_path url
+    remote_name="$1"
+    local_name="$2"
+    local_path="$(c="$local_name" jq -re '.canisters[env.c].candid' dfx.json)"
+    url="https://raw.githubusercontent.com/dfinity/ic/$DFX_IC_COMMIT/${remote_name}"
+    echo "Getting  $local_path from $url..."
+    curl -sSLf --retry 5 "$url" -o "$local_path"
+  }
+  get_did rs/bitcoin/ckbtc/kyt/kyt.did "${LOCAL_PREFIX}kyt"
+  get_did rs/bitcoin/ckbtc/minter/ckbtc_minter.did "${LOCAL_PREFIX}minter"
+  get_did rs/rosetta-api/icrc1/ledger/ledger.did "${LOCAL_PREFIX}ledger"
+  get_did rs/rosetta-api/icrc1/index/index.did "${LOCAL_PREFIX}index"
+
+  : "Ckbtc canister import complete."
+}
+
+# Checks whether ckbtc canisters have already been installed.
+ckbtc_import_check() {
+  : Verify that all file are present and correct
+  for canister in kyt minter ledger index; do
+    : "Check that the config is in dfx.json:"
+    canister_config="$(n="$LOCAL_PREFIX$canister" jq '.canisters[env.n]' dfx.json)"
+    [[ "$canister_config" != "null" ]] || {
+      printf "ERROR: %s\n" "$LOCAL_PREFIX$canister should be in dfx.json"
+      exit 1
+    } 2>&1
+    : "Check that there is a wasm file at the indicated location"
+    canister_wasm_path="$(printf "%s" "$canister_config" | jq -r .wasm)"
+    [[ "$canister_wasm_path" != "null" ]] || {
+      printf "ERROR: %s\n" "$LOCAL_PREFIX$canister config in dfx.json should include \"wasm\": <PATH TO WASM>"
+      exit 1
+    } >&2
+    test -e "$canister_wasm_path" || {
+      printf "ERROR: %s\n" "Wasm for $LOCAL_PREFIX$canister not found at the path given in dfx.json: '$canister_wasm_path'"
+      exit 1
+    } >&2
+    : "... is the file a wasm file?"
+    file "$canister_wasm_path" | grep -q wasm || {
+      printf "ERROR: %s\n" "Wasm for $LOCAL_PREFIX$canister at '$canister_wasm_path' is not a wasm file."
+      exit 1
+    } >&2
+    : "Check that the candid file is present and correct"
+    canister_did_path="$(printf "%s" "$canister_config" | jq -r .candid)"
+    [[ "$canister_did_path" != "null" ]] || {
+      printf "ERROR: %s\n" "$LOCAL_PREFIX$canister config in dfx.json should include \"candid\": <PATH TO .did FILE>"
+      exit 1
+    } >&2
+    test -e "$canister_did_path" || {
+      printf "ERROR: %s\n" "Candid for $LOCAL_PREFIX$canister not found at the path given in dfx.json: '$canister_did_path'"
+      exit 1
+    } >&2
+    : "... Basic check - does the candid file define a service?"
+    grep -E '^service ' "$canister_did_path" >/dev/null || {
+      printf "ERROR: %s\n" "Candid for $LOCAL_PREFIX$canister at '$canister_did_path' is not a valid did file."
+      exit 1
+    } >&2
+  done
+}
+
+###########
+# M A I N #
+###########
+if [[ "${DFX_CHECK:-}" == "true" ]]; then
+  ckbtc_import_check
+else
+  ckbtc_import
+fi

--- a/bin/dfx-token-import
+++ b/bin/dfx-token-import
@@ -7,7 +7,7 @@ PATH="$SOURCE_DIR:$PATH"
 print_help() {
   cat <<-EOF
 
-	Adds ckbtc canisters to the local dfx.json and populates the corresponding wasm and did files.
+	Adds ledger and index canisters for a given ICRC-1 token to the local dfx.json and populates the corresponding wasm and did files.
 
 	EOF
 }
@@ -16,7 +16,7 @@ print_help() {
 source "$SOURCE_DIR/clap.bash"
 # Define options
 clap.define short=c long=commit desc="Commit of the IC repo to download canisters from" variable=DFX_IC_COMMIT default="$DFX_IC_COMMIT"
-clap.define short=p long=prefix desc="Prefix for the local canister names" variable=LOCAL_PREFIX default="ckbtc_"
+clap.define short=p long=prefix desc="Prefix for the local canister names" variable=LOCAL_PREFIX default="mytoken_"
 clap.define long=check desc="Check whether the canisters have been imported" variable=DFX_CHECK nargs=0
 clap.define long=wasm_dir desc="Where to store the imported wasm files" variable=WASM_DIR default="wasms"        # Matches `dfx nns import`
 clap.define long=candid_dir desc="Where to store the imported candid files" variable=CANDID_DIR default="candid" # Matches `dfx nns import`
@@ -24,7 +24,7 @@ clap.define long=candid_dir desc="Where to store the imported candid files" vari
 source "$(clap.build)"
 
 # Imports wasm, candid and populate dfx.json
-ckbtc_import() {
+token_import() {
   test -e dfx.json || {
     echo "ERROR: No dfx.json found.  Please run this from inside a dfx project."
     exit 1
@@ -36,10 +36,8 @@ ckbtc_import() {
     WASM_DIR="${WASM_DIR:-}" \
     CANDID_DIR="${CANDID_DIR:-}" \
     jq -s '{canisters:
-      { "\(env.LOCAL_PREFIX)kyt" : { build: "true", candid: "\(env.CANDID_DIR)/\(env.LOCAL_PREFIX)kyt.did",  wasm: "\(env.WASM_DIR)/\(env.LOCAL_PREFIX)kyt.wasm",  type: "custom", remote: { id: {mainnet: "pjihx-aaaaa-aaaar-qaaka-cai"} }}
-      , "\(env.LOCAL_PREFIX)ledger": { build: "true", candid: "\(env.CANDID_DIR)/\(env.LOCAL_PREFIX)ledger.did", wasm: "\(env.WASM_DIR)/\(env.LOCAL_PREFIX)ledger.wasm", type: "custom", remote: { id: {mainnet: "mxzaz-hqaaa-aaaar-qaada-cai"} }}
-      , "\(env.LOCAL_PREFIX)minter": { build: "true", candid: "\(env.CANDID_DIR)/\(env.LOCAL_PREFIX)minter.did", wasm: "\(env.WASM_DIR)/\(env.LOCAL_PREFIX)minter.wasm", type: "custom", remote: { id: {} }}
-      , "\(env.LOCAL_PREFIX)index" : { build: "true", candid: "\(env.CANDID_DIR)/\(env.LOCAL_PREFIX)index.did",  wasm: "\(env.WASM_DIR)/\(env.LOCAL_PREFIX)index.wasm",  type: "custom", remote: { id: {mainnet: "n5wcd-faaaa-aaaar-qaaea-cai"} }}
+      { "\(env.LOCAL_PREFIX)ledger": { build: "true", candid: "\(env.CANDID_DIR)/\(env.LOCAL_PREFIX)ledger.did", wasm: "\(env.WASM_DIR)/\(env.LOCAL_PREFIX)ledger.wasm", type: "custom" }
+      , "\(env.LOCAL_PREFIX)index" : { build: "true", candid: "\(env.CANDID_DIR)/\(env.LOCAL_PREFIX)index.did",  wasm: "\(env.WASM_DIR)/\(env.LOCAL_PREFIX)index.wasm",  type: "custom" }
       }} * .[0]
   ' dfx.json | sponge dfx.json
 
@@ -54,8 +52,6 @@ ckbtc_import() {
     echo "Getting  $local_path from $url..."
     curl -fsSL "$url" | gunzip >"${local_path}"
   }
-  get_wasm ic-ckbtc-kyt.wasm "${LOCAL_PREFIX}kyt"
-  get_wasm ic-ckbtc-minter.wasm "${LOCAL_PREFIX}minter"
   get_wasm ic-icrc1-ledger.wasm "${LOCAL_PREFIX}ledger"
   get_wasm ic-icrc1-index.wasm "${LOCAL_PREFIX}index"
 
@@ -70,18 +66,16 @@ ckbtc_import() {
     echo "Getting  $local_path from $url..."
     curl -sSLf --retry 5 "$url" -o "$local_path"
   }
-  get_did rs/bitcoin/ckbtc/kyt/kyt.did "${LOCAL_PREFIX}kyt"
-  get_did rs/bitcoin/ckbtc/minter/ckbtc_minter.did "${LOCAL_PREFIX}minter"
   get_did rs/rosetta-api/icrc1/ledger/ledger.did "${LOCAL_PREFIX}ledger"
   get_did rs/rosetta-api/icrc1/index/index.did "${LOCAL_PREFIX}index"
 
-  : "Ckbtc canister import complete."
+  : "Token canister import complete."
 }
 
-# Checks whether ckbtc canisters have already been installed.
-ckbtc_import_check() {
+# Checks whether token canisters have already been installed.
+token_import_check() {
   : Verify that all file are present and correct
-  for canister in kyt minter ledger index; do
+  for canister in ledger index; do
     : "Check that the config is in dfx.json:"
     canister_config="$(n="$LOCAL_PREFIX$canister" jq '.canisters[env.n]' dfx.json)"
     [[ "$canister_config" != "null" ]] || {
@@ -125,7 +119,7 @@ ckbtc_import_check() {
 # M A I N #
 ###########
 if [[ "${DFX_CHECK:-}" == "true" ]]; then
-  ckbtc_import_check
+  token_import_check
 else
-  ckbtc_import
+  token_import
 fi

--- a/bin/dfx-token-import.test
+++ b/bin/dfx-token-import.test
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+indent() {
+  sed 's/^/    /g'
+}
+
+test_install() {
+  (
+    local flags=("${@}")
+    echo "Before importing, checking for ckBTC should fail:"
+    if bin/dfx-ckbtc-import --check "${flags[@]}"; then
+      echo "ERROR: Check should fail without ckBTC canisters"
+      exit 1
+    fi
+    echo "Now import"
+    bin/dfx-ckbtc-import "${flags[@]}"
+    echo "After importing, checking for ckBTC should succeed"
+    bin/dfx-ckbtc-import --check "${flags[@]}"
+  ) |& indent
+}
+
+(
+  echo "Default canister installation should work"
+  test_install
+)
+
+(
+  echo "Installation with a prefix should work"
+  for prefix in "" foo; do
+    {
+      echo "Installing with prefix '${prefix:-}'"
+      test_install --prefix "$prefix"
+    } |& indent
+  done
+)
+
+echo "$(basename "$0") PASSED"

--- a/bin/dfx-token-import.test
+++ b/bin/dfx-token-import.test
@@ -8,15 +8,15 @@ indent() {
 test_install() {
   (
     local flags=("${@}")
-    echo "Before importing, checking for ckBTC should fail:"
-    if bin/dfx-ckbtc-import --check "${flags[@]}"; then
-      echo "ERROR: Check should fail without ckBTC canisters"
+    echo "Before importing, checking for mytoken should fail:"
+    if bin/dfx-token-import --check "${flags[@]}"; then
+      echo "ERROR: Check should fail without myToken canisters"
       exit 1
     fi
     echo "Now import"
-    bin/dfx-ckbtc-import "${flags[@]}"
-    echo "After importing, checking for ckBTC should succeed"
-    bin/dfx-ckbtc-import --check "${flags[@]}"
+    bin/dfx-token-import "${flags[@]}"
+    echo "After importing, checking for mytoken should succeed"
+    bin/dfx-token-import --check "${flags[@]}"
   ) |& indent
 }
 


### PR DESCRIPTION
# Motivation

We want to deploy a ledger+index canister to test ckETH functionality.
We add a script to deploy generic tokens with parameters to specify "ckETH".

This will be used in a future PR to add ckETH canisters to a stock snapshot.

NOTE: Look at the second commit separately to see how the generic scripts differ from the ckBTC scripts.

# Changes

1. Make copies of ckBTC specific scripts.
2. Remove KYT, minter and other ckBTC specific code.
3. Add tests to CI.