### PR TITLE
Install ckETH canisters in stock deploy

### DIFF
--- a/bin/dfx-stock-deploy
+++ b/bin/dfx-stock-deploy
@@ -49,6 +49,17 @@ fi
 dfx-ckbtc-import --prefix ckbtc_
 dfx-ckbtc-deploy --prefix ckbtc_ --network "$DFX_NETWORK" --yes
 
+: Set up cketh canisters
+dfx-token-import --prefix cketh_ --commit "$DFX_IC_COMMIT"
+dfx-token-deploy --prefix cketh_ --token ckETH --network "$DFX_NETWORK" --yes
+
+: Mint 10M ckETH into the faucet address.
+# See https://github.com/dfinity/nns-dapp/blob/main/frontend/src/lib/api/dev.api.ts
+FAUCET_ADDRESS="jg6qm-uw64t-m6ppo-oluwn-ogr5j-dc5pm-lgy2p-eh6px-hebcd-5v73i-nqe"
+# The current identity was set as minting account and minting is done by
+# transferring from the minting account.
+dfx canister call cketh_ledger icrc1_transfer "(record {to=record{owner=principal \"$FAUCET_ADDRESS\"}; amount=1_000_000_000_000_000:nat})"
+
 : Add the nns root as a controller to the frontend canisters
 NNS_ROOT="$(dfx canister id nns-root --network "$DFX_NETWORK")"
 for canister in nns-dapp internet_identity; do


### PR DESCRIPTION
# Motivation

We want to support the ckETH token in the NNS dapp.
So we install an additional ICRC-1 token and call it ckETH to use in the test environment.

# Changes

1. Import and deploy a token and call it ckETH.
2. Mint 10M tokens into the faucet address such that "Get ckETH" on the NNS dapp will work.

# Tested

Manually: Created a snapshot and checked that I could get the new ledger IDs when running the snapshot.