### PR TITLE
Make token name same as symbol

### DIFF
--- a/bin/dfx-ckbtc-deploy
+++ b/bin/dfx-ckbtc-deploy
@@ -85,7 +85,7 @@ deploy_ckbtc() {
   dfx deploy "${LOCAL_PREFIX}ledger" --network "$DFX_NETWORK" --argument "(variant {
   Init = record {
      token_symbol = \"ckBTC\";
-     token_name = \"Token ckBTC\";
+     token_name = \"ckBTC\";
      minting_account = record { owner = principal \"$MINTERID\" };
      transfer_fee = 10;
      max_memo_length = opt 64;

--- a/bin/dfx-token-deploy
+++ b/bin/dfx-token-deploy
@@ -48,7 +48,7 @@ deploy_token() {
   dfx deploy "${LOCAL_PREFIX}ledger" --network "$DFX_NETWORK" --argument "(variant {
   Init = record {
      token_symbol = \"$TOKEN\";
-     token_name = \"Token $TOKEN\";
+     token_name = \"$TOKEN\";
      minting_account = record { owner = principal \"$DFX_IDENTITY_PRINCIPAL\" };
      transfer_fee = 10;
      max_memo_length = opt 64;


### PR DESCRIPTION
# Motivation

In the universe selector in NNS dapp, ckETH is listed as "Token ckETH", which looks strange next to ckBTC (without "Token"). Apparently ckBTC doesn't get its token name from the ledger metadata but ckETH does.

# Change

Remove "Token" from the token name of the generic token deploy script and the ckbtc deploy script.