### PR TITLE
Set decimals in dfx-token-deploy

### DIFF
--- a/bin/dfx-stock-deploy
+++ b/bin/dfx-stock-deploy
@@ -51,7 +51,7 @@ dfx-ckbtc-deploy --prefix ckbtc_ --network "$DFX_NETWORK" --yes
 
 : Set up cketh canisters
 dfx-token-import --prefix cketh_ --commit "$DFX_IC_COMMIT"
-dfx-token-deploy --prefix cketh_ --token ckETH --network "$DFX_NETWORK" --yes
+dfx-token-deploy --prefix cketh_ --token ckETH --decimals 18 --network "$DFX_NETWORK" --yes
 
 : Mint 10M ckETH into the faucet address.
 # See https://github.com/dfinity/nns-dapp/blob/main/frontend/src/lib/api/dev.api.ts

--- a/bin/dfx-token-deploy
+++ b/bin/dfx-token-deploy
@@ -53,7 +53,7 @@ deploy_token() {
      minting_account = record { owner = principal \"$DFX_IDENTITY_PRINCIPAL\" };
      transfer_fee = 10;
      max_memo_length = opt 64;
-     decimals = $DECIMALS;
+     decimals = opt $DECIMALS;
      metadata = vec {};
      initial_balances = vec { record { record { owner = principal \"$DFX_IDENTITY_PRINCIPAL\"; }; 10_000_000; }; };
      archive_options = record {

--- a/bin/dfx-token-deploy
+++ b/bin/dfx-token-deploy
@@ -20,6 +20,7 @@ source "$SOURCE_DIR/clap.bash"
 clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
 clap.define short=p long=prefix desc="Prefix for the local canister names" variable=LOCAL_PREFIX default="mytoken_"
 clap.define long=token desc="The token name/symbol" variable=TOKEN default="MyToken"
+clap.define long=decimals desc="Number of decimals to use in ledger canister" variable=DECIMALS default="8"
 clap.define short=y long=yes desc="Deploy even if there are existing canisters." variable=DFX_YES nargs=0
 clap.define short=c long=check desc="Check that the canisters are present and correct." variable=DFX_CHECK nargs=0
 clap.define short=m long=mode desc="Canister install mode." variable=DFX_MODE default="reinstall"
@@ -52,6 +53,7 @@ deploy_token() {
      minting_account = record { owner = principal \"$DFX_IDENTITY_PRINCIPAL\" };
      transfer_fee = 10;
      max_memo_length = opt 64;
+     decimals = $DECIMALS;
      metadata = vec {};
      initial_balances = vec { record { record { owner = principal \"$DFX_IDENTITY_PRINCIPAL\"; }; 10_000_000; }; };
      archive_options = record {


### PR DESCRIPTION
# Motivation

cketh needs 18 decimals

# Change

1. Update `dfx-token-deploy` to take `--decimals`, defaults to 8.
2. Pass `--decimals 18` to create cketh in stock deploy.

# Tested

Manually created a snapshot and ran
```
$ dfx canister call cketh_ledger icrc1_metadata
(
  vec {
    record { "icrc1:decimals"; variant { 3_900_609 = 18 : nat } };
    record { "icrc1:name"; variant { 936_573_133 = "ckETH" } };
    record { "icrc1:symbol"; variant { 936_573_133 = "ckETH" } };
    record { "icrc1:fee"; variant { 3_900_609 = 10 : nat } };
    record { "icrc1:max_memo_length"; variant { 3_900_609 = 64 : nat } };
  },
)
```