### PR TITLE
Install u256 canisters for ckETH

### DIFF
--- a/bin/dfx-stock-deploy
+++ b/bin/dfx-stock-deploy
@@ -51,7 +51,13 @@ dfx-ckbtc-deploy --prefix ckbtc_ --network "$DFX_NETWORK" --yes
 
 : Set up cketh canisters
 dfx-token-import --prefix cketh_ --commit "$DFX_IC_COMMIT"
-dfx-token-deploy --prefix cketh_ --token ckETH --decimals 18 --network "$DFX_NETWORK" --yes
+dfx-token-deploy \
+  --prefix cketh_ \
+  --token ckETH \
+  --decimals 18 \
+  --fee 2_000_000_000_000 \
+  --network "$DFX_NETWORK" \
+  --yes
 
 : Mint 10M ckETH into the faucet address.
 # See https://github.com/dfinity/nns-dapp/blob/main/frontend/src/lib/api/dev.api.ts

--- a/bin/dfx-stock-deploy
+++ b/bin/dfx-stock-deploy
@@ -58,7 +58,7 @@ dfx-token-deploy --prefix cketh_ --token ckETH --decimals 18 --network "$DFX_NET
 FAUCET_ADDRESS="jg6qm-uw64t-m6ppo-oluwn-ogr5j-dc5pm-lgy2p-eh6px-hebcd-5v73i-nqe"
 # The current identity was set as minting account and minting is done by
 # transferring from the minting account.
-dfx canister call cketh_ledger icrc1_transfer "(record {to=record{owner=principal \"$FAUCET_ADDRESS\"}; amount=1_000_000_000_000_000:nat})"
+dfx canister call cketh_ledger icrc1_transfer "(record {to=record{owner=principal \"$FAUCET_ADDRESS\"}; amount=10_000_000_000_000_000_000_000_000:nat})"
 
 : Add the nns root as a controller to the frontend canisters
 NNS_ROOT="$(dfx canister id nns-root --network "$DFX_NETWORK")"

--- a/bin/dfx-token-deploy
+++ b/bin/dfx-token-deploy
@@ -21,6 +21,7 @@ clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETW
 clap.define short=p long=prefix desc="Prefix for the local canister names" variable=LOCAL_PREFIX default="mytoken_"
 clap.define long=token desc="The token name/symbol" variable=TOKEN default="MyToken"
 clap.define long=decimals desc="Number of decimals to use in ledger canister" variable=DECIMALS default="8"
+clap.define long=fee desc="The transaction fee to set" variable=FEE default="10"
 clap.define short=y long=yes desc="Deploy even if there are existing canisters." variable=DFX_YES nargs=0
 clap.define short=c long=check desc="Check that the canisters are present and correct." variable=DFX_CHECK nargs=0
 clap.define short=m long=mode desc="Canister install mode." variable=DFX_MODE default="reinstall"
@@ -51,7 +52,7 @@ deploy_token() {
      token_symbol = \"$TOKEN\";
      token_name = \"$TOKEN\";
      minting_account = record { owner = principal \"$DFX_IDENTITY_PRINCIPAL\" };
-     transfer_fee = 2000_000_000_000;
+     transfer_fee = $FEE;
      max_memo_length = opt 64;
      decimals = opt $DECIMALS;
      metadata = vec {};

--- a/bin/dfx-token-deploy
+++ b/bin/dfx-token-deploy
@@ -70,7 +70,7 @@ deploy_token() {
 })" --mode="$DFX_MODE" ${DFX_YES:+--yes} --upgrade-unchanged
 
   echo "Step 2: deploying index canister..."
-  dfx deploy "${LOCAL_PREFIX}index" --network "$DFX_NETWORK" --argument "(record { ledger_id = principal \"$LEDGERID\" })" --mode="${DFX_MODE}" ${DFX_YES:+--yes} --upgrade-unchanged
+  dfx deploy "${LOCAL_PREFIX}index" --network "$DFX_NETWORK" --argument "(opt variant { Init = record { ledger_id = principal \"$LEDGERID\" } })" --mode="${DFX_MODE}" ${DFX_YES:+--yes} --upgrade-unchanged
 }
 
 check_token_deployment() {

--- a/bin/dfx-token-deploy
+++ b/bin/dfx-token-deploy
@@ -51,7 +51,7 @@ deploy_token() {
      token_symbol = \"$TOKEN\";
      token_name = \"$TOKEN\";
      minting_account = record { owner = principal \"$DFX_IDENTITY_PRINCIPAL\" };
-     transfer_fee = 10;
+     transfer_fee = 2000_000_000_000;
      max_memo_length = opt 64;
      decimals = opt $DECIMALS;
      metadata = vec {};

--- a/bin/dfx-token-import
+++ b/bin/dfx-token-import
@@ -67,7 +67,7 @@ token_import() {
     curl -sSLf --retry 5 "$url" -o "$local_path"
   }
   get_did rs/rosetta-api/icrc1/ledger/ledger.did "${LOCAL_PREFIX}ledger"
-  get_did rs/rosetta-api/icrc1/index/index.did "${LOCAL_PREFIX}index"
+  get_did rs/rosetta-api/icrc1/index-ng/index-ng.did "${LOCAL_PREFIX}index"
 
   : "Token canister import complete."
 }

--- a/bin/dfx-token-import
+++ b/bin/dfx-token-import
@@ -52,8 +52,8 @@ token_import() {
     echo "Getting  $local_path from $url..."
     curl -fsSL "$url" | gunzip >"${local_path}"
   }
-  get_wasm ic-icrc1-ledger.wasm "${LOCAL_PREFIX}ledger"
-  get_wasm ic-icrc1-index.wasm "${LOCAL_PREFIX}index"
+  get_wasm ic-icrc1-ledger-u256.wasm "${LOCAL_PREFIX}ledger"
+  get_wasm ic-icrc1-index-ng-u256.wasm "${LOCAL_PREFIX}index"
 
   : Get the candid files
   mkdir -p "$CANDID_DIR"


### PR DESCRIPTION
# Motivation

The standard ledger and index canisters use `nat64` numbers for amounts.
Because ckETH uses 18 decimals, the larges amount of ckETH that can be represented in a `nat64` is less than 19.00.
So we need to use different ledger and index canisters to support larger numbers.

# Changes

1. Use `ic-icrc1-ledger-u256.wasm` and `ic-icrc1-index-ng-u256.wasm` when installing a generic token.
2. Use `index-ng.did`.
3. Make `--fee` a parameter of `dfx-token-deploy`.
4. Set a fee of `2_000_000_000_000` which matches the proposed mainnet ckETH fee in https://dashboard.internetcomputer.org/proposal/126170
5. Transfer 10M ckETH instead of 0.001 ckETH to the faucet.

# Tested

Snapshot created and used manually.