### PR TITLE
Use index-ng for ckBTC

### DIFF
--- a/bin/dfx-ckbtc-deploy
+++ b/bin/dfx-ckbtc-deploy
@@ -104,7 +104,7 @@ deploy_ckbtc() {
 })" --mode="$DFX_MODE" ${DFX_YES:+--yes} --upgrade-unchanged
 
   echo "Step 4: deploying index canister..."
-  dfx deploy "${LOCAL_PREFIX}index" --network "$DFX_NETWORK" --argument "(record { ledger_id = principal \"$LEDGERID\" })" --mode="${DFX_MODE}" ${DFX_YES:+--yes} --upgrade-unchanged
+  dfx deploy "${LOCAL_PREFIX}index" --network "$DFX_NETWORK" --argument "(opt variant { Init = record { ledger_id = principal \"$LEDGERID\" } })" --mode="${DFX_MODE}" ${DFX_YES:+--yes} --upgrade-unchanged
 
   # Example to mint ckBTC
 

--- a/bin/dfx-ckbtc-import
+++ b/bin/dfx-ckbtc-import
@@ -61,7 +61,7 @@ ckbtc_import() {
   get_wasm ic-ckbtc-kyt.wasm "${LOCAL_PREFIX}kyt"
   get_wasm ic-ckbtc-minter.wasm "${LOCAL_PREFIX}minter"
   get_wasm ic-icrc1-ledger.wasm "${LOCAL_PREFIX}ledger"
-  get_wasm ic-icrc1-index.wasm "${LOCAL_PREFIX}index"
+  get_wasm ic-icrc1-index-ng.wasm "${LOCAL_PREFIX}index"
 
   : Get the candid files
   mkdir -p "$CANDID_DIR"
@@ -77,7 +77,7 @@ ckbtc_import() {
   get_did rs/bitcoin/ckbtc/kyt/kyt.did "${LOCAL_PREFIX}kyt"
   get_did rs/bitcoin/ckbtc/minter/ckbtc_minter.did "${LOCAL_PREFIX}minter"
   get_did rs/rosetta-api/icrc1/ledger/ledger.did "${LOCAL_PREFIX}ledger"
-  get_did rs/rosetta-api/icrc1/index/index.did "${LOCAL_PREFIX}index"
+  get_did rs/rosetta-api/icrc1/index-ng/index-ng.did "${LOCAL_PREFIX}index"
 
   : "Ckbtc canister import complete."
 }


### PR DESCRIPTION
# Motivation

There is a new index canister called index-ng.
For ckETH we had to use the new index canister because the old one does not support u256 balances.
For SNS the canisters are installed by SNS-W which we don't control.
But for ckBTC we were still using the old index canister.

# Changes

1. In `dfx-ckbtc-import` download the wasm and candid files for index-ng.
2. In `dfx-ckbtc-deploy` use the init arg format for index-ng.

# Tested

I created a snapshot and used it with nns-dapp.
I thought the reason that minter burn transactions don't have the spender field set was because we were still using the old index canister. But I tested it and the new index canister also doesn't seem to have the spender field set.
But it also doesn't seem to cause any problem and it seems good to use the new canister since mainnet ckBTC also uses it.