### PR TITLE
Include dfx version in update PR title

### DIFF
--- a/.github/workflows/update-dfx.yml
+++ b/.github/workflows/update-dfx.yml
@@ -35,6 +35,7 @@ jobs:
             echo An update is available for dfx.
             git diff
             echo "updated=1" >> "$GITHUB_OUTPUT"
+            echo "title=\"Update dfx to version $latest_dfx_version\"" >> "$GITHUB_OUTPUT"
           else
             echo "updated=0" >> "$GITHUB_OUTPUT"
           fi
@@ -48,12 +49,12 @@ jobs:
           add-paths: |
             dfx.json
             dfx.json.original
-          commit-message: Update dfx version
+          commit-message: ${{ steps.update.outputs.title }}
           committer: GitHub <noreply@github.com>
           author: gix-bot <gix-bot@users.noreply.github.com>
           branch: bot-dfx-update
           delete-branch: true
-          title: 'Update dfx version'
+          title: ${{ steps.update.outputs.new_version }}
           # Since the this is a scheduled job, a failure won't be shown on any
           # PR status. To notify the team, we send a message to our Slack channel on failure.
       - name: Notify Slack on failure

--- a/.github/workflows/update-dfx.yml
+++ b/.github/workflows/update-dfx.yml
@@ -53,8 +53,9 @@ jobs:
           committer: GitHub <noreply@github.com>
           author: gix-bot <gix-bot@users.noreply.github.com>
           branch: bot-dfx-update
+          branch-suffix: timestamp
           delete-branch: true
-          title: ${{ steps.update.outputs.new_version }}
+          title: ${{ steps.update.outputs.title }}
           # Since the this is a scheduled job, a failure won't be shown on any
           # PR status. To notify the team, we send a message to our Slack channel on failure.
       - name: Notify Slack on failure

--- a/.github/workflows/update-dfx.yml
+++ b/.github/workflows/update-dfx.yml
@@ -35,7 +35,7 @@ jobs:
             echo An update is available for dfx.
             git diff
             echo "updated=1" >> "$GITHUB_OUTPUT"
-            echo "title=\"Update dfx to version $latest_dfx_version\"" >> "$GITHUB_OUTPUT"
+            echo "title=Update dfx to version $latest_dfx_version" >> "$GITHUB_OUTPUT"
           else
             echo "updated=0" >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
# Motivation

convenience

# Changes

1. Include the new dfx version in the automated update PR title and commit message.
2. Drive-by: Use branch-suffix as we do in nns-dapp update workflows as well.

# Tested:

Created this PR with the workflow: https://github.com/dfinity/snsdemo/pull/293