### PR TITLE
Install ic-admin and sns in dfx-sns-demo-install

### DIFF
--- a/bin/dfx-sns-demo-install
+++ b/bin/dfx-sns-demo-install
@@ -24,3 +24,4 @@ dfx-software-openssl-install
 dfx-software-dfx-install --version "$(jq -r .dfx dfx.json)"
 dfx-software-idl2json-install --version pinned
 dfx-software-quill-install --version pinned
+dfx-software-ic-install-executable ic-admin sns

--- a/bin/dfx-sns-propose
+++ b/bin/dfx-sns-propose
@@ -26,4 +26,4 @@ DFX_NNS_URL="$(dfx-network-provider --network "$DFX_NETWORK")"
 
 export DFX_IDENTITY
 
-bin-other/sns propose --neuron-id "$DFX_NEURON_ID" ${PROPOSAL_ID_FILE:+--save-to "$PROPOSAL_ID_FILE"} --network "$DFX_NNS_URL" sns.yml
+sns propose --neuron-id "$DFX_NEURON_ID" ${PROPOSAL_ID_FILE:+--save-to "$PROPOSAL_ID_FILE"} --network "$DFX_NNS_URL" sns.yml


### PR DESCRIPTION
# Motivation

NNS dapp [CI fails](https://github.com/dfinity/nns-dapp/actions/runs/7217631679/job/19735417625?pr=4042) when trying to update its version of snsdemo because when `aggregator_test` tries to create an SNS it can't find `sns` CLI.

Previously, creating an SNS would use the 2-proposal flow, which would used `ic-admin` but now it uses the 1-proposal flow, which uses `sns`.
snsdemo has scripts to install `ic-admin` and `sns` but both are also available from the `dfx` cache.

`aggregator_test` from nns-dapp CI does not install `ic-admin` or `sns` but calls `dfx-sns-demo-mksns` from snsdemo. This used to call [bin/dfx-sns-whitelist-me](https://github.com/dfinity/snsdemo/blob/7fe4aabc62341b3c15a9c3ac0db78fdcd51d5686/bin/dfx-sns-whitelist-me) and `bin/dfx-sns-sale-propose`, but now it calls [bin/dfx-sns-propose](https://github.com/dfinity/snsdemo/blob/19b216f03ecae1a2e45d45bc6b8e21f16dfb5b5e/bin/dfx-sns-propose).
The difference is that `bin/dfx-sns-whitelist-me` puts `$(dfx cache show)` in the PATH, such that `ic-admin` and `sns` are available even when not explicitly installed by snsdemo.

We could also put `$(dfx cache show)` in the PATH in `bin/dfx-sns-propose` but that uses a version of `sns` that comes with dfx and might not support all fields of `sns_init.yaml` that we need. Especially since we are currently stuck at dfx 0.14.4 until 0.15.3 is released which can accessed remotely on a DevEnv.

# Changes

1. Install `ic-admin` and `sns` as part of `bin/dfx-sns-demo-install`.
2. Call `sns` from the path instead of explicitly from `bin-other` in `bin/dfx-sns-propose`.

# Tested

CI passes
Will make a new release after merging and test nns-dapp can upgrade snsdemo again.