### PR TITLE
Disable automatic update of dfx version

### DIFF
--- a/.github/workflows/update-dfx.yml
+++ b/.github/workflows/update-dfx.yml
@@ -2,9 +2,6 @@
 # and creates a PR on new versions.
 name: Update dfx
 on:
-  schedule:
-    # check for new dfx versions weekly
-    - cron: '30 3 * * FRI'
   workflow_dispatch:
   # Provide an option to run this manually.
   push:


### PR DESCRIPTION
# Motivation

Having to update dfx very frequently is somewhat painful.
Especially since snapshots don't work between versions.
Also there is limited benefit to always being on the latest version unless we need a specific feature.

# Changes

Remove the scheduled running of the dfx update job.
We keep the job so it can be run manually if we want.