### PR TITLE
Use index-ng in snsdemo

### DIFF
--- a/bin/sns_dfx.json
+++ b/bin/sns_dfx.json
@@ -15,7 +15,7 @@
         },
         "build": "",
         "wasm": "ic-icrc1-index-ng.wasm",
-        "candid": "../../rosetta-api/icrc1/index/index.did",
+        "candid": "../../rosetta-api/icrc1/index-ng/index.did",
         "type": "custom"
       },
       "sns-ledger": {

--- a/bin/sns_dfx.json
+++ b/bin/sns_dfx.json
@@ -14,7 +14,7 @@
             "nns_sns_wasm_name": "index"
         },
         "build": "",
-        "wasm": "ic-icrc1-index.wasm",
+        "wasm": "ic-icrc1-index-ng.wasm",
         "candid": "../../rosetta-api/icrc1/index/index.did",
         "type": "custom"
       },

--- a/bin/sns_dfx.json
+++ b/bin/sns_dfx.json
@@ -15,7 +15,7 @@
         },
         "build": "",
         "wasm": "ic-icrc1-index-ng.wasm",
-        "candid": "../../rosetta-api/icrc1/index-ng/index.did",
+        "candid": "../../rosetta-api/icrc1/index-ng/index-ng.did",
         "type": "custom"
       },
       "sns-ledger": {

--- a/bin/versions.bash
+++ b/bin/versions.bash
@@ -2,7 +2,7 @@
 # shellcheck disable=SC2034 # Variables are expected to be unused in this file
 # Release from 2023-05-30 which includes geo restriction fields
 SNS_AGGREGATOR_RELEASE=proposal-125509-agg
-DFX_IC_COMMIT=75c4492ed7dc1692a93d41ed8c23d038095bd997
+DFX_IC_COMMIT=0d7eadd62e2ca638dc4000d4df9292197b691c0f
 INTERNET_IDENTITY_RELEASE=release-2023-10-27
 NNS_DAPP_RELEASE=proposal-121690
 DIDC_VERSION=2023-07-25


### PR DESCRIPTION
# Motivation

CI is currently broken when using the latest IC commit: https://github.com/dfinity/snsdemo/actions/runs/7960043264
This is because the latests SNS WASM install the index canister with install arguments accepted by the index-ng canister but not by the (non-ng) index canister.

We upload SNS wasms in `bin/dfx-sns-wasm-upload`, which reads from `bin/sns_dfx.json` which wasms to download.

# Changes

1. Change `bin/sns_dfx.json` such that `bin/dfx-sns-wasm-upload` downloads the index-ng wasm.
2. Use the correct corresponding candid.
3. Update the pinned version of IC commit we use to one that support index-ng.

# Tested

Both "current" and "latest" pass: https://github.com/dfinity/snsdemo/actions/runs/7962223917/job/21735204419?pr=323