### PR TITLE
SNSDEMO: Fix CI, use GitHub action to install dfx

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -75,7 +75,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
       - name: Install dfx
-        run: ./bin/dfx-software-dfx-install --version "$(jq -r .dfx dfx.json)"
+        uses: dfinity/setup-dfx@main
       - name: "Test the aggregator wasm install command"
         run: ./bin/dfx-software-sns-aggregator-install.test --verbose
         env:
@@ -89,7 +89,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install moreutils -yy && command -v more
       - uses: actions/checkout@v3
       - name: Install dfx
-        run: ./bin/dfx-software-dfx-install --version "$(jq -r .dfx dfx.json)"
+        uses: dfinity/setup-dfx@main
       - name: Import ckbtc works
         run: |
           set -euxo pipefail
@@ -154,7 +154,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install moreutils -yy && command -v more
       - uses: actions/checkout@v3
       - name: Install dfx
-        run: ./bin/dfx-software-dfx-install --version "$(jq -r .dfx dfx.json)"
+        uses: dfinity/setup-dfx@main
       - name: dfx-canister-url works
         run: |
           set -euxo pipefail

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -37,6 +37,8 @@ jobs:
           brew install bash
           echo "/usr/local/bin" >> $GITHUB_PATH
           echo "$(brew --prefix)/opt/gnu-sed/libexec/gnubin" >> $GITHUB_PATH
+      - name: Install dfx
+        uses: dfinity/setup-dfx@main
       - name: Install dependencies
         run: ./bin/dfx-sns-demo-install --verbose
       - name: Run the demo with the current default ic commits
@@ -93,6 +95,8 @@ jobs:
           brew install bash
           echo "/usr/local/bin" >> $GITHUB_PATH
           echo "$(brew --prefix)/opt/gnu-sed/libexec/gnubin" >> $GITHUB_PATH
+      - name: Install dfx
+        uses: dfinity/setup-dfx@main
       - name: Install dependencies
         run: ./bin/dfx-sns-demo-install --verbose
       # Clone the ic repo so that we can find the latest published commit. 

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -19,6 +19,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Install dfx
+        uses: dfinity/setup-dfx@main
       - name: Create snapshot
         id: snapshot
         run: |


### PR DESCRIPTION
# Motivation

The dfx install script at https://sdk.dfinity.org/install.sh changed and now installs dfxvm (version manager) instead of dfx itself and also requires interaction. This broke the installation of dfx on our CI jobs.

There is a GitHub actions provide which also installs dfx.

# Changes

In our CI jobs that requires dfx installed, use the GitHub action before `bin/dfx-sns-demo-install` gets called, such that we are not forced into the interactive install flow.