### PR TITLE
Fix snsdemo snapshot for dfxvm

### DIFF
--- a/bin/dfx-snapshot-save
+++ b/bin/dfx-snapshot-save
@@ -45,7 +45,10 @@ IFS=', ' read -r -a DFX_IDENTITIES <<<"$DFX_IDENTITIES"
 
 # Get global state
 pushd "$HOME"
-tar --create --file "$DFX_SNAPSHOT_TEMP_FILE" "$LOCAL_REPLICA_DATA_DIR" .config/dfx/{networks,version-manager}.json
+tar --create --file "$DFX_SNAPSHOT_TEMP_FILE" "$LOCAL_REPLICA_DATA_DIR" .config/dfx/networks.json
+if [[ -f .config/dfx/version-manager.json ]]; then
+  tar --append --file "$DFX_SNAPSHOT_TEMP_FILE" .config/dfx/version-manager.json
+fi
 for id in "${DFX_IDENTITIES[@]}"; do
   tar --append --file "$DFX_SNAPSHOT_TEMP_FILE" ".config/dfx/identity/${id}"
 done

--- a/bin/dfx-snapshot-save
+++ b/bin/dfx-snapshot-save
@@ -45,7 +45,7 @@ IFS=', ' read -r -a DFX_IDENTITIES <<<"$DFX_IDENTITIES"
 
 # Get global state
 pushd "$HOME"
-tar --create --file "$DFX_SNAPSHOT_TEMP_FILE" "$LOCAL_REPLICA_DATA_DIR" .config/dfx/networks.json
+tar --create --file "$DFX_SNAPSHOT_TEMP_FILE" "$LOCAL_REPLICA_DATA_DIR" .config/dfx/{networks,version-manager}.json
 for id in "${DFX_IDENTITIES[@]}"; do
   tar --append --file "$DFX_SNAPSHOT_TEMP_FILE" ".config/dfx/identity/${id}"
 done

--- a/bin/dfx-sns-demo-mksns-parallel
+++ b/bin/dfx-sns-demo-mksns-parallel
@@ -22,14 +22,19 @@ make_user() {
   (
     DEMO_USER="$1"
     DEMODIR="$DEMO_USER_DIR/$1"
+    if [[ "$(uname)" == "Darwin" ]]; then
+      RELATIVE_DFX_DIR="Library/Application Support/org.dfinity.dfx"
+    else
+      RELATIVE_DFX_DIR=".local/share/dfx"
+    fi
     rm -fr "$DEMODIR"
-    mkdir -p "$DEMODIR/.config" "$DEMODIR/.local/share"
+    mkdir -p "$DEMODIR/.config" "$(dirname "$DEMODIR/$RELATIVE_DFX_DIR")"
     # Share some data:
     ln -s "$PWD/bin" "$DEMODIR/bin"
     ln -s "$PWD/logo.png" "$DEMODIR/logo.png"
     ln -s "$PWD/candid" "$DEMODIR/candid"
     ln -s "$PWD/bin-other" "$DEMODIR/bin-other"
-    ln -s "$HOME/.local/share/dfx" "$DEMODIR/.local/share/dfx"
+    ln -s "$HOME/$RELATIVE_DFX_DIR" "$DEMODIR/$RELATIVE_DFX_DIR"
     # Copy dfx.json and the user config
     cp dfx.json "$DEMODIR/"
     cp -R "$HOME/.config/dfx" "$DEMODIR/.config/dfx"


### PR DESCRIPTION
# Motivation

When using `dfx` with `dfxvm`, there some extra required configuration to determine which version of `dfx` to use.
This affects snapshots in 2 ways:

1. When you start a snapshot, this configuration is replaced by the snapshot, so if the snapshot does not contain it, you will get an error when running dfx because it doesn't know which version to use.
2. The script to create SNSes in parallel creates separate users and these users need this configuration to use `dfx`. This already worked on Linux because a symbolic link of the config directory was created. But the config directory is different on Mac.

# Changes

1. Include `version-manager.json` in the snapshot, so that when the snapshot is used, `dfx` knows which version to use.
2. Use the correct directory on Mac to create a symbolic link for the config.

# Tested

Manually tested on DevEnv and Mac. Tested on CI.