### PR TITLE
Replace the GIX team with the NNS team in the codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # The codebase is owned by the Governance & Identity Experience team at DFINITY
 # For questions, reach out to: <gix@dfinity.org>
-* @dfinity/gix
+* @dfinity/nns-team


### PR DESCRIPTION
# Motivation
@dfinity/nns-team has taken over maintenance of this project.  The codeowners file needs to be updated to reflect this.

# Changes
- Replace @dfinity/gix with @dfinity/nns-team in the CODEOWNERS file