### PR TITLE
Update IC commit

### DIFF
--- a/bin/versions.bash
+++ b/bin/versions.bash
@@ -2,7 +2,7 @@
 # shellcheck disable=SC2034 # Variables are expected to be unused in this file
 # Release from 2023-05-30 which includes geo restriction fields
 SNS_AGGREGATOR_RELEASE=proposal-125509-agg
-DFX_IC_COMMIT=b531d2e0a7438d61ce14915a2d0b43684ff7d667
+DFX_IC_COMMIT=dd129cd0ac86a90f2dc97073f1271456ddfd9296
 INTERNET_IDENTITY_RELEASE=release-2023-10-27
 NNS_DAPP_RELEASE=proposal-121690
 DIDC_VERSION=2023-07-25


### PR DESCRIPTION
# Motivation

I'm adding tests for proposal types in nns-dapp and for that we need a version of `ic-admin` that supports `propose-to-revise-elected-hostos-versions`.

# Changes

Update IC commit to [dd129cd0ac86a90f2dc97073f1271456ddfd9296](https://github.com/dfinity/ic/commit/dd129cd0ac86a90f2dc97073f1271456ddfd9296).

# Tested

Installed `ic-admin` from this commit and was able to use all the subcommands I wanted to test.
With the current IC commit, I was not able to run `propose-to-revise-elected-hostos-versions`.
