### PR TITLE
Make it easier to create a manual snsdemo release

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Stop dfx
         run: dfx stop
       - name: Tag if release should be created
-        if: ${{ (github.event_name == 'schedule') || (github.inputs.make_release == true)}}
+        if: ${{ (github.event_name == 'schedule') || (inputs.make_release)}}
         id: tag
         run: |
           set -euxo pipefail

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -2,6 +2,11 @@ name: Create a snapshot image
 on:
   push:
   workflow_dispatch:
+    inputs:
+      make_release:
+        description: 'Make release'
+        default: false
+        type: boolean
   schedule:
     - cron: '30 3 * * WED'
 env:
@@ -43,19 +48,21 @@ jobs:
       - name: Stop dfx
         run: dfx stop
       - name: Tag if run on a schedule
-        if: ${{ (github.event_name == 'schedule') || (github.ref_name == 'snapshot-schedule') }}
+        if: ${{ (github.event_name == 'schedule') || (github.inputs.make_release == true)}}
         id: tag
         run: |
           set -euxo pipefail
           tag_name="$(date +release-%Y-%m-%d)"
-          if git show-ref --tags --verify --quiet "refs/tags/${tag_name}";
-          then
-            echo "There is already a tag for today's release: ${tag_name}"
-          else
-            echo "Tagging as '${tag_name}'"
-            git tag "${tag_name}"
-            git push origin "refs/tags/${tag_name}"
-          fi
+          index=0
+          while git show-ref --tags --verify --quiet "refs/tags/${tag_name}"; do
+            echo "Tag ${tag_name} already exists."
+            index=$((index + 1))
+            tag_name="$(date +release-%Y-%m-%d).${index}"
+            echo "Trying tag ${tag_name}."
+          done
+          echo "Tagging as '${tag_name}'"
+          git tag "${tag_name}"
+          git push origin "refs/tags/${tag_name}"
       - name: Release
         uses: ./.github/actions/release
         with:

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -47,7 +47,7 @@ jobs:
         run: bin/dfx-stock-test
       - name: Stop dfx
         run: dfx stop
-      - name: Tag if run on a schedule
+      - name: Tag if release should be created
         if: ${{ (github.event_name == 'schedule') || (github.inputs.make_release == true)}}
         id: tag
         run: |

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -54,6 +54,7 @@ jobs:
           set -euxo pipefail
           tag_name="$(date +release-%Y-%m-%d)"
           index=0
+          # If there is already a tag with the same name, try appending ".${next_integer}".
           while git show-ref --tags --verify --quiet "refs/tags/${tag_name}"; do
             echo "Tag ${tag_name} already exists."
             index=$((index + 1))

--- a/README.md
+++ b/README.md
@@ -37,14 +37,9 @@ the parameters passed to `ic-admin` from `bin/dfx-sns-sale-propose`.
 
 ### CI
 
-A new stock snapshot can be released by pushing a tag:
-
-```
-RELEASE="release-$(date +"%Y-%m-%d")"
-echo "$RELEASE"
-git tag "$RELEASE"
-git push origin "$RELEASE"
-```
+A new stock snapshot can be released by running the
+[Create a snapshot image workflow](https://github.com/dfinity/snsdemo/actions/workflows/snapshot.yml)
+and checking the "Make release" box.
 
 This will cause GitHub actions to create a new snapshot, which can be found
 [here](https://github.com/dfinity/snsdemo/tags).


### PR DESCRIPTION
# Motivation

snsdemo releases are automatically created once a week.
In order to create a release outside the schedule, one has to perform some manual steps.
Since we already have a workflow that can create a release let's also use that for manual release.

# Changes

1. Add a checkbox when starting the workflow manually to indicate a release should be created.
2. Create a release when the checkbox is checked in addition to when the workflow runs on schedule.
3. Remove the functionality to create a release from branch `snapshot-schedule`. This was a branch created by @bitdivine supposedly for testing.
4. If a release was already created on the same day, try appending `.1` or `.2` etc., similar to what ic-js and gix-components do.

# Tested

Checkbox appears:
<img width="385" alt="image" src="https://github.com/dfinity/snsdemo/assets/122978264/1a2e4363-6be8-4e7a-b8c0-5f8e15558ce8">

Created this release from this branch: https://github.com/dfinity/snsdemo/releases/tag/release-2024-05-10