### PR TITLE
Revert "Disable automatic update of dfx version"

### DIFF
--- a/.github/workflows/update-dfx.yml
+++ b/.github/workflows/update-dfx.yml
@@ -2,6 +2,9 @@
 # and creates a PR on new versions.
 name: Update dfx
 on:
+  schedule:
+    # check for new dfx versions weekly
+    - cron: '30 3 * * FRI'
   workflow_dispatch:
   # Provide an option to run this manually.
   push:


### PR DESCRIPTION
Reverts dfinity/snsdemo#322

# Motivation

With `dfxvm` it is less disruptive to have frequent `dfx` updates.
It's good to find out early when `dfx` breaks us.

# Changes

Clicked the "Revert" button in GitHub.