### PR TITLE
Do not recreate snsdemo8 identity

### DIFF
--- a/bin/dfx-sns-demo
+++ b/bin/dfx-sns-demo
@@ -44,12 +44,12 @@ export DFX_IC_COMMIT
 } >&2
 
 sleep 1
-rm -fr "$HOME/.config/dfx/identity/snsdemo8"
-sleep 1
-dfx identity new --storage-mode=plaintext snsdemo8
-sleep 1
+if dfx identity get-principal --identity snsdemo8; then
+  rm -fr "$HOME/.config/dfx/identity/snsdemo8/neurons/local"
+else
+  dfx identity new --storage-mode=plaintext snsdemo8
+fi
 dfx identity use snsdemo8
-sleep 1
 
 sleep 1
 dfx-network-deploy --network "$DFX_NETWORK" --ic_dir "$IC_REPO_DIR" --nd_dir "$ND_REPO_DIR" --commit "$DFX_IC_COMMIT"


### PR DESCRIPTION
# Motivation

`dfx-sns-demo` deletes and recreates the snsdemo8 identity every time it is run.
This is unnecessary and can be confusing and inconvenient.

# Changes

1. Instead of deleting the entire snsdemo8 identity, only delete the neurons file. The neuron will be recreated during the demo and the old neuron won't exist anymore. But it's expected to get the same neuron ID because we pass a `--name` which determines the nonce that's used.
2. Only create the snsdemo8 identity if it doesn't exist already.

# Tested

Ran `dfx-sns-demo` with and without pre-existing snsdemo8 identity.