### PR TITLE
Store selected identity in snapshot

### DIFF
--- a/bin/dfx-snapshot-save
+++ b/bin/dfx-snapshot-save
@@ -46,9 +46,12 @@ IFS=', ' read -r -a DFX_IDENTITIES <<<"$DFX_IDENTITIES"
 # Get global state
 pushd "$HOME"
 tar --create --file "$DFX_SNAPSHOT_TEMP_FILE" "$LOCAL_REPLICA_DATA_DIR" .config/dfx/networks.json
-if [[ -f .config/dfx/version-manager.json ]]; then
-  tar --append --file "$DFX_SNAPSHOT_TEMP_FILE" .config/dfx/version-manager.json
-fi
+for config_file in identity.json version-manager.json; do
+  config_path=".config/dfx/$config_file"
+  if [[ -f "$config_path" ]]; then
+    tar --append --file "$DFX_SNAPSHOT_TEMP_FILE" "$config_path"
+  fi
+done
 for id in "${DFX_IDENTITIES[@]}"; do
   tar --append --file "$DFX_SNAPSHOT_TEMP_FILE" ".config/dfx/identity/${id}"
 done


### PR DESCRIPTION
# Motivation

Currently when starting a snapshot, you need to run `dfx identity use snsdemo8` before you can upgrade any canisters.
This is because we don't include `identity.json` in the snapshot.

# Changes

Include `identity.json` in the snapshot.

# Tested

Created and started a snapshot. Then ran `dfx identity list` to see `snsdemo8` selected. The original identity is selected once again when the snapshot is stopped.