### PR TITLE
Refuse to create a snapshot if a replica is running.

### DIFF
--- a/bin/dfx-snapshot-stock-make
+++ b/bin/dfx-snapshot-stock-make
@@ -20,6 +20,11 @@ clap.define long=parallel_sns_count desc="Number of additional SNSes to create i
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
+if pgrep replica; then
+  echo "❌ A replica is already running. Stop it before creating a snapshot."
+  exit 1
+fi
+
 onSetupFailure() {
   # Stop the replica because otherwise it continues outputting logs, obscuring
   # the fact that the script has finished and making the error message hard to


### PR DESCRIPTION
# Motivation

When creating a snapshot, if any replicas are already running, they are killed.
This can be confusing or unintended.

But especially if it's a previously installed snapshot, that snapshot can be corrupted before it's stopped.
For example, when `bin/dfx-snapshot-stock-make` runs `dfxvm default "$(jq -r .dfx dfx.json)"` this may change the dfx version with which the currently active snapshot will be run next time, leading to corruption.

# Changes

Refuse to start the snapshot creation process if a replica is running.

# Tested

Ran `bin/dfx-snapshot-stock-make` while also creating another snapshot.