### PR TITLE
Update IC commit in snsdemo

### DIFF
--- a/bin/dfx-sns-propose
+++ b/bin/dfx-sns-propose
@@ -32,4 +32,4 @@ if [ ! -f logo.png ]; then
   ln -s "$SOURCE_DIR/../logo.png" ./logo.png
 fi
 
-sns propose --neuron-id "$DFX_NEURON_ID" ${PROPOSAL_ID_FILE:+--save-to "$PROPOSAL_ID_FILE"} --network "$DFX_NNS_URL" sns.yml
+sns propose --neuron-id "$DFX_NEURON_ID" ${PROPOSAL_ID_FILE:+--save-to "$PROPOSAL_ID_FILE"} --skip-confirmation --network "$DFX_NNS_URL" sns.yml

--- a/bin/versions.bash
+++ b/bin/versions.bash
@@ -2,7 +2,7 @@
 # shellcheck disable=SC2034 # Variables are expected to be unused in this file
 # Release from 2023-05-30 which includes geo restriction fields
 SNS_AGGREGATOR_RELEASE=proposal-125509-agg
-DFX_IC_COMMIT=1c221e6c4c1fe8fedd039505dd46760e24af7b22
+DFX_IC_COMMIT=416058ebefaccb09c7056e6151fc72fcbae5a1ba
 INTERNET_IDENTITY_RELEASE=release-2023-10-27
 NNS_DAPP_RELEASE=proposal-121690
 DIDC_VERSION=2023-07-25


### PR DESCRIPTION
# Motivation

https://github.com/dfinity/snsdemo/pull/365 failed to update the IC commit automatically, because sns CLI was changed in https://gitlab.com/dfinity-lab/public/ic/-/merge_requests/19803 to require human interaction.

# Changes

1. Update IC commit
2. Pass `--skip-confirmation` to  `sns propose`.

# Tested

CI passes again
