### PR TITLE
Make background replica output darker

### DIFF
--- a/bin/dfx-network-deploy
+++ b/bin/dfx-network-deploy
@@ -47,7 +47,12 @@ if [[ "$DFX_NETWORK" == "local" ]]; then
   : "Get the specified version of the nns-sns-wasm.wasm"
   curl "https://download.dfinity.systems/ic/${DFX_IC_COMMIT}/canisters/sns-wasm-canister.wasm.gz" | gunzip >"${WASM_DIR}/sns-wasm-canister.wasm"
 
-  dfx start --clean --background
+  # Output background replica output in a different color to make it easier to
+  # distinguish from the output of foreground processes.
+  export DARK="$(tput setab 8; tput setaf 0)"
+  export NORMAL="$(tput sgr0)"
+  dfx start --clean --background 2>&1 | sed -e "s@.*@${DARK}&${NORMAL}@" &
+
   dfx-nns-install --ic_commit "$DFX_IC_COMMIT"
   dfx-nns-import --network "$DFX_NETWORK"
   dfx-canister-set-id --canister_name nns-dapp --canister_id qsgjb-riaaa-aaaaa-aaaga-cai

--- a/bin/dfx-network-deploy
+++ b/bin/dfx-network-deploy
@@ -49,7 +49,10 @@ if [[ "$DFX_NETWORK" == "local" ]]; then
 
   # Output background replica output in a different color to make it easier to
   # distinguish from the output of foreground processes.
-  export DARK="$(tput setab 8; tput setaf 0)"
+  export DARK="$(
+    tput setab 8
+    tput setaf 0
+  )"
   export NORMAL="$(tput sgr0)"
   dfx start --clean --background 2>&1 | sed -e "s@.*@${DARK}&${NORMAL}@" &
 


### PR DESCRIPTION
# Motivation

When creating a snapshot, the replica runs in the background and its output is interleaved with the output of scripts setting up the state. This can make it difficult to understand what's going on, especially when debugging failures.

# Changes

Output the background replica output in a darker style.

# Tested

Example output from manual testing:
<img width="1220" alt="image" src="https://github.com/dfinity/snsdemo/assets/122978264/e87e83fc-f81d-4e6b-a087-7e299528df9a">

Unfortunately it is not visible on the GitHub Actions logs.