### PR TITLE
Use the access token when committing formatting changes

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -47,9 +47,8 @@ jobs:
         uses: EndBug/add-and-commit@v9.1.1
         with:
           add: .
-          author_name: Formatting Committer
-          author_email: "<nobody@example.com>"
-          message: "Updating frontend formatting"
+          default_author: github_actions
+          message: "Updating formatting"
           # do not pull: if this branch is behind, then we might as well let
           # the pushing fail
           pull_strategy: "NO-PULL"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -22,12 +22,12 @@ jobs:
 
       - name: Checkout
         if: steps.check_pat.outputs.has_pat == 'true'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           token: ${{ secrets.GIX_CREATE_PR_PAT }}
       - name: Checkout without personal access token
         if: steps.check_pat.outputs.has_pat == 'false'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install shfmt
         run: sudo snap install --classic shfmt

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -7,31 +7,61 @@ on:
 jobs:
   formatting:
     runs-on: ubuntu-20.04
-    env:
-      DFX_NETWORK: mainnet
+
+    # In order to trigger the CLA after committing formatting changes, we need
+    # to use the GIX_CREATE_PR_PAT token. This token is not available for all
+    # users. So on PRs where the token is not available, we don't commit
+    # changes and instead just fail if the formatting is incorrect.
     steps:
+      - name: Check if personal access token is available
+        id: check_pat
+        run: |
+          echo "has_pat=${{ secrets.GIX_CREATE_PR_PAT != '' }}" >> $GITHUB_OUTPUT
+
       - name: Checkout
+        if: steps.check_pat.outputs.has_pat == 'true'
         uses: actions/checkout@v3
-        if: ${{ github.event_name == 'pull_request' }}
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
-      - name: Checkout
+          token: ${{ secrets.GIX_CREATE_PR_PAT }}
+      - name: Checkout without personal access token
+        if: steps.check_pat.outputs.has_pat == 'false'
         uses: actions/checkout@v3
-        if: ${{ github.event_name != 'pull_request' }}
+
       - name: Install shfmt
         run: sudo snap install --classic shfmt
       - name: Format shell scripts
         run: ./scripts/fmt-sh
+
       - name: Restore dfx.json
         run: cp dfx.json.original dfx.json
-      - name: Commit Formatting changes - will not trigger rebuild
+      - name: Commit Formatting changes
         uses: EndBug/add-and-commit@v9.1.1
-        if: ${{ github.event_name == 'pull_request' }}
+
+      - name: Check formatting changes
+        id: check_format
+        run: |
+          if git diff --exit-code; then
+            echo "formatting_needed=false" >> $GITHUB_OUTPUT
+          else
+            echo "formatting_needed=true" >> $GITHUB_OUTPUT
+          fi
+      - name: Commit Formatting changes
+        if: steps.check_pat.outputs.has_pat == 'true' && steps.check_format.outputs.formatting_needed == 'true'
+        uses: EndBug/add-and-commit@v7.2.0
         with:
           add: .
           author_name: Formatting Committer
           author_email: "<nobody@example.com>"
           message: "Updating frontend formatting"
+          # do not pull: if this branch is behind, then we might as well let
+          # the pushing fail
+          pull_strategy: "NO-PULL"
+
+      - name: Fail for formatting issues without personal access token
+        if: steps.check_pat.outputs.has_pat == 'false' && steps.check_format.outputs.formatting_needed == 'true'
+        run: |
+          echo "Formatting changes are needed but couldn't be committed because the personal access token isn't available."
+          exit 1
   shell-checks:
     needs: formatting
     name: ShellCheck

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -34,9 +34,6 @@ jobs:
 
       - name: Restore dfx.json
         run: cp dfx.json.original dfx.json
-      - name: Commit Formatting changes
-        uses: EndBug/add-and-commit@v9.1.1
-
       - name: Check formatting changes
         id: check_format
         run: |
@@ -47,7 +44,7 @@ jobs:
           fi
       - name: Commit Formatting changes
         if: steps.check_pat.outputs.has_pat == 'true' && steps.check_format.outputs.formatting_needed == 'true'
-        uses: EndBug/add-and-commit@v7.2.0
+        uses: EndBug/add-and-commit@v9.1.1
         with:
           add: .
           author_name: Formatting Committer

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   formatting:
     runs-on: ubuntu-20.04
+    env:
+      DFX_NETWORK: mainnet
 
     # In order to trigger the CLA after committing formatting changes, we need
     # to use the GIX_CREATE_PR_PAT token. This token is not available for all

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -46,7 +46,7 @@ jobs:
           fi
       - name: Commit Formatting changes
         if: steps.check_pat.outputs.has_pat == 'true' && steps.check_format.outputs.formatting_needed == 'true'
-        uses: EndBug/add-and-commit@v9.1.1
+        uses: EndBug/add-and-commit@v7.2.0
         with:
           add: .
           default_author: github_actions

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -20,12 +20,12 @@ jobs:
 
       - name: Checkout
         if: steps.check_pat.outputs.has_pat == 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
         with:
           token: ${{ secrets.GIX_CREATE_PR_PAT }}
       - name: Checkout without personal access token
         if: steps.check_pat.outputs.has_pat == 'false'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
 
       - name: Install shfmt
         run: sudo snap install --classic shfmt

--- a/bin/dfx-software-ic-latest
+++ b/bin/dfx-software-ic-latest
@@ -52,7 +52,7 @@ if [[ "$(git rev-parse --is-inside-work-tree)" != "true" ]]; then
 fi
 
 (
-  git      fetch
+  git fetch
   if test -n "${IC_COMMIT_BEFORE:-}"; then
     IC_COMMIT="$(git log --pretty=%P -n 1 "$IC_COMMIT_BEFORE" | awk '{print $(NF)}')"
   elif test -n "${IC_COMMIT_AFTER:-}"; then

--- a/bin/dfx-software-ic-latest
+++ b/bin/dfx-software-ic-latest
@@ -52,7 +52,7 @@ if [[ "$(git rev-parse --is-inside-work-tree)" != "true" ]]; then
 fi
 
 (
-  git fetch
+  git      fetch
   if test -n "${IC_COMMIT_BEFORE:-}"; then
     IC_COMMIT="$(git log --pretty=%P -n 1 "$IC_COMMIT_BEFORE" | awk '{print $(NF)}')"
   elif test -n "${IC_COMMIT_AFTER:-}"; then

--- a/bin/dfx-software-ic-latest
+++ b/bin/dfx-software-ic-latest
@@ -52,7 +52,7 @@ if [[ "$(git rev-parse --is-inside-work-tree)" != "true" ]]; then
 fi
 
 (
-  git    fetch
+  git fetch
   if test -n "${IC_COMMIT_BEFORE:-}"; then
     IC_COMMIT="$(git log --pretty=%P -n 1 "$IC_COMMIT_BEFORE" | awk '{print $(NF)}')"
   elif test -n "${IC_COMMIT_AFTER:-}"; then

--- a/bin/dfx-software-ic-latest
+++ b/bin/dfx-software-ic-latest
@@ -52,7 +52,7 @@ if [[ "$(git rev-parse --is-inside-work-tree)" != "true" ]]; then
 fi
 
 (
-  git fetch
+  git    fetch
   if test -n "${IC_COMMIT_BEFORE:-}"; then
     IC_COMMIT="$(git log --pretty=%P -n 1 "$IC_COMMIT_BEFORE" | awk '{print $(NF)}')"
   elif test -n "${IC_COMMIT_AFTER:-}"; then


### PR DESCRIPTION
# Motivation

When the GitHub workflow commits formatting changes, it doesn't retrigger the CLA.
To make this work we need to use the personal access token.
Similar to [how we do it on gix-components](https://github.com/dfinity/gix-components/blob/cd06965e233ea02f91cef5c9ac2500c1ca8814bf/.github/workflows/checks.yml#L10).

# Changes

1. Check if the access token is available
2. If so, use it for checkout out the code, and later commit changes.
3. If not, just fail if changes were required.
4. Remove the `ref: ${{ github.event.pull_request.head.ref }}` parameter in case of pull requests. It's needed for the newer version of EndBug but would result in having to have 4 different conditional checkout steps.

Note that I had to use the same older version of `EndBug/add-and-commit@v7.2.0` that gix-components uses because  with `EndBug/add-and-commit@v9.1.1` I get:
https://github.com/dfinity/snsdemo/actions/runs/9594195671/job/26456241660
```
Error: Error: fatal: You are not currently on a branch.
```