### PR TITLE
Remove usage of sns import

### DIFF
--- a/bin/dfx-sns-demo
+++ b/bin/dfx-sns-demo
@@ -62,7 +62,6 @@ sleep 1
 dfx-nns-import --network "$DFX_NETWORK"
 sleep 1
 dfx-software-dfx-extension-sns-install --if-not-installed
-dfx sns import
 sleep 1
 
 bin/dfx-ledger-get-icp --icp 900000000 --network "$DFX_NETWORK"


### PR DESCRIPTION
Hopefully we can remove it from the SNS cli soon. Removing it from here means that won't be an issue. Thanks to https://github.com/dfinity/sdk/pull/3818, it no longer serves any purpose in this repository anyway