### PR TITLE
Add "unique_logo" flag

### DIFF
--- a/bin/dfx-snapshot-stock-make
+++ b/bin/dfx-snapshot-stock-make
@@ -17,6 +17,7 @@ clap.define short=s long=snapshot desc="The file to save to" variable=DFX_SNAPSH
 clap.define short=c long=ic_commit desc="The IC commit to use" variable=DFX_IC_COMMIT default="$(dfx-software ic current)"
 clap.define short=x long=ic_dir desc="Directory containing the ic source code; needed for deployments to static testnets" variable=IC_REPO_DIR default="$HOME/dfn/ic"
 clap.define long=parallel_sns_count desc="Number of additional SNSes to create in parallel after dfx-sns-demo finishes" variable=PARALLEL_SNS_COUNT default="10"
+clap.define long=unique_logo desc="A flag to use an config-index-based pseudo-unique logo instead of the default logo." variable=UNIQUE_LOGO default=false
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
@@ -40,7 +41,7 @@ trap onSetupFailure EXIT
 dfxvm default "$(jq -r .dfx dfx.json)"
 
 : Create stock state
-dfx-stock-deploy --ic_commit "$DFX_IC_COMMIT" --ic_dir "$IC_REPO_DIR" --parallel_sns_count "$PARALLEL_SNS_COUNT"
+dfx-stock-deploy --ic_commit "$DFX_IC_COMMIT" --ic_dir "$IC_REPO_DIR" --parallel_sns_count "$PARALLEL_SNS_COUNT" --unique_logo "$UNIQUE_LOGO"
 
 : "Wait for aggregator to get all SNSs"
 # 2 SNSes were created by dfx-sns-demo.

--- a/bin/dfx-sns-demo
+++ b/bin/dfx-sns-demo
@@ -13,6 +13,7 @@ clap.define short=c long=ic_commit desc="The IC commit to use" variable=DFX_IC_C
 clap.define short=x long=ic_dir desc="Directory containing the ic source code" variable=IC_REPO_DIR default="$HOME/dfn/ic"
 clap.define short=y long=nd_dir desc="Directory containing the nns-dapp source code" variable=ND_REPO_DIR default="$HOME/dfn/nns-dapp"
 clap.define long=config_index desc="The value for the dfx-sns-demo-mksns-config --config_index parameter" variable=CONFIG_INDEX default="0"
+clap.define long=unique_logo desc="A flag to use an config-index-based pseudo-unique logo instead of the default logo." variable=UNIQUE_LOGO default=false
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 set -x
@@ -80,7 +81,7 @@ sleep 1
 ./bin/dfx-sns-wasm-upload --network "$DFX_NETWORK"
 sleep 1
 
-./bin/dfx-sns-demo-mksns --network "$DFX_NETWORK" --config_index "$CONFIG_INDEX"
+./bin/dfx-sns-demo-mksns --network "$DFX_NETWORK" --config_index "$CONFIG_INDEX" --unique_logo "$UNIQUE_LOGO"
 sleep 1
 ./bin/dfx-sns-sale-buy --network "$DFX_NETWORK"
 sleep 1

--- a/bin/dfx-sns-demo-mksns
+++ b/bin/dfx-sns-demo-mksns
@@ -16,12 +16,13 @@ source "$SOURCE_DIR/clap.bash"
 clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
 clap.define long=confirmation_text desc="A text that needs to be confirmed by the participants" variable=CONFIRMATION_TEXT default=""
 clap.define short=i long=config_index desc="The value for the dfx-sns-demo-mksns-config --config_index parameter" variable=CONFIG_INDEX default="0"
+clap.define long=unique_logo desc="A flag to use an config-index-based pseudo-unique logo instead of the default logo." variable=UNIQUE_LOGO default=false
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 set -x
 
 : Generate the sns.yml file.
-dfx-sns-demo-mksns-config --confirmation_text "${CONFIRMATION_TEXT:-}" --config_index "$CONFIG_INDEX"
+dfx-sns-demo-mksns-config --confirmation_text "${CONFIRMATION_TEXT:-}" --config_index "$CONFIG_INDEX" --unique_logo "$UNIQUE_LOGO"
 
 : Make sure we have enough resources.
 dfx ledger top-up --amount 2.0 --network "$DFX_NETWORK" "$(dfx identity get-wallet --network "$DFX_NETWORK")"

--- a/bin/dfx-sns-demo-mksns-config
+++ b/bin/dfx-sns-demo-mksns-config
@@ -14,7 +14,8 @@ source "$SOURCE_DIR/clap.bash"
 # Define options
 clap.define long=template_file desc="The sns init template yaml file" variable=SNS_INIT_PATH default="$SOURCE_DIR/sns_init.yaml"
 clap.define long=confirmation_text desc="A text that needs to be confirmed by the swap participants" variable=CONFIRMATION_TEXT default=""
-clap.define long=config_index desc="An index used to select different names and logos for Sns configuration." variable=CONFIG_INDEX
+clap.define long=config_index desc="An index used to select different names and/or logos for Sns configuration." variable=CONFIG_INDEX
+clap.define long=unique_logo desc="A flag to use an config-index-based pseudo-unique logo instead of the default logo." variable=UNIQUE_LOGO default=false
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
@@ -35,7 +36,12 @@ if [ $iteration -gt 0 ]; then
   TOKEN_SYMBOL="${TOKEN_SYMBOL}${iteration}"
   TOKEN_NAME="${TOKEN_NAME}${iteration}"
 fi
-TOKEN_LOGO="logos/$(echo "$TOKEN_NAME" | cut -c1).png"
+TOKEN_LOGO="logo.png"
+if [ "$UNIQUE_LOGO" = true ]; then
+    TOKEN_LOGO="logos/$(echo "$TOKEN_NAME" | cut -c1).png"
+fi
+
+
 PRINCIPAL="$(dfx identity get-principal)"
 # For original controllers, use:
 # dfx canister info smiley_dapp --network "$DFX_NETWORK" | perl -e 'while($_ = <>){ if (s/^Controllers: *//){s/ +/, /g;print $_} }'

--- a/bin/dfx-sns-demo-mksns-config
+++ b/bin/dfx-sns-demo-mksns-config
@@ -38,9 +38,8 @@ if [ $iteration -gt 0 ]; then
 fi
 TOKEN_LOGO="logo.png"
 if [ "$UNIQUE_LOGO" = true ]; then
-    TOKEN_LOGO="logos/$(echo "$TOKEN_NAME" | cut -c1).png"
+  TOKEN_LOGO="logos/$(echo "$TOKEN_NAME" | cut -c1).png"
 fi
-
 
 PRINCIPAL="$(dfx identity get-principal)"
 # For original controllers, use:

--- a/bin/dfx-sns-demo-mksns-parallel
+++ b/bin/dfx-sns-demo-mksns-parallel
@@ -12,6 +12,7 @@ clap.define short=s long=num_sns desc="The number of SNSs to create" variable=NU
 clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
 clap.define short=m long=majority desc="A user representing the majority vote" variable=DFX_PROPOSER default=""
 clap.define short=o long=config_index_offset desc="The start value for the dfx-sns-demo-mksns-config --config_index parameter" variable=CONFIG_INDEX_OFFSET default="0"
+clap.define long=unique_logo desc="A flag to use an config-index-based pseudo-unique logo instead of the default logo." variable=UNIQUE_LOGO default=false
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 set -x
@@ -78,7 +79,7 @@ create_all_sns() {
       make_user "$DEMO_USER"
       become_user "$DEMO_USER"
 
-      ./bin/dfx-sns-demo-mksns-config --config_index $((CONFIG_INDEX_OFFSET + i))
+      ./bin/dfx-sns-demo-mksns-config --config_index $((CONFIG_INDEX_OFFSET + i)) --unique_logo "$UNIQUE_LOGO"
       dfx ledger top-up --amount 4.0 --network "$DFX_NETWORK" "$(dfx identity get-wallet --network "$DFX_NETWORK")"
       dfx wallet balance --network "$DFX_NETWORK"
       dfx canister deposit-cycles 180000000000000 --network "$DFX_NETWORK" "$(dfx canister id nns-sns-wasm --network "$DFX_NETWORK")"

--- a/bin/dfx-stock-deploy
+++ b/bin/dfx-stock-deploy
@@ -34,7 +34,7 @@ if [[ "${DFX_IC_COMMIT:-}" == "latest" ]]; then
 fi
 
 : Set up SNS state and create one finalized SNS
-dfx-sns-demo --network "$DFX_NETWORK" --ic_commit "$DFX_IC_COMMIT" --ic_dir "$IC_REPO_DIR" --nd_dir "$ND_REPO_DIR"
+dfx-sns-demo --network "$DFX_NETWORK" --ic_commit "$DFX_IC_COMMIT" --ic_dir "$IC_REPO_DIR" --nd_dir "$ND_REPO_DIR" --unique_logo "$UNIQUE_LOGO"
 
 dfx-software-mock-bitcoin-install --network "$DFX_NETWORK" --ic_commit "$DFX_IC_COMMIT"
 

--- a/bin/dfx-stock-deploy
+++ b/bin/dfx-stock-deploy
@@ -23,6 +23,7 @@ clap.define short=c long=ic_commit desc="The IC commit to use" variable=DFX_IC_C
 clap.define short=x long=ic_dir desc="Directory containing the ic source code; needed for deployments to static testnets" variable=IC_REPO_DIR default="$HOME/dfn/ic"
 clap.define short=y long=nd_dir desc="Directory containing the nns-dapp source code; needed for deployments to static testnets" variable=ND_REPO_DIR default="$HOME/dfn/nns-dapp"
 clap.define long=parallel_sns_count desc="Number of additional SNSes to create in parallel after dfx-sns-demo finishes" variable=PARALLEL_SNS_COUNT default="10"
+clap.define long=unique_logo desc="A flag to use an config-index-based pseudo-unique logo instead of the default logo." variable=UNIQUE_LOGO default=false
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 set -x
@@ -38,11 +39,11 @@ dfx-sns-demo --network "$DFX_NETWORK" --ic_commit "$DFX_IC_COMMIT" --ic_dir "$IC
 dfx-software-mock-bitcoin-install --network "$DFX_NETWORK" --ic_commit "$DFX_IC_COMMIT"
 
 : Add 1 open SNS project.
-dfx-sns-demo-mksns --network "$DFX_NETWORK" --confirmation_text "I confirm the confirmation text" --config_index 1
+dfx-sns-demo-mksns --network "$DFX_NETWORK" --confirmation_text "I confirm the confirmation text" --config_index 1 --unique_logo "$UNIQUE_LOGO"
 
 : Add some more finalized SNS projects.
 if [ "${PARALLEL_SNS_COUNT:-0}" -gt 0 ]; then
-  dfx-sns-demo-mksns-parallel --network "$DFX_NETWORK" --num_sns "$PARALLEL_SNS_COUNT" --majority snsdemo8 --config_index_offset 2
+  dfx-sns-demo-mksns-parallel --network "$DFX_NETWORK" --num_sns "$PARALLEL_SNS_COUNT" --majority snsdemo8 --config_index_offset 2 --unique_logo "$UNIQUE_LOGO"
 fi
 
 : Set up ckbtc canisters


### PR DESCRIPTION
# Motivation

After using unique SNS names and logos, the new SNS demo images break the aggregator test because it's too much data to output all the stable memory as JSON. Having nice logos on CI isn't necessary. To reduce the size, we changed the scripts related to SNS creation to use a "logo.png" (which is 7816 bytes) image by default for all generated SNSes.

# Changes

- add `unique_logo` flag with false as default value.

# Test

- Tested manually by calling `dfx-snapshot-stock-make`, `dfx-sns-demo-mksns` and `dfx-sns-demo-mksns-config` scripts with different params.

`dfx-snapshot-stock-make --snapshot ...`
<img width="1519" alt="Screenshot 2024-07-05 at 12 39 28" src="https://github.com/dfinity/snsdemo/assets/98811342/ae5d68fe-c44c-4d29-a202-dae10984171b">


`dfx-snapshot-stock-make --unique_logo true --snapshot ...`
<img width="1519" alt="image" src="https://github.com/dfinity/snsdemo/assets/98811342/96ef9f69-39a0-40ce-bac3-8b28f88442b0">

