### PR TITLE
Add ckRED canisters to snapshot

### DIFF
--- a/bin/dfx-stock-deploy
+++ b/bin/dfx-stock-deploy
@@ -76,7 +76,7 @@ dfx-token-import --prefix ckred_ --commit "$DFX_IC_COMMIT"
 dfx-token-deploy \
   --prefix ckred_ \
   --token ckRED \
-  --decimals 6 \
+  --decimals 7 \
   --fee 4000 \
   --logo-svg-file "$SOURCE_DIR/../ckRED-logo.svg" \
   --network "$DFX_NETWORK" \

--- a/bin/dfx-stock-deploy
+++ b/bin/dfx-stock-deploy
@@ -71,6 +71,17 @@ dfx-token-deploy \
   --network "$DFX_NETWORK" \
   --yes
 
+: Set up ckRED canisters
+dfx-token-import --prefix ckred_ --commit "$DFX_IC_COMMIT"
+dfx-token-deploy \
+  --prefix ckred_ \
+  --token ckRED \
+  --decimals 6 \
+  --fee 4000 \
+  --logo-svg-file "$SOURCE_DIR/../ckRED-logo.svg" \
+  --network "$DFX_NETWORK" \
+  --yes
+
 : Mint 10M ckETH into the faucet addresses.
 # See https://github.com/dfinity/nns-dapp/blob/main/frontend/src/lib/api/dev.api.ts
 FAUCET_ADDRESS="jg6qm-uw64t-m6ppo-oluwn-ogr5j-dc5pm-lgy2p-eh6px-hebcd-5v73i-nqe"
@@ -78,6 +89,7 @@ FAUCET_ADDRESS="jg6qm-uw64t-m6ppo-oluwn-ogr5j-dc5pm-lgy2p-eh6px-hebcd-5v73i-nqe"
 # transferring from the minting account.
 dfx canister call cketh_ledger icrc1_transfer "(record {to=record{owner=principal \"$FAUCET_ADDRESS\"}; amount=10_000_000_000_000_000_000_000_000:nat})"
 dfx canister call ckusdc_ledger icrc1_transfer "(record {to=record{owner=principal \"$FAUCET_ADDRESS\"}; amount=10_000_000_000_000:nat})"
+dfx canister call ckred_ledger icrc1_transfer "(record {to=record{owner=principal \"$FAUCET_ADDRESS\"}; amount=10_000_000_000_000:nat})"
 
 : Add the nns root as a controller to the frontend canisters
 NNS_ROOT="$(dfx canister id nns-root --network "$DFX_NETWORK")"

--- a/ckRED-logo.svg
+++ b/ckRED-logo.svg
@@ -1,0 +1,26 @@
+<svg width="152" height="152" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <filter id="aShadow" x="-50%" y="-50%" width="200%" height="200%">
+            <feDropShadow dx="4" dy="4" stdDeviation="2" flood-color="black" flood-opacity="0.95" />
+        </filter>
+    </defs>
+
+    <!-- Concentric Circles -->
+    <circle cx="76" cy="76" r="75" stroke="#000000" stroke-width="0.1" fill="#FF0000" />
+    <circle cx="77" cy="73" r="70" stroke="#000000" stroke-width="0.1" fill="#FF4C4C" filter="url(#aShadow)" />
+    <circle cx="74" cy="74" r="65" stroke="#000000" stroke-width="0.1" fill="#FF6666" filter="url(#aShadow)" />
+    <circle cx="78" cy="71" r="60" stroke="#000000" stroke-width="0.1" fill="#FF8080" filter="url(#aShadow)" />
+    <circle cx="70" cy="74" r="55" stroke="#000000" stroke-width="0.1" fill="#FF9999" filter="url(#aShadow)" />
+    <circle cx="80" cy="72" r="50" stroke="#000000" stroke-width="0.1" fill="#FFB3B3" filter="url(#aShadow)" />
+    <circle cx="76" cy="79" r="45" stroke="#000000" stroke-width="0.1" fill="#FFCCCC" filter="url(#aShadow)" />
+    <circle cx="75" cy="81" r="40" stroke="#000000" stroke-width="0.1" fill="#FFE6E6" filter="url(#aShadow)" />
+    <circle cx="78" cy="73" r="35" stroke="#000000" stroke-width="0.1" fill="#FF0000" filter="url(#aShadow)" />
+    <circle cx="73" cy="74" r="30" stroke="#000000" stroke-width="0.1" fill="#FF4C4C" filter="url(#aShadow)" />
+    <circle cx="76" cy="77" r="25" stroke="#000000" stroke-width="0.1" fill="#FF6666" filter="url(#aShadow)" />
+    <circle cx="70" cy="74" r="20" stroke="#000000" stroke-width="0.1" fill="#FF8080" filter="url(#aShadow)" />
+    <circle cx="71" cy="78" r="15" stroke="#000000" stroke-width="0.1" fill="#FF9999" filter="url(#aShadow)" />
+    <circle cx="76" cy="73" r="10" stroke="#000000" stroke-width="0.1" fill="#FFB3B3" filter="url(#aShadow)" />
+    <circle cx="76" cy="76" r="4" stroke="#000000" stroke-width="0.1" fill="#FFCCCC" filter="url(#aShadow)" />
+    <!-- Text -->
+    <text x="76" y="85" font-weight="700" font-family="sans-serif" font-size="32" fill="#FFEFEF"  text-anchor="middle" filter="url(#aShadow)">ckRED</text>
+</svg>


### PR DESCRIPTION
# Motivation

For the imported token feature we need a custom token for testing.

# Changes

1. Add a logo file (generated new svg).
3. Create ckRED canisters in `bin/dfx-stock-deploy`.
4. Add 10M ckRED to the faucet.

# Tested

Created a snapshot and used it in NNS dapp

<img width="788" alt="image" src="https://github.com/dfinity/snsdemo/assets/98811342/4704a0c2-866c-4b1f-a681-10ecb9548360">
