### PR TITLE
Using aggregator installed by dfx

### DIFF
--- a/bin/dfx-network-deploy
+++ b/bin/dfx-network-deploy
@@ -59,6 +59,7 @@ if [[ "$DFX_NETWORK" == "local" ]]; then
   dfx-nns-install --ic_commit "$DFX_IC_COMMIT"
   dfx-nns-import --network "$DFX_NETWORK"
   dfx-canister-set-id --canister_name nns-dapp --canister_id qsgjb-riaaa-aaaaa-aaaga-cai
+  dfx-canister-set-id --canister_name sns_aggregator --canister_id sgymv-uiaaa-aaaaa-aaaia-cai
   dfx-canister-set-id --canister_name internet_identity --canister_id qhbym-qaaaa-aaaaa-aaafq-cai
   # Import and install ICP Index canister
   # TODO: Remove once the sdk team adds it to `dfx nns install`: https://dfinity.atlassian.net/browse/SDKTG-270

--- a/bin/dfx-nns-import
+++ b/bin/dfx-nns-import
@@ -89,11 +89,13 @@ case "${DFX_NETWORK}" in
 ic | mainnet)
   set_remote qoctq-giaaa-aaaaa-aaaea-cai nns-dapp
   set_remote rdmx6-jaaaa-aaaaa-aaadq-cai internet_identity
+  set_remote 3r4gx-wqaaa-aaaaq-aaaia-cai sns_aggregator
   ;;
 local)
   # `dfx nns install` installs canisters here:
   set_remote qhbym-qaaaa-aaaaa-aaafq-cai internet_identity
   set_remote qsgjb-riaaa-aaaaa-aaaga-cai nns-dapp
+  set_remote sgymv-uiaaa-aaaaa-aaaia-cai sns_aggregator
   ;;
 *)
   # Installation to other networks SHOULD be done in a way

--- a/bin/dfx-nns-install
+++ b/bin/dfx-nns-install
@@ -74,7 +74,8 @@ CURRENT_PRINCIPAL="$(dfx identity get-principal)"
 # ... `dfx nns install` does not populate canister IDs in `dfx.json` so we need to provide the canister IDs ourselves.
 II_CANISTER_ID=qhbym-qaaaa-aaaaa-aaafq-cai
 ND_CANISTER_ID=qsgjb-riaaa-aaaaa-aaaga-cai
-for canister in "$II_CANISTER_ID" "$ND_CANISTER_ID"; do
+AGG_CANISTER_ID=sgymv-uiaaa-aaaaa-aaaia-cai
+for canister in "$II_CANISTER_ID" "$ND_CANISTER_ID" "$AGG_CANISTER_ID"; do
   # If the current user is not already a controller...
   dfx canister info "$canister" | awk '($1 == "Controllers:")' | grep -w "$CURRENT_PRINCIPAL" || {
     # ... this is presumably dfx v0.15.1 or later and the anonymous user is a controller

--- a/bin/dfx-sns-aggregator-wait
+++ b/bin/dfx-sns-aggregator-wait
@@ -71,7 +71,7 @@ get_sns_count() {
       aggregator_url="http://$(dfx canister id sns_aggregator).localhost:8080/v1/sns/list/page/$page/slow.json"
       curl -fsS "$aggregator_url" 2>/dev/null | jq length
     } || true
-  done | awk '{i+=$1}END{print i}'
+  done | awk 'BEGIN{i=0}{i+=$1}END{print i}'
 }
 
 wait_for_sns_count() {

--- a/bin/dfx-software-sns-aggregator-install
+++ b/bin/dfx-software-sns-aggregator-install
@@ -57,10 +57,9 @@ jq -e '.canisters.sns_aggregator' dfx.json >/dev/null || {
   jq -s '.[0] * .[1]' <(echo '{"canisters": { "sns_aggregator": { "type": "custom", "candid": "candid/sns_aggregator.did", "wasm": "'"${WASM_FILE}"'", "build": "true" }}}') dfx.json | sponge dfx.json
 }
 
-echo "Creating sns_aggregator canister..."
-dfx canister create sns_aggregator --network "${DFX_NETWORK}" || {
-  echo "Canister seems to exist already."
-}
+: "If the canister was remote, it isn't any more:"
+DFX_NETWORK="$DFX_NETWORK" jq 'del(.canisters.sns_aggregator.remote.id[env.DFX_NETWORK])' dfx.json | sponge dfx.json
+
 echo "Installing sns_aggregator..."
 # Note: We specify the wasm file explicitly as an existing wasm path may not point to the requested wasm.
 dfx canister install sns_aggregator --wasm "$WASM_FILE" --upgrade-unchanged --mode "$DFX_MODE" --yes --network "${DFX_NETWORK}"

--- a/bin/dfx-software-sns-aggregator-install.test
+++ b/bin/dfx-software-sns-aggregator-install.test
@@ -24,6 +24,12 @@ for flavour in dev prod; do
       git checkout dfx.json
       dfx-network-stop
       dfx start --clean --background 2>/dev/null
+      jq '.canisters.sns_aggregator = {
+        "type": "custom",
+        "wasm": "",
+        "candid": "sns_aggregator.did"
+      }' dfx.json | sponge dfx.json
+      dfx canister create sns_aggregator
       : Install
       dfx-software-sns-aggregator-install --release "$release" --flavor "$flavour"
       : The downloaded wasm should be the pinned, production version, not called 'pinned' or some mutable alias:


### PR DESCRIPTION
# Motivation

The latest `dfx nns` extension now also install the SNS aggregator.
That means that snsdemo snapshot now have 2 aggregators installed.
Additionally the aggregator installed by dfx has setting which cause it to produce a lot of spam.
The solution is to reinstall the installed aggregator instead of installing a second one.

# Changes

1. Hard code sns_aggregator canister ID similar to how nns-dapp and internet_identity are hard coded.
2. Make `snsdemo8` a controlled of the sns_aggregator installed by dfx, similar to nns-dapp and internet_identity.
3. Instead of creating a new sns_aggregator canister, make it so the existing one can be reinstalled.
4. Drive-by: Fix `bin/dfx-sns-aggregator-wait` for the case when there are 0 SNSes.

# Tested

1. Created a snapshot.
2. Checked that it didn't produce crazy amounts of spam.
3. Checked that there is only aggregator output from 1 canister.
4. Checked that NNS dapp connects correctly to the aggregator.
5. Update `bin/dfx-software-sns-aggregator-install.test` to make sure the canister already exists, as if `dfx nns install` was already called.