### PR TITLE
Use access token GIX_CREATE_PR_PAT instead of GIX_SNSDEMO_BOT_GH_TOKEN

### DIFF
--- a/.github/workflows/update-dfx.yml
+++ b/.github/workflows/update-dfx.yml
@@ -42,9 +42,9 @@ jobs:
         # If a newer dfx is available, create a PR.
       - name: Create Pull Request
         if: ${{ steps.update.outputs.updated == '1' }}
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v4
         with:
-          token: ${{ secrets.GIX_SNSDEMO_BOT_GH_TOKEN }}
+          token: ${{ secrets.GIX_CREATE_PR_PAT }}
           base: main
           add-paths: |
             dfx.json

--- a/.github/workflows/update-dfx.yml
+++ b/.github/workflows/update-dfx.yml
@@ -42,7 +42,7 @@ jobs:
         # If a newer dfx is available, create a PR.
       - name: Create Pull Request
         if: ${{ steps.update.outputs.updated == '1' }}
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.GIX_SNSDEMO_BOT_GH_TOKEN }}
           base: main

--- a/.github/workflows/update-ic.yml
+++ b/.github/workflows/update-ic.yml
@@ -47,7 +47,7 @@ jobs:
         # If a newer commit is available, create a PR.
       - name: Create Pull Request
         if: ${{ steps.update.outputs.updated == '1' }}
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.GIX_SNSDEMO_BOT_GH_TOKEN }}
           base: main

--- a/.github/workflows/update-ic.yml
+++ b/.github/workflows/update-ic.yml
@@ -47,7 +47,7 @@ jobs:
         # If a newer commit is available, create a PR.
       - name: Create Pull Request
         if: ${{ steps.update.outputs.updated == '1' }}
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v4
         with:
           token: ${{ secrets.GIX_SNSDEMO_BOT_GH_TOKEN }}
           base: main

--- a/.github/workflows/update-ic.yml
+++ b/.github/workflows/update-ic.yml
@@ -49,7 +49,7 @@ jobs:
         if: ${{ steps.update.outputs.updated == '1' }}
         uses: peter-evans/create-pull-request@v4
         with:
-          token: ${{ secrets.GIX_SNSDEMO_BOT_GH_TOKEN }}
+          token: ${{ secrets.GIX_CREATE_PR_PAT }}
           base: main
           add-paths: |
             bin/versions.bash


### PR DESCRIPTION
# Motivation

The [latest run](https://github.com/dfinity/snsdemo/actions/runs/10553072245/job/29232813566) to update the IC commit in snsdemo, had the following error:
```
fatal: could not read Username for 'https://github.com': No such device or address
```

After some searching, I found [this](https://github.com/peter-evans/create-pull-request/issues/2094), indicating that this is an issue with the access token.

After switching from `GIX_SNSDEMO_BOT_GH_TOKEN` to `GIX_CREATE_PR_PAT`, the issue went away.
We already use `GIX_CREATE_PR_PAT` in `nns-dapp`, `ic-js` and `gix-components` so it seems fine to use in snsdemo as well. The snsdemo repo already had access to the token.

# Changes

Change the version of `peter-evans/create-pull-request` that we use from v4 to v5.

# Tests

Ran the workflow from the branch and it succeeded:
https://github.com/dfinity/snsdemo/actions/runs/10556505138/job/29242171471
And it created this PR:
https://github.com/dfinity/snsdemo/pull/392