### PR TITLE
Include only network/local in Linux snapshot

### DIFF
--- a/bin/dfx-snapshot-restore
+++ b/bin/dfx-snapshot-restore
@@ -24,7 +24,7 @@ source "$(clap.build)"
 DFX_SNAPSHOT_FILE="$(realpath "$DFX_SNAPSHOT_FILE")"
 
 pushd "$HOME"
-rm -fr .local/share/dfx
+rm -fr .local/share/dfx/network/local
 tar --extract --xz --file "$DFX_SNAPSHOT_FILE"
 # Note: dfx start works here but not in the project dir.
 dfx start --background

--- a/bin/dfx-snapshot-save
+++ b/bin/dfx-snapshot-save
@@ -20,7 +20,7 @@ source "$(clap.build)"
 
 case "$(uname)" in
 Linux)
-  LOCAL_REPLICA_DATA_DIR=".local/share/dfx"
+  LOCAL_REPLICA_DATA_DIR=".local/share/dfx/network/local"
   ;;
 Darwin)
   LOCAL_REPLICA_DATA_DIR="Library/Application Support/org.dfinity.dfx/network/local"


### PR DESCRIPTION
# Motivation

I noticed that snapshots created on Linux were getting huge (> 600 MB), compared to snapshots created on Mac (~ 130 MB).
Inspecting the contents, it turned out that the snapshot includes full installations of all versions of `dfx` present on the system.

# Changes

1. Include `.local/share/dfx/network/local` in the archive instead of all of `.local/share/dfx`. This matches having `Library/Application Support/org.dfinity.dfx/network/local` on Mac, rather than all of `Library/Application Support/org.dfinity.dfx`.
2. Fix `bin/dfx-snapshot-restore` to not delete all of `.local/share/dfx`.

# Tested

1. CI still passes and runs on Linux.
3. Manually created a snapshot on DevEnv and was able to use it. Checked its size and it was 124 MB.