### PR TITLE
Bump sns_aggregator version to 129614-agg

### DIFF
--- a/bin/versions.bash
+++ b/bin/versions.bash
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2034 # Variables are expected to be unused in this file
-# Release from 2023-05-30 which includes geo restriction fields
-SNS_AGGREGATOR_RELEASE=proposal-125509-agg
+# Release from 2024-05-02 which includes nervous_system_parameters.
+SNS_AGGREGATOR_RELEASE=proposal-129614-agg
 DFX_IC_COMMIT=20321d1029aa2d0dff8c9148b1c236f5d7a78713
 INTERNET_IDENTITY_RELEASE=release-2023-10-27
 NNS_DAPP_RELEASE=proposal-121690


### PR DESCRIPTION
# Motivation

https://github.com/dfinity/nns-dapp/pull/4014 made nervous system parameters available via the SNS aggregator.
This change was made after release `proposal-125509-agg`.

# Changes

Update the pinned `SNS_AGGREGATOR_RELEASE` to `129614-agg`.

# Tested

Created a snapshot and checked that the aggregator has `"nervous_system_parameters"` with `"neuron_minimum_stake_e8s"`.