### PR TITLE
Install SNS wasms without gunzipping

### DIFF
--- a/bin/dfx-sns-wasm-download
+++ b/bin/dfx-sns-wasm-download
@@ -16,5 +16,5 @@ export DFX_IC_COMMIT
 
 if [[ "${1:-wasms}" == "wasms" ]]; then
   mkdir -p wasms
-  jq <"$SOURCE_DIR/sns_dfx.json" -r '.canisters | to_entries | map({url: "https://download.dfinity.systems/ic/\(env.DFX_IC_COMMIT)/canisters/\(.value.wasm).gz", file: "wasms/\(.value.wasm)"}) | map ("curl -L --fail \(.url) | gunzip > \(.file)") | .[]' | xargs -I{} bash -xc '{}'
+  jq <"$SOURCE_DIR/sns_dfx.json" -r '.canisters | to_entries | map({url: "https://download.dfinity.systems/ic/\(env.DFX_IC_COMMIT)/canisters/\(.value.wasm)", file: "wasms/\(.value.wasm)"}) | map ("curl -L --fail \(.url) > \(.file)") | .[]' | xargs -I{} bash -xc '{}'
 fi

--- a/bin/sns_dfx.json
+++ b/bin/sns_dfx.json
@@ -5,7 +5,7 @@
             "nns_sns_wasm_name": "governance"
         },
         "build": "",
-        "wasm": "sns-governance-canister_test.wasm",
+        "wasm": "sns-governance-canister_test.wasm.gz",
         "candid": "../governance/canister/governance.did",
         "type": "custom"
       },
@@ -14,7 +14,7 @@
             "nns_sns_wasm_name": "index"
         },
         "build": "",
-        "wasm": "ic-icrc1-index-ng.wasm",
+        "wasm": "ic-icrc1-index-ng.wasm.gz",
         "candid": "../../rosetta-api/icrc1/index-ng/index-ng.did",
         "type": "custom"
       },
@@ -23,7 +23,7 @@
             "nns_sns_wasm_name": "ledger"
         },
         "build": "",
-        "wasm": "ic-icrc1-ledger.wasm",
+        "wasm": "ic-icrc1-ledger.wasm.gz",
         "candid": "../../rosetta-api/icrc1/ledger/icrc1.did",
         "type": "custom"
       },
@@ -32,7 +32,7 @@
             "nns_sns_wasm_name": "archive"
         },
         "build": "",
-        "wasm": "ic-icrc1-archive.wasm",
+        "wasm": "ic-icrc1-archive.wasm.gz",
         "candid": "../swap/canister/swap.did",
         "type": "custom"
       },
@@ -41,7 +41,7 @@
             "nns_sns_wasm_name": "root"
         },
         "build": "",
-        "wasm": "sns-root-canister.wasm",
+        "wasm": "sns-root-canister.wasm.gz",
         "candid": "../root/canister/root.did",
         "type": "custom"
       },
@@ -50,7 +50,7 @@
             "nns_sns_wasm_name": "swap"
         },
         "build": "",
-        "wasm": "sns-swap-canister.wasm",
+        "wasm": "sns-swap-canister.wasm.gz",
         "candid": "../swap/canister/swap.did",
         "type": "custom"
       }


### PR DESCRIPTION
# Motivation

https://github.com/dfinity/ic/commit/7f0f5d5d3f2d7a827158daf8b20530c81e3fd46c caused the uncompressed SNS governance wasm to be too large to be uploaded to SNS-W.
This results in ([logs](https://github.com/dfinity/snsdemo/actions/runs/10877138238/job/30178056736?pr=400)):
```
Caused by: The replica returned an HTTP Error: Http Error: status 413 Payload Too Large, content type "text/plain; charset=utf-8", content: Request 0x873d0da0b95934042af97fe6d220608b3ce8aeb8aca343ef5f06a53c404d03c8 is too large. Message byte size 3687223 is larger than the max allowed 3670016.
```
when [updating the IC commit](https://github.com/dfinity/snsdemo/pull/400).

This happens because we decompress wasms before uploading them but there is no need to do that.

# Changes

1. Do not `gunzip` downloaded SNS wasms but upload the compressed wasms directly.
2. Update the wasm filenames in `bin/sns_dfx.json` to be what we actually store.

# Tested

I tried running `bin/dfx-sns-demo` with these changes with IC commit `d4ee25b0865e89d3eaac13a60f0016d5e3296b31` which caused the failures in https://github.com/dfinity/snsdemo/pull/400 and it no longer failed.