### PR TITLE
Wait for SNS lifecycle

### DIFF
--- a/bin/dfx-sns-get-lifecycle
+++ b/bin/dfx-sns-get-lifecycle
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+
+print_help() {
+  cat <<-EOF
+
+	Get the current lifecycle of the SNS as a descriptive string rather than a
+	number.
+	EOF
+}
+
+declare -A LIFECYCLE_MAP=(
+  [1]="pending"
+  [2]="open"
+  [3]="committed"
+  [4]="aborted"
+  [5]="adopted"
+)
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/clap.bash"
+# Define options
+clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
+clap.define short=i long=identity desc="The dfx identity to use" variable=DFX_IDENTITY default="$(dfx identity whoami)"
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+
+export DFX_NETWORK
+export DFX_IDENTITY
+
+LIFECYCLE_ID="$(dfx canister call sns_swap get_lifecycle '(record{})' | idl2json | jq -r '.lifecycle[0]')"
+
+echo "${LIFECYCLE_MAP[$LIFECYCLE_ID]}"

--- a/bin/dfx-sns-sale-buy
+++ b/bin/dfx-sns-sale-buy
@@ -15,6 +15,9 @@ source "$(clap.build)"
 
 export DFX_NETWORK
 
+# The swap must be open before we can buy in.
+dfx-sns-wait-for-lifecycle --lifecycle "open" --network "$DFX_NETWORK" --identity "$DFX_IDENTITY"
+
 # Set the purchased amout to the maximum allowed, if requested.
 if [[ "${AMOUNT:-}" = "max" ]]; then
   SWAP_STATE="$(dfx canister call sns_swap get_state '(record {})' --network "$DFX_NETWORK")"

--- a/bin/dfx-sns-sale-finalize
+++ b/bin/dfx-sns-sale-finalize
@@ -16,6 +16,9 @@ clap.define short=b long=bin desc="Local directory for executables" variable=USE
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
+# The swap must be committed before it can be finalized.
+dfx-sns-wait-for-lifecycle --lifecycle "committed" --network "$DFX_NETWORK" --identity "$DFX_IDENTITY"
+
 dfx canister --network "$DFX_NETWORK" call sns_swap finalize_swap '(record {})' | tee ,sns-sale-finalize.idl
 
 ERROR_MESSAGE="$(idl2json <,sns-sale-finalize.idl | jq -r '.error_message')"

--- a/bin/dfx-sns-wait-for-lifecycle
+++ b/bin/dfx-sns-wait-for-lifecycle
@@ -4,6 +4,8 @@ SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
 
 print_help() {
+  # ShellCheck somehow thinks this code is unreachable.
+  # shellcheck disable=SC2317
   cat <<-EOF
 
 	Wait up to 2 minutes for the current SNS to reach the given lifecycle.
@@ -30,6 +32,9 @@ clap.define short=i long=identity desc="The dfx identity to use" variable=DFX_ID
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
+# ShellCheck wants to remove the quotes to match on a regex. But the quote are
+# important to preserve the leading space.
+# shellcheck disable=SC2076
 if [[ ! "${LIFECYCLE_LIST}" =~ " ${LIFECYCLE:-}," ]]; then
   echo "ERROR: Unknown lifecycle '$LIFECYCLE'"
   echo "Please choose one of: $LIFECYCLE_LIST"

--- a/bin/dfx-sns-wait-for-lifecycle
+++ b/bin/dfx-sns-wait-for-lifecycle
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+PATH="$SOURCE_DIR:$PATH"
+
+print_help() {
+  cat <<-EOF
+
+	Wait up to 2 minutes for the current SNS to reach the given lifecycle.
+	EOF
+}
+
+LIFECYCLES=(
+  "pending"
+  "open"
+  "committed"
+  "aborted"
+  "adopted"
+)
+
+LIFECYCLE_LIST=$(printf " %s," "${LIFECYCLES[@]}")
+LIFECYCLE_LIST=${LIFECYCLE_LIST%,*}
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/clap.bash"
+# Define options
+clap.define short=l long=lifecycle desc="One of $LIFECYCLE_LIST" variable=LIFECYCLE default="open"
+clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
+clap.define short=i long=identity desc="The dfx identity to use" variable=DFX_IDENTITY default="$(dfx identity whoami)"
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+
+if [[ ! "${LIFECYCLE_LIST}" =~ " ${LIFECYCLE:-}," ]]; then
+  echo "ERROR: Unknown lifecycle '$LIFECYCLE'"
+  echo "Please choose one of: $LIFECYCLE_LIST"
+  exit 1
+fi
+
+current_lifecycle=$(dfx-sns-get-lifecycle --network "$DFX_NETWORK" --identity "$DFX_IDENTITY")
+
+echo "Current lifecycle: $current_lifecycle"
+echo "Waiting for lifecycle: $LIFECYCLE"
+
+for ((try = 60; try > 0; try--)); do
+  if [[ "$current_lifecycle" == "$LIFECYCLE" ]]; then
+    echo "Lifecycle reached."
+    exit 0
+  fi
+  sleep 2
+  current_lifecycle=$(dfx-sns-get-lifecycle --network "$DFX_NETWORK" --identity "$DFX_IDENTITY")
+done
+
+echo "ERROR: Lifecycle not reached after 2 minutes."
+exit 1


### PR DESCRIPTION
# Motivation

SNS swap used to update its lifecycle every second. Now it only does so once a minute.
When buying into the swap, or when finalizing the swap, it needs to be in the correct lifecycle.

# Changes

1. Add a script to get the current lifecycle of the current SNS.
2. Add a script to wait for the current SNS to be at a given lifecycle.
3. Use the script to make sure we are at the correct lifecycle before buying or finalizing.

# Tested

Tried creating a snapshot with the IC commit which has the new swap canister. It failed without these changes and passes with these (and other, upcoming) changes.