### PR TITLE
Update IC repo candid paths

### DIFF
--- a/bin/dfx-ckbtc-import
+++ b/bin/dfx-ckbtc-import
@@ -76,8 +76,8 @@ ckbtc_import() {
   }
   get_did rs/bitcoin/ckbtc/kyt/kyt.did "${LOCAL_PREFIX}kyt"
   get_did rs/bitcoin/ckbtc/minter/ckbtc_minter.did "${LOCAL_PREFIX}minter"
-  get_did rs/rosetta-api/icrc1/ledger/ledger.did "${LOCAL_PREFIX}ledger"
-  get_did rs/rosetta-api/icrc1/index-ng/index-ng.did "${LOCAL_PREFIX}index"
+  get_did rs/ledger_suite/icrc1/ledger/ledger.did "${LOCAL_PREFIX}ledger"
+  get_did rs/ledger_suite/icrc1/index-ng/index-ng.did "${LOCAL_PREFIX}index"
 
   : "Ckbtc canister import complete."
 }

--- a/bin/dfx-token-import
+++ b/bin/dfx-token-import
@@ -66,8 +66,8 @@ token_import() {
     echo "Getting  $local_path from $url..."
     curl -sSLf --retry 5 "$url" -o "$local_path"
   }
-  get_did rs/rosetta-api/icrc1/ledger/ledger.did "${LOCAL_PREFIX}ledger"
-  get_did rs/rosetta-api/icrc1/index-ng/index-ng.did "${LOCAL_PREFIX}index"
+  get_did rs/ledger_suite/icrc1/ledger/ledger.did "${LOCAL_PREFIX}ledger"
+  get_did rs/ledger_suite/icrc1/index-ng/index-ng.did "${LOCAL_PREFIX}index"
 
   : "Token canister import complete."
 }

--- a/bin/versions.bash
+++ b/bin/versions.bash
@@ -2,7 +2,7 @@
 # shellcheck disable=SC2034 # Variables are expected to be unused in this file
 # Release from 2024-05-02 which includes nervous_system_parameters.
 SNS_AGGREGATOR_RELEASE=proposal-129614-agg
-DFX_IC_COMMIT=afad27aa2fd646cc04a479e5f15b4cc7aa9ea446
+DFX_IC_COMMIT=51a67f0977e4354e8d44849a41baec9231395128
 INTERNET_IDENTITY_RELEASE=release-2023-10-27
 NNS_DAPP_RELEASE=proposal-121690
 DIDC_VERSION=2023-07-25


### PR DESCRIPTION
# Motivation

Ledger and Index Candid files were moved to a different directory in https://github.com/dfinity/ic/pull/1682

# Changes

1. Update the IC commit to one where the candid files have been moved.
2. Download the candid files from the new paths.

# Tested

CI passes