### PR TITLE
feat(sns-cli): Rename Distribution.InitialBalances.governance as Distribution.InitialBalances.treasury

### DIFF
--- a/bin/sns_init.yaml
+++ b/bin/sns_init.yaml
@@ -339,7 +339,7 @@ Distribution:
         # as the treasury. This is initialized in a special sub-account, as the
         # main account of Governance is the minting account of the SNS Ledger.
         # This field is specified as a token. For instance, "1 token".
-        governance: 2_937 tokens
+        treasury: 2_937 tokens
 
         # The initial SNS token balance of the Swap canister is what will be
         # available for the decentralization swap. These tokens will be swapped

--- a/bin/versions.bash
+++ b/bin/versions.bash
@@ -2,7 +2,7 @@
 # shellcheck disable=SC2034 # Variables are expected to be unused in this file
 # Release from 2024-05-02 which includes nervous_system_parameters.
 SNS_AGGREGATOR_RELEASE=proposal-129614-agg
-DFX_IC_COMMIT=36cbd803b7f6e5f811c720361e648b614ef66162
+DFX_IC_COMMIT=a1a9e39d6e94a48cc3f2a461cf328032b37b8b21
 INTERNET_IDENTITY_RELEASE=release-2023-10-27
 NNS_DAPP_RELEASE=proposal-133373
 DIDC_VERSION=2023-07-25

--- a/bin/versions.bash
+++ b/bin/versions.bash
@@ -2,7 +2,7 @@
 # shellcheck disable=SC2034 # Variables are expected to be unused in this file
 # Release from 2024-05-02 which includes nervous_system_parameters.
 SNS_AGGREGATOR_RELEASE=proposal-129614-agg
-DFX_IC_COMMIT=a1a9e39d6e94a48cc3f2a461cf328032b37b8b21
+DFX_IC_COMMIT=2b3b69ee4bdad75776a0ed668aa53500600af044
 INTERNET_IDENTITY_RELEASE=release-2023-10-27
 NNS_DAPP_RELEASE=proposal-133373
 DIDC_VERSION=2023-07-25


### PR DESCRIPTION
This PR adjusts the SNS configuration file after `Distribution.InitialBalances.governance` has been remapped from 
`initialTokenDistribution.treasuryDistribution.total` to
`Distribution.InitialBalances.treasury` in https://github.com/dfinity/ic/pull/1755.