### PR TITLE
Create wallet canisters sequentially

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -12,7 +12,7 @@ jobs:
   #    strategy:
   #      fail-fast: false
   #      matrix:
-  #        os: [ macos-12, ubuntu-22.04 ]
+  #        os: [ macos-14, ubuntu-22.04 ]
   #    steps:
   #      - name: Checkout
   #        uses: actions/checkout@v3
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-12, ubuntu-22.04]
+        os: [macos-14, ubuntu-22.04]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -32,7 +32,7 @@ jobs:
           echo "$HOME/.local/bin" >> $GITHUB_PATH
           echo "$PWD/bin" >> $GITHUB_PATH
       - name: Unbork mac
-        if: matrix.os == 'macos-12'
+        if: matrix.os == 'macos-14'
         run: |
           brew install bash
           echo "/usr/local/bin" >> $GITHUB_PATH
@@ -49,11 +49,11 @@ jobs:
           ./bin/dfx-sns-sale-buy
           ./bin/dfx-sns-sale-finalize
       - name: Create lots of SNS
-        if: matrix.os != 'macos-12'
+        if: matrix.os != 'macos-14'
         run: |
           ./bin/dfx-sns-demo-mksns-parallel -s 10 --config_index_offset 2 -m snsdemo8
       - name: Save state
-        if: matrix.os != 'macos-12'
+        if: matrix.os != 'macos-14'
         run: |
           # Stop the replica to let it persist all its state before we save the state.
           dfx stop
@@ -69,7 +69,7 @@ jobs:
           echo "Saving state"
           bin/dfx-snapshot-save --verbose --snapshot state.tar.xz
       - name: Upload state
-        if: matrix.os != 'macos-12'
+        if: matrix.os != 'macos-14'
         uses: actions/upload-artifact@v3
         with:
           name: snsdemo
@@ -81,7 +81,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-12, ubuntu-22.04]
+        os: [macos-14, ubuntu-22.04]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -90,7 +90,7 @@ jobs:
           echo "$HOME/.local/bin" >> $GITHUB_PATH
           echo "$PWD/bin" >> $GITHUB_PATH
       - name: Unbork mac
-        if: matrix.os == 'macos-12'
+        if: matrix.os == 'macos-14'
         run: |
           brew install bash
           echo "/usr/local/bin" >> $GITHUB_PATH
@@ -115,6 +115,6 @@ jobs:
           ./bin/dfx-sns-sale-buy
           ./bin/dfx-sns-sale-finalize
       - name: Create lots of SNS
-        if: matrix.os != 'macos-12'
+        if: matrix.os != 'macos-14'
         run: |
           ./bin/dfx-sns-demo-mksns-parallel -s 10 --config_index_offset 2 -m snsdemo8

--- a/bin/dfx-sns-demo-mksns-parallel
+++ b/bin/dfx-sns-demo-mksns-parallel
@@ -73,10 +73,14 @@ create_all_sns() {
   PROCESSES=()
   echo "I am $$"
   for ((i = 0; i < NUM_SNS_TO_MAKE; i++)); do
+    # Creating wallet canisters in parallel started occasionally failing with
+    # 0.24.1. When creating 10 in parallel, almost always at least 1 would fail.
+    # So we create the users outside the background process.
+    DEMO_USER="snsdemo_$i"
+    make_user "$DEMO_USER"
     (
       echo "Starting $BASHPID"
       DEMO_USER="snsdemo_$i"
-      make_user "$DEMO_USER"
       become_user "$DEMO_USER"
 
       ./bin/dfx-sns-demo-mksns-config --config_index $((CONFIG_INDEX_OFFSET + i)) --unique_logo "$UNIQUE_LOGO"

--- a/bin/dfx-sns-import-by-proposal
+++ b/bin/dfx-sns-import-by-proposal
@@ -64,13 +64,6 @@ for ((try = 20; try > 0; try--)); do
   sleep 2
 done
 
-list_root_canister_id() {
-  dfx canister call nns-sns-wasm list_deployed_snses '(record{})' | idl2json | jq -r '.instances[] | .root_canister_id[0]'
-}
-
-echo "Current $(list_root_canister_id | wc -l) existing SNS root canister Ids:"
-list_root_canister_id
-
 if [[ "$SUCCESS" = "false" ]]; then
   echo "Failed to import SNS canisters for proposal $PROPOSAL_ID" >&2
   exit 1

--- a/bin/dfx-sns-import-by-proposal
+++ b/bin/dfx-sns-import-by-proposal
@@ -69,7 +69,7 @@ list_root_canister_id() {
 }
 
 echo "Current $(list_root_canister_id | wc -l) existing SNS root canister Ids:"
-list_deployed_snses
+list_root_canister_id
 
 if [[ "$SUCCESS" = "false" ]]; then
   echo "Failed to import SNS canisters for proposal $PROPOSAL_ID" >&2

--- a/bin/dfx-sns-import-by-proposal
+++ b/bin/dfx-sns-import-by-proposal
@@ -64,6 +64,9 @@ for ((try = 20; try > 0; try--)); do
   sleep 2
 done
 
+echo "Current existing SNS root canister Ids:"
+dfx canister call nns-sns-wasm list_deployed_snses '(record{})' | idl2json | jq -r '.instances[] | .root_canister_id[0]'
+
 if [[ "$SUCCESS" = "false" ]]; then
   echo "Failed to import SNS canisters for proposal $PROPOSAL_ID" >&2
   exit 1

--- a/bin/dfx-sns-import-by-proposal
+++ b/bin/dfx-sns-import-by-proposal
@@ -65,7 +65,7 @@ for ((try = 20; try > 0; try--)); do
 done
 
 list_root_canister_id() {
-dfx canister call nns-sns-wasm list_deployed_snses '(record{})' | idl2json | jq -r '.instances[] | .root_canister_id[0]'
+  dfx canister call nns-sns-wasm list_deployed_snses '(record{})' | idl2json | jq -r '.instances[] | .root_canister_id[0]'
 }
 
 echo "Current $(list_root_canister_id | wc -l) existing SNS root canister Ids:"

--- a/bin/dfx-sns-import-by-proposal
+++ b/bin/dfx-sns-import-by-proposal
@@ -64,8 +64,12 @@ for ((try = 20; try > 0; try--)); do
   sleep 2
 done
 
-echo "Current existing SNS root canister Ids:"
+list_root_canister_id() {
 dfx canister call nns-sns-wasm list_deployed_snses '(record{})' | idl2json | jq -r '.instances[] | .root_canister_id[0]'
+}
+
+echo "Current $(list_root_canister_id | wc -l) existing SNS root canister Ids:"
+list_deployed_snses
 
 if [[ "$SUCCESS" = "false" ]]; then
   echo "Failed to import SNS canisters for proposal $PROPOSAL_ID" >&2

--- a/bin/dfx-stock-deploy
+++ b/bin/dfx-stock-deploy
@@ -49,6 +49,13 @@ if [ "${PARALLEL_SNS_COUNT:-0}" -gt 0 ]; then
   dfx-sns-demo-mksns-parallel --network "$DFX_NETWORK" --num_sns "$PARALLEL_SNS_COUNT" --majority snsdemo8 --config_index_offset 2 --unique_logo "$UNIQUE_LOGO"
 fi
 
+SNS_COUNT="$(dfx canister call nns-sns-wasm list_deployed_snses '(record{})' | idl2json | jq -r '.instances | length')"
+EXPECTED_SNS_COUNT="$((2 + PARALLEL_SNS_COUNT))"
+if [[ "$SNS_COUNT" != "$EXPECTED_SNS_COUNT" ]]; then
+  echo "❌ Expected $EXPECTED_SNS_COUNT SNSes. Found $SNS_COUNT"
+  exit 1
+fi
+
 : Set up ckbtc canisters
 dfx-ckbtc-import --prefix ckbtc_
 dfx-ckbtc-deploy --prefix ckbtc_ --network "$DFX_NETWORK" --yes


### PR DESCRIPTION
# Motivation

Since `dfx` 0.24.1, creating the snapshot results in creating only 11 or 10 SNSes instead of 12 almost every time.
For example: https://github.com/dfinity/snsdemo/actions/runs/11659664378/job/32460602932?pr=418

After debugging, I found out that creating wallet canisters as part of the parallel SNS creation started occasionally failing with.
```
Error: Failed to setup wallet caller.
Caused by: Failed to create wallet
Caused by: Failed to load wallet configuration
Caused by: failed to parse contents of /home/runner/work/snsdemo/snsdemo/users/snsdemo_1/.local/share/dfx/network/local/wallets.json as json
Caused by: EOF while parsing a value at line 1 column 0
```

I'm not sure why but it might not work well anymore to create many wallet canisters simultaneously.

Also, while I was debugging this it appears that MacOS-12 stopped being supported on GitHub.

# Changes

1. Move the creating the snsdemo identities (which includes wallet canister creation) outside the parallel process so that it is done sequentially.
2. Check that we have the expected number of SNSes after SNS creation is done.
3. Use MacOS 14 instead of MacOS 12.