### PR TITLE
Enforces an exact match of replica processes

### DIFF
--- a/bin/dfx-network-stop
+++ b/bin/dfx-network-stop
@@ -19,7 +19,7 @@ if [[ "$DFX_NETWORK" == "local" ]]; then
   echo "Waiting for replica to stop..."
   for ((i = 100; i > 0; i--)); do
     printf '\r % 4d' "$i"
-    pgrep replica 2>/dev/null || break
+    pgrep -x replica 2>/dev/null || break
     sleep 1
   done
   printf "\n...stopped.\n"

--- a/bin/dfx-snapshot-stock-make
+++ b/bin/dfx-snapshot-stock-make
@@ -21,7 +21,7 @@ clap.define long=unique_logo desc="A flag to use an config-index-based pseudo-un
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
-if pgrep replica; then
+if pgrep -x replica; then
   echo "❌ A replica is already running. Stop it before creating a snapshot."
   exit 1
 fi


### PR DESCRIPTION
A script runs `pgrep -l replica` to check for replica processes, but it can't receive false positives from a process called `replicatord`.

Eg:

```sh
$ pgrep -l replica
781 replicatord
95113 replica
```

This change allowed me to run it without issues. I also tried to start a second snapshot, and it correctly informed me that a replica was already running.

Related to https://github.com/dfinity/nns-dapp/pull/5732