### PR TITLE
Check webserver-port instead of replica-port in dfx-network-provider

### DIFF
--- a/bin/dfx-network-provider
+++ b/bin/dfx-network-provider
@@ -33,7 +33,7 @@ url)
     WEBSERVER_PORT="$(dfx info webserver-port 2>/dev/null || true)"
     [[ "${WEBSERVER_PORT:-}" != "" ]] || {
       # The above command can fail if not run in the same directory as the replica working directory.
-      DFX_EXEC_DIR="$(lsof -p $(pgrep pocket-ic | head -1) | grep cwd | awk '{print $NF}')"
+      DFX_EXEC_DIR="$(lsof -p "$(pgrep pocket-ic | head -1)" | grep cwd | awk '{print $NF}')"
       cd "$DFX_EXEC_DIR"
       WEBSERVER_PORT="$(HOME="$(get_home)" dfx info webserver-port)"
     }

--- a/bin/dfx-network-provider
+++ b/bin/dfx-network-provider
@@ -30,14 +30,14 @@ get_home() {
 case "${FORMAT}" in
 url)
   if [[ "$DFX_NETWORK" == "local" ]]; then
-    REPLICA_PORT="$(dfx info replica-port 2>/dev/null || true)"
-    [[ "${REPLICA_PORT:-}" != "" ]] || {
+    WEBSERVER_PORT="$(dfx info webserver-port 2>/dev/null || true)"
+    [[ "${WEBSERVER_PORT:-}" != "" ]] || {
       # The above command can fail if not run in the same directory as the replica working directory.
-      DFX_EXEC_DIR="$(lsof -p $(pgrep pocket-ic) | grep cwd | awk '{print $NF}')"
+      DFX_EXEC_DIR="$(lsof -p $(pgrep pocket-ic | head -1) | grep cwd | awk '{print $NF}')"
       cd "$DFX_EXEC_DIR"
-      REPLICA_PORT="$(HOME="$(get_home)" dfx info replica-port)"
+      WEBSERVER_PORT="$(HOME="$(get_home)" dfx info webserver-port)"
     }
-    echo "http://localhost:$REPLICA_PORT"
+    echo "http://localhost:$WEBSERVER_PORT"
   elif [[ "${DFX_NETWORK:-}" =~ mainnet|ic ]]; then
     echo "https://ic0.app"
   else


### PR DESCRIPTION
# Motivation

When using `ic-admin` you need to provide an `--nns-url`.
In snsdemo we use the script `dfx-network-provider` to create this URL.
It uses the dfx `replica-port` for this URL.
But when using PocketIC, you need to use the `webserver-port` instead of the `replica-port` and when not using PocketIC, both seem to work.
So to be ready to start using PocketIC, we should use the `webserver-port`.

Also it currently uses `pgrep pocket-ic` to find a process that was started by `dfx start`. This works even when starting `dfx` without `--pocketic` because it already uses PocketIC as the gateway even if it's not used to replace the replica.
When `dfx start` will be called with `--pocketic` there will actually be multiple PocketIC processes so we need to pick one of the PIDs.

# Changes

1. Use `dfx info webserver-port` instead of `dfx info replica-port` in `dfx-network-provider`
2. Add `| head -1` after `pgrep pocket-ic` to get a single PID.

# Tests

1. Tested manually to use PocketIC locally.
2. Still works on CI without PocketIC.