### PR TITLE
Use PocketIC in snsdemo

### DIFF
--- a/bin/dfx-network-deploy
+++ b/bin/dfx-network-deploy
@@ -54,7 +54,7 @@ if [[ "$DFX_NETWORK" == "local" ]]; then
     tput setaf 0
   )"
   export NORMAL="$(tput sgr0)"
-  dfx start --clean --background 2>&1 | sed -e "s@.*@${DARK}&${NORMAL}@" &
+  dfx start --clean --pocketic --background 2>&1 | sed -e "s@.*@${DARK}&${NORMAL}@" &
 
   dfx-nns-install --ic_commit "$DFX_IC_COMMIT"
   dfx-nns-import --network "$DFX_NETWORK"

--- a/bin/dfx-snapshot-restore
+++ b/bin/dfx-snapshot-restore
@@ -27,7 +27,7 @@ pushd "$HOME"
 rm -fr .local/share/dfx/network/local
 tar --extract --xz --file "$DFX_SNAPSHOT_FILE"
 # Note: dfx start works here but not in the project dir.
-dfx start --background
+dfx start --pocketic --background
 num_canisters="$(curl -s "http://localhost:$(dfx info webserver-port)/_/dashboard" | grep -c '<h3>Execution state</h3>')"
 echo "Approx num canisters: $num_canisters"
 popd

--- a/bin/dfx-snapshot-stock-make
+++ b/bin/dfx-snapshot-stock-make
@@ -43,9 +43,6 @@ dfxvm default "$(jq -r .dfx dfx.json)"
 : Create stock state
 dfx-stock-deploy --ic_commit "$DFX_IC_COMMIT" --ic_dir "$IC_REPO_DIR" --parallel_sns_count "$PARALLEL_SNS_COUNT" --unique_logo "$UNIQUE_LOGO"
 
-: "Wait for a checkpoint"
-dfx-network-wait-for-checkpoint --timeout 600
-
 : "Stop the replica gently but forcefully.  It must be stopped and should ideally have a clean state."
 dfx-network-stop
 


### PR DESCRIPTION
# Motivation

Using PocketIC will eventually be the default, and then the only option, with `dfx start`.
But using it sooner will help with being able to control SNS canisters and making them run out of cycles in the test environment.

# Changes

1. Pass `--pocketic` when starting dfx to create a snapshot.
2. Using `--pocketic` when starting dfx to run a snapshot.
3. Stop waiting for a checkpoint. PocketIC will write a checkpoint when it's being stopped. And waiting for one earlier will just time out.

# Tests

Tested manually starting the snsdemo snapshot from nns-dapp on Mac and Linux.