### PR TITLE
Rename btc kyt canister

### DIFF
--- a/bin/dfx-ckbtc-deploy
+++ b/bin/dfx-ckbtc-deploy
@@ -57,7 +57,7 @@ deploy_ckbtc() {
   dfx deploy "${LOCAL_PREFIX}kyt" --network "$DFX_NETWORK" --argument "(variant {
   InitArg = record {
       btc_network = variant { mainnet };
-      kyt_mode = variant { AcceptAll };
+      check_mode = variant { AcceptAll };
   }
 })" --mode="${DFX_MODE}" ${DFX_YES:+--yes} --upgrade-unchanged
 

--- a/bin/dfx-ckbtc-deploy
+++ b/bin/dfx-ckbtc-deploy
@@ -72,7 +72,7 @@ deploy_ckbtc() {
        min_confirmations = opt 12;
        mode = variant { GeneralAvailability };
        kyt_fee = opt 13_333;
-       kyt_principal = opt principal \"$KYT_ID\";
+       btc_checker_principal = opt principal \"$KYT_ID\";
    }
 })" --mode="${DFX_MODE}" ${DFX_YES:+--yes} --upgrade-unchanged
 

--- a/bin/dfx-ckbtc-import
+++ b/bin/dfx-ckbtc-import
@@ -58,7 +58,7 @@ ckbtc_import() {
     echo "Getting  $local_path from $url..."
     curl -fsSL "$url" | gunzip >"${local_path}"
   }
-  get_wasm ic-btc-kyt.wasm "${LOCAL_PREFIX}kyt"
+  get_wasm ic-btc-checker.wasm "${LOCAL_PREFIX}kyt"
   get_wasm ic-ckbtc-minter.wasm "${LOCAL_PREFIX}minter"
   get_wasm ic-icrc1-ledger.wasm "${LOCAL_PREFIX}ledger"
   get_wasm ic-icrc1-index-ng.wasm "${LOCAL_PREFIX}index"
@@ -74,7 +74,7 @@ ckbtc_import() {
     echo "Getting  $local_path from $url..."
     curl -sSLf --retry 5 "$url" -o "$local_path"
   }
-  get_did rs/bitcoin/kyt/btc_kyt_canister.did "${LOCAL_PREFIX}kyt"
+  get_did rs/bitcoin/checker/btc_checker_canister.did "${LOCAL_PREFIX}kyt"
   get_did rs/bitcoin/ckbtc/minter/ckbtc_minter.did "${LOCAL_PREFIX}minter"
   get_did rs/ledger_suite/icrc1/ledger/ledger.did "${LOCAL_PREFIX}ledger"
   get_did rs/ledger_suite/icrc1/index-ng/index-ng.did "${LOCAL_PREFIX}index"

--- a/bin/dfx-software-ic-latest
+++ b/bin/dfx-software-ic-latest
@@ -21,7 +21,7 @@ function downloads_exist() {
       "binaries/x86_64-linux/ic-admin.gz" \
       "binaries/x86_64-linux/sns.gz" \
       "canisters/bitcoin-mock-canister.wasm.gz" \
-      "canisters/ic-btc-kyt.wasm.gz" \
+      "canisters/ic-btc-checker.wasm.gz" \
       "canisters/ic-ckbtc-minter.wasm.gz" \
       "canisters/ic-icrc1-index-ng-u256.wasm.gz" \
       "canisters/ic-icrc1-index-ng.wasm.gz" \

--- a/bin/versions.bash
+++ b/bin/versions.bash
@@ -2,7 +2,7 @@
 # shellcheck disable=SC2034 # Variables are expected to be unused in this file
 # Release from 2024-05-02 which includes nervous_system_parameters.
 SNS_AGGREGATOR_RELEASE=proposal-129614-agg
-DFX_IC_COMMIT=9f5674ce6ba13379b24d2e49663d6dae087ae247
+DFX_IC_COMMIT=b937ba1951780e1b64878af21f3f1f27ae21709a
 INTERNET_IDENTITY_RELEASE=release-2023-10-27
 NNS_DAPP_RELEASE=proposal-133373
 DIDC_VERSION=2023-07-25


### PR DESCRIPTION
# Motivation

The IC commit wasn't updating past `9f5674ce6ba13379b24d2e49663d6dae087ae247` because it couldn't find `canisters/ic-btc-kyt.wasm.gz` because it was renamed in https://github.com/dfinity/ic/pull/2966

# Changes

1. Update IC commit
2. Rename kyt to checker.

# Tests

CI passes