### PR TITLE
Provide num_subnet_nodes to bitcoin ckbtc_kyt

### DIFF
--- a/bin/dfx-ckbtc-deploy
+++ b/bin/dfx-ckbtc-deploy
@@ -58,7 +58,7 @@ deploy_ckbtc() {
   InitArg = record {
       btc_network = variant { mainnet };
       check_mode = variant { AcceptAll };
-      num_subnet_nodes = opt 1;
+      num_subnet_nodes = 1;
   }
 })" --mode="${DFX_MODE}" ${DFX_YES:+--yes} --upgrade-unchanged
 

--- a/bin/dfx-ckbtc-deploy
+++ b/bin/dfx-ckbtc-deploy
@@ -58,6 +58,7 @@ deploy_ckbtc() {
   InitArg = record {
       btc_network = variant { mainnet };
       check_mode = variant { AcceptAll };
+      num_subnet_nodes = opt 1;
   }
 })" --mode="${DFX_MODE}" ${DFX_YES:+--yes} --upgrade-unchanged
 

--- a/bin/versions.bash
+++ b/bin/versions.bash
@@ -2,7 +2,7 @@
 # shellcheck disable=SC2034 # Variables are expected to be unused in this file
 # Release from 2024-05-02 which includes nervous_system_parameters.
 SNS_AGGREGATOR_RELEASE=proposal-129614-agg
-DFX_IC_COMMIT=bdb7c71b590e33040fa721eac1936ab108a65a96
+DFX_IC_COMMIT=76a634c31dfb840da25fbe286855eb0be1818ca8
 INTERNET_IDENTITY_RELEASE=release-2023-10-27
 NNS_DAPP_RELEASE=proposal-133373
 DIDC_VERSION=2023-07-25


### PR DESCRIPTION
# Motivation

[Updating the IC commit](https://github.com/dfinity/snsdemo/pull/437) [failed](https://github.com/dfinity/snsdemo/actions/runs/12541516365/job/34970180020?pr=437) with
```
Error: Failed while trying to deploy canisters.
Caused by: Failed while trying to install all canisters.
Caused by: Failed to install wasm module to canister 'ckbtc_kyt'.
Caused by: Failed to create argument blob.
Caused by: Invalid data: Unable to serialize Candid values: Invalid data: Unable to serialize Candid values: record field num_subnet_nodes not found
```
because https://github.com/dfinity/ic/pull/3056 added a new required field in the init arguments of the bitcoin checker.

# Changes

1. Update the pinned IC commit hash.
2. Provide `num_subnet_nodes` in the install args of the KYT/checker canister.

# Tested

Creating a snapshot fails after updating the IC commit hash but works again after specifying the `num_subnet_nodes`.