### PR TITLE
Add BOT_APPROVED_FILES

### DIFF
--- a/.github/repo_policies/BOT_APPROVED_FILES
+++ b/.github/repo_policies/BOT_APPROVED_FILES
@@ -1,0 +1,3 @@
+bin/versions.bash
+dfx.json
+dfx.json.original

--- a/.github/workflows/update-dfx.yml
+++ b/.github/workflows/update-dfx.yml
@@ -41,7 +41,7 @@ jobs:
             echo An update is available for dfx.
             git diff
             echo "updated=1" >> "$GITHUB_OUTPUT"
-            echo "title=Update dfx to version $latest_dfx_version" >> "$GITHUB_OUTPUT"
+            echo "title=bot: Update dfx to version $latest_dfx_version" >> "$GITHUB_OUTPUT"
           else
             echo "updated=0" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/update-ic.yml
+++ b/.github/workflows/update-ic.yml
@@ -64,7 +64,7 @@ jobs:
           author: gix-bot <gix-bot@users.noreply.github.com>
           branch: bot-ic-update
           delete-branch: true
-          title: 'Update IC commit'
+          title: 'bot: Update IC commit'
           # Since the this is a scheduled job, a failure won't be shown on any
           # PR status. To notify the team, we send a message to our Slack channel on failure.
       - name: Notify Slack on failure


### PR DESCRIPTION
# Motivation

Starting soon, files changed by bots must be listed in `.github/repo_policies/BOT_APPROVED_FILES`.

# Changes

1. I looked at recent PRs made by bots and added the files changed by them to `.github/repo_policies/BOT_APPROVED_FILES`.
2. Made bot PRs easier to spot in the future by prepending "bot: " to their titles, like we do in nns-dapp.