### PR TITLE
Fail if no new IC commit

### DIFF
--- a/.github/workflows/update-ic.yml
+++ b/.github/workflows/update-ic.yml
@@ -46,13 +46,12 @@ jobs:
             awk -v version="$latest_ic_commit" -F= 'BEGIN{IFS=OFS="="}($1=="DFX_IC_COMMIT"){$2=version}{print}' bin/versions.bash |  sponge bin/versions.bash
             echo An new IC commit is available.
             git diff
-            echo "updated=1" >> "$GITHUB_OUTPUT"
           else
-            echo "updated=0" >> "$GITHUB_OUTPUT"
+            echo "No new IC commit available since $current_ic_commit." >&2
+            exit 1
           fi
         # If a newer commit is available, create a PR.
       - name: Create Pull Request
-        if: ${{ steps.update.outputs.updated == '1' }}
         uses: peter-evans/create-pull-request@v4
         with:
           token: ${{ steps.app-token.outputs.token }}

--- a/bin/dfx-software-ic-latest
+++ b/bin/dfx-software-ic-latest
@@ -29,8 +29,11 @@ function downloads_exist() {
       "canisters/ic-icrc1-ledger.wasm.gz" \
       "canisters/sns-wasm-canister.wasm.gz"; do
 
-      curl --location --output /dev/null --silent --head --fail \
-        "https://download.dfinity.systems/ic/${GIT_REVISION}/$file" || exit 1
+      if ! curl --location --output /dev/null --silent --head --fail \
+        "https://download.dfinity.systems/ic/${GIT_REVISION}/$file"; then
+        echo "File $file does not exist for revision $GIT_REVISION" >&2
+        exit 1
+      fi
     done
 
     # Syncing to the public repo may be slow


### PR DESCRIPTION
# Motivation

It's very unlikely there will not be a new commit on the IC repo for a week.
So if we try to update the IC commit in snsdemo and there is no newer commit that supports all the necessary downloads, it's probably because one of the downloads moved or is broken and we should look into it.

# Changes

1. When finding the latest IC commit, output which downloads are not available for skipped IC commits.
2. When there is no new IC commit, fail the workflow so that we get a message on Slack.

# Tested

Ran [here](https://github.com/dfinity/snsdemo/actions/runs/12865338979/job/35865653929), resulting in [this slack message](https://dfinity.slack.com/archives/C05G2RZFJAJ/p1737366787388989).