### PR TITLE
Use unique branch for update-ic bot PRs

### DIFF
--- a/.github/workflows/update-ic.yml
+++ b/.github/workflows/update-ic.yml
@@ -62,6 +62,7 @@ jobs:
           committer: GitHub <noreply@github.com>
           author: gix-bot <gix-bot@users.noreply.github.com>
           branch: bot-ic-update
+          branch-suffix: timestamp
           delete-branch: true
           title: 'bot: Update IC commit'
           # Since the this is a scheduled job, a failure won't be shown on any


### PR DESCRIPTION
# Motivation

Reusing the same branch for different PRs can be confusing when the previous PR is not merged before the next PR is created.

# Changes

Use `branch-suffix: timestamp` to always use a unique branch name for `update-ic` bot PRs.

# Tested

Not tested. We already use this in many places ([example](https://github.com/dfinity/nns-dapp/blob/89a0cd36a6de95703e8f1487a2b6548974114430/.github/workflows/update-rust.yml#L76C11-L76C35)) so I'm assuming it will work.