### PR TITLE
Use webserver-port instead of replica-port

### DIFF
--- a/bin/dfx-snapshot-restore
+++ b/bin/dfx-snapshot-restore
@@ -28,7 +28,7 @@ rm -fr .local/share/dfx/network/local
 tar --extract --xz --file "$DFX_SNAPSHOT_FILE"
 # Note: dfx start works here but not in the project dir.
 dfx start --background
-num_canisters="$(curl -s "http://localhost:$(dfx info replica-port)/_/dashboard" | grep -c '<h3>Execution state</h3>')"
+num_canisters="$(curl -s "http://localhost:$(dfx info webserver-port)/_/dashboard" | grep -c '<h3>Execution state</h3>')"
 echo "Approx num canisters: $num_canisters"
 popd
 rm -fr .dfx

--- a/bin/dfx-state-install
+++ b/bin/dfx-state-install
@@ -28,7 +28,7 @@ rm -fr .local/share/dfx
 unzip -q "$DFX_SNAPSHOT_FILE"
 # Note: dfx start works here but not in the project dir.
 dfx start --background
-num_canisters="$(curl -s "http://localhost:$(dfx info replica-port)/_/dashboard" | grep -c '<h3>Execution state</h3>')"
+num_canisters="$(curl -s "http://localhost:$(dfx info webserver-port)/_/dashboard" | grep -c '<h3>Execution state</h3>')"
 echo "Approx num canisters: $num_canisters"
 popd
 rm -fr .dfx


### PR DESCRIPTION
# Motivation

It seems to be that when running a local replica with `dfx` you can reach the webserver on the replica port (which you get with `dfx info replica-port`).
But when using PocketIC (with `dfx start --pocketic`) you need to use the webserver port (which you get with `dfx info webserver-port`) explicitly.

So in preparation to using dfx with PocketIC, we should switch to using `webserver-port`.

# Changes

1. Use `dfx info webserver-port` instead of `dfx info replica-port` when we are trying to connect to the webserver.

# Tested

1. CI still passes
2. When trying `--pocketic` locally, this change was necessary to make it work.