### PR TITLE
Install pinned version of nns extension

### DIFF
--- a/bin/dfx-nns-install
+++ b/bin/dfx-nns-install
@@ -25,7 +25,7 @@ clap.define short=c long=ic_commit desc="The IC commit of the wasms" variable=DF
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
-"$SOURCE_DIR/dfx-software-dfx-extension-nns-install" --if-not-installed
+"$SOURCE_DIR/dfx-software-dfx-extension-nns-install" --version pinned
 
 WASMS_DIR="$(dfx cache show)/wasms"
 mkdir -p "$WASMS_DIR"


### PR DESCRIPTION
# Motivation

We need the newest version of the nns extension to be able to freeze SNSes.
Currently `dfx-nns-install` makes sure the extension is installed, but if it's already installed it leaves it at the current version.

# Changes

1. Make sure the pinned version of the nns extension is installed by passing `--version pinned` instead of `--if-not-installed`.

# Tested

1. Manually, freezing SNS canisters didn't work because I still had an older version of the extension. After this change I saw it correctly update the extension and I was able to freeze SNS canisters.