### PR TITLE
Check for pocket-ic process

### DIFF
--- a/bin/dfx-network-stop
+++ b/bin/dfx-network-stop
@@ -19,7 +19,7 @@ if [[ "$DFX_NETWORK" == "local" ]]; then
   echo "Waiting for replica to stop..."
   for ((i = 100; i > 0; i--)); do
     printf '\r % 4d' "$i"
-    pgrep -x replica 2>/dev/null || break
+    pgrep -x pocket-ic 2>/dev/null || break
     sleep 1
   done
   printf "\n...stopped.\n"

--- a/bin/dfx-snapshot-stock-make
+++ b/bin/dfx-snapshot-stock-make
@@ -21,7 +21,7 @@ clap.define long=unique_logo desc="A flag to use an config-index-based pseudo-un
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
-if pgrep -x replica; then
+if pgrep -x pocket-ic; then
   echo "❌ A replica is already running. Stop it before creating a snapshot."
   exit 1
 fi


### PR DESCRIPTION
# Motivation

In some places we check if a replica is running. Now that we switched to PocketIC, we should check if `pocket-ic` is running.

# Changes

Change `pgrep -x replica` to `pgrep -x pocket-ic`

# Tested

Tried to run `bin/dfx-snapshot-stock-make` while creating a snapshot and saw the `A replica is already running.` warning. While previously it just killed the other snapshot.
