### PR TITLE
Make pocket-ic optional

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install dependencies
         run: ./bin/dfx-sns-demo-install --verbose
       - name: Run the demo with the current default ic commits
-        run: bin/dfx-sns-demo --config_index 0
+        run: bin/dfx-sns-demo --config_index 0 --pocketic
       - name: Create and finalize an additional SNS
         run: |
           ./bin/dfx-sns-demo-mksns --config_index 1
@@ -85,7 +85,7 @@ jobs:
           fetch-depth: 100
           path: ic
       - name: Run the demo with the latest repo
-        run: bin/dfx-sns-demo --ic_commit latest --ic_dir ic --config_index 0
+        run: bin/dfx-sns-demo --ic_commit latest --ic_dir ic --config_index 0 --pocketic
       - name: Create and finalize an additional SNS
         run: |
           ./bin/dfx-sns-demo-mksns --config_index 1

--- a/bin/dfx-network-deploy
+++ b/bin/dfx-network-deploy
@@ -26,6 +26,7 @@ clap.define short=c long=commit desc="The IC commit of the wasms" variable=DFX_I
 )"
 clap.define short=x long=ic_dir desc="Directory containing the ic source code" variable=IC_REPO_DIR default="$HOME/dfn/ic"
 clap.define short=y long=nd_dir desc="Directory containing the nns-dapp source code" variable=ND_REPO_DIR default="$HOME/dfn/nns-dapp"
+clap.define long=pocketic desc="Whether to start dfx with --pocketic" variable=USE_POCKET_IC nargs=0 default=false
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
@@ -54,7 +55,11 @@ if [[ "$DFX_NETWORK" == "local" ]]; then
     tput setaf 0
   )"
   export NORMAL="$(tput sgr0)"
-  dfx start --clean --pocketic --background 2>&1 | sed -e "s@.*@${DARK}&${NORMAL}@" &
+  POCKET_IC_ARG=()
+  if [[ "${USE_POCKET_IC:-}" == "true" ]]; then
+    POCKET_IC_ARG=(--pocketic)
+  fi
+  dfx start --clean "${POCKET_IC_ARG[@]}" --background 2>&1 | sed -e "s@.*@${DARK}&${NORMAL}@" &
 
   dfx-nns-install --ic_commit "$DFX_IC_COMMIT"
   dfx-nns-import --network "$DFX_NETWORK"

--- a/bin/dfx-network-provider
+++ b/bin/dfx-network-provider
@@ -33,7 +33,7 @@ url)
     WEBSERVER_PORT="$(dfx info webserver-port 2>/dev/null || true)"
     [[ "${WEBSERVER_PORT:-}" != "" ]] || {
       # The above command can fail if not run in the same directory as the replica working directory.
-      DFX_EXEC_DIR="$(lsof -p "$(pgrep pocket-ic | head -1)" | grep cwd | awk '{print $NF}')"
+      DFX_EXEC_DIR="$(lsof -p "$(pgrep -x pocket-ic || pgrep -x replica | head -1)" | grep cwd | awk '{print $NF}')"
       cd "$DFX_EXEC_DIR"
       WEBSERVER_PORT="$(HOME="$(get_home)" dfx info webserver-port)"
     }

--- a/bin/dfx-network-stop
+++ b/bin/dfx-network-stop
@@ -19,7 +19,7 @@ if [[ "$DFX_NETWORK" == "local" ]]; then
   echo "Waiting for replica to stop..."
   for ((i = 100; i > 0; i--)); do
     printf '\r % 4d' "$i"
-    pgrep -x pocket-ic 2>/dev/null || break
+    pgrep -x pocket-ic || pgrep -x replica 2>/dev/null || break
     sleep 1
   done
   printf "\n...stopped.\n"

--- a/bin/dfx-snapshot-restore
+++ b/bin/dfx-snapshot-restore
@@ -18,6 +18,7 @@ help_text() {
 source "$SOURCE_DIR/clap.bash"
 # Define options
 clap.define short=s long=snapshot desc="The file to save to" variable=DFX_SNAPSHOT_FILE default="state.tar.xz"
+clap.define long=pocketic desc="Whether to start dfx with --pocketic" variable=USE_POCKET_IC nargs=0 default=false
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
@@ -26,8 +27,12 @@ DFX_SNAPSHOT_FILE="$(realpath "$DFX_SNAPSHOT_FILE")"
 pushd "$HOME"
 rm -fr .local/share/dfx/network/local
 tar --extract --xz --file "$DFX_SNAPSHOT_FILE"
+POCKET_IC_ARG=()
+if [[ "${USE_POCKET_IC:-}" == "true" ]]; then
+  POCKET_IC_ARG=(--pocketic)
+fi
 # Note: dfx start works here but not in the project dir.
-dfx start --pocketic --background
+dfx start "${POCKET_IC_ARG[@]}" --background
 num_canisters="$(curl -s "http://localhost:$(dfx info webserver-port)/_/dashboard" | grep -c '<h3>Execution state</h3>')"
 echo "Approx num canisters: $num_canisters"
 popd

--- a/bin/dfx-snapshot-stock-make
+++ b/bin/dfx-snapshot-stock-make
@@ -41,18 +41,20 @@ trap onSetupFailure EXIT
 : "Make sure the snapshot is used with the same version of dfx that created it."
 dfxvm default "$(jq -r .dfx dfx.json)"
 
-: Create stock state
 POCKET_IC_ARG=()
 if [[ "${USE_POCKET_IC:-}" == "true" ]]; then
   POCKET_IC_ARG=(--pocketic)
 fi
+
+: Create stock state
 dfx-stock-deploy --ic_commit "$DFX_IC_COMMIT" --ic_dir "$IC_REPO_DIR" --parallel_sns_count "$PARALLEL_SNS_COUNT" --unique_logo "$UNIQUE_LOGO" "${POCKET_IC_ARG[@]}"
 
 if [[ "${USE_POCKET_IC:-}" == "false" ]]; then
   : "Wait for a checkpoint"
-  dfx-network-wait-for-checkpoint --timeout 600: "Stop the replica gently but forcefully.  It must be stopped and should ideally have a clean state."
+  dfx-network-wait-for-checkpoint --timeout 600
 fi
 
+: "Stop the replica gently but forcefully.  It must be stopped and should ideally have a clean state."
 dfx-network-stop
 
 : "We made it. Remove the trap."

--- a/bin/dfx-snapshot-stock-make
+++ b/bin/dfx-snapshot-stock-make
@@ -18,10 +18,11 @@ clap.define short=c long=ic_commit desc="The IC commit to use" variable=DFX_IC_C
 clap.define short=x long=ic_dir desc="Directory containing the ic source code; needed for deployments to static testnets" variable=IC_REPO_DIR default="$HOME/dfn/ic"
 clap.define long=parallel_sns_count desc="Number of additional SNSes to create in parallel after dfx-sns-demo finishes" variable=PARALLEL_SNS_COUNT default="10"
 clap.define long=unique_logo desc="A flag to use an config-index-based pseudo-unique logo instead of the default logo." variable=UNIQUE_LOGO default=false
+clap.define long=pocketic desc="Whether to start dfx with --pocketic" variable=USE_POCKET_IC nargs=0 default=false
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
-if pgrep -x pocket-ic; then
+if pgrep -x pocket-ic || pgrep -x replica; then
   echo "❌ A replica is already running. Stop it before creating a snapshot."
   exit 1
 fi
@@ -41,9 +42,17 @@ trap onSetupFailure EXIT
 dfxvm default "$(jq -r .dfx dfx.json)"
 
 : Create stock state
-dfx-stock-deploy --ic_commit "$DFX_IC_COMMIT" --ic_dir "$IC_REPO_DIR" --parallel_sns_count "$PARALLEL_SNS_COUNT" --unique_logo "$UNIQUE_LOGO"
+POCKET_IC_ARG=()
+if [[ "${USE_POCKET_IC:-}" == "true" ]]; then
+  POCKET_IC_ARG=(--pocketic)
+fi
+dfx-stock-deploy --ic_commit "$DFX_IC_COMMIT" --ic_dir "$IC_REPO_DIR" --parallel_sns_count "$PARALLEL_SNS_COUNT" --unique_logo "$UNIQUE_LOGO" "${POCKET_IC_ARG[@]}"
 
-: "Stop the replica gently but forcefully.  It must be stopped and should ideally have a clean state."
+if [[ "${USE_POCKET_IC:-}" == "false" ]]; then
+  : "Wait for a checkpoint"
+  dfx-network-wait-for-checkpoint --timeout 600: "Stop the replica gently but forcefully.  It must be stopped and should ideally have a clean state."
+fi
+
 dfx-network-stop
 
 : "We made it. Remove the trap."

--- a/bin/dfx-sns-demo
+++ b/bin/dfx-sns-demo
@@ -14,6 +14,7 @@ clap.define short=x long=ic_dir desc="Directory containing the ic source code" v
 clap.define short=y long=nd_dir desc="Directory containing the nns-dapp source code" variable=ND_REPO_DIR default="$HOME/dfn/nns-dapp"
 clap.define long=config_index desc="The value for the dfx-sns-demo-mksns-config --config_index parameter" variable=CONFIG_INDEX default="0"
 clap.define long=unique_logo desc="A flag to use an config-index-based pseudo-unique logo instead of the default logo." variable=UNIQUE_LOGO default=false
+clap.define long=pocketic desc="Whether to start dfx with --pocketic" variable=USE_POCKET_IC nargs=0 default=false
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 set -x
@@ -54,7 +55,11 @@ fi
 dfx identity use snsdemo8
 
 sleep 1
-dfx-network-deploy --network "$DFX_NETWORK" --ic_dir "$IC_REPO_DIR" --nd_dir "$ND_REPO_DIR" --commit "$DFX_IC_COMMIT"
+POCKET_IC_ARG=()
+if [[ "${USE_POCKET_IC:-}" == "true" ]]; then
+  POCKET_IC_ARG=(--pocketic)
+fi
+dfx-network-deploy --network "$DFX_NETWORK" --ic_dir "$IC_REPO_DIR" --nd_dir "$ND_REPO_DIR" --commit "$DFX_IC_COMMIT" "${POCKET_IC_ARG[@]}"
 # Make sure that we use snsdemo8, in case the network deployment needed to change that.
 dfx identity use snsdemo8
 
@@ -80,7 +85,13 @@ sleep 1
 ./bin/dfx-sns-wasm-upload --network "$DFX_NETWORK"
 sleep 1
 
-./bin/dfx-sns-demo-mksns --network "$DFX_NETWORK" --config_index "$CONFIG_INDEX" --unique_logo "$UNIQUE_LOGO" --add_controller "$(dfx identity get-principal)"
+NEW_SNS_CONTROLLER="$(dfx identity get-principal)"
+ADD_CONTROLLER_ARG=()
+if [[ "${USE_POCKET_IC:-}" == "true" ]]; then
+  ADD_CONTROLLER_ARG=(--add_controller "$NEW_SNS_CONTROLLER")
+fi
+
+./bin/dfx-sns-demo-mksns --network "$DFX_NETWORK" --config_index "$CONFIG_INDEX" --unique_logo "$UNIQUE_LOGO" "${ADD_CONTROLLER_ARG[@]}"
 sleep 1
 ./bin/dfx-sns-sale-buy --network "$DFX_NETWORK"
 sleep 1

--- a/bin/dfx-stock-deploy
+++ b/bin/dfx-stock-deploy
@@ -46,8 +46,6 @@ dfx-mock-exchange-rate-set --network "$DFX_NETWORK" --base_asset ICP --quote_ass
 
 dfx-software-mock-bitcoin-install --network "$DFX_NETWORK" --ic_commit "$DFX_IC_COMMIT"
 
-set -x
-
 NEW_SNS_CONTROLLER="$(dfx identity get-principal)"
 ADD_CONTROLLER_ARG=()
 if [[ "${USE_POCKET_IC:-}" == "true" ]]; then

--- a/bin/dfx-stock-deploy
+++ b/bin/dfx-stock-deploy
@@ -24,6 +24,7 @@ clap.define short=x long=ic_dir desc="Directory containing the ic source code; n
 clap.define short=y long=nd_dir desc="Directory containing the nns-dapp source code; needed for deployments to static testnets" variable=ND_REPO_DIR default="$HOME/dfn/nns-dapp"
 clap.define long=parallel_sns_count desc="Number of additional SNSes to create in parallel after dfx-sns-demo finishes" variable=PARALLEL_SNS_COUNT default="10"
 clap.define long=unique_logo desc="A flag to use an config-index-based pseudo-unique logo instead of the default logo." variable=UNIQUE_LOGO default=false
+clap.define long=pocketic desc="Whether to start dfx with --pocketic" variable=USE_POCKET_IC nargs=0 default=false
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 set -x
@@ -34,21 +35,31 @@ if [[ "${DFX_IC_COMMIT:-}" == "latest" ]]; then
 fi
 
 : Set up SNS state and create one finalized SNS
-dfx-sns-demo --network "$DFX_NETWORK" --ic_commit "$DFX_IC_COMMIT" --ic_dir "$IC_REPO_DIR" --nd_dir "$ND_REPO_DIR" --unique_logo "$UNIQUE_LOGO"
+POCKET_IC_ARG=()
+if [[ "${USE_POCKET_IC:-}" == "true" ]]; then
+  POCKET_IC_ARG=(--pocketic)
+fi
+dfx-sns-demo --network "$DFX_NETWORK" --ic_commit "$DFX_IC_COMMIT" --ic_dir "$IC_REPO_DIR" --nd_dir "$ND_REPO_DIR" --unique_logo "$UNIQUE_LOGO" "${POCKET_IC_ARG[@]}"
 
 dfx-mock-exchange-rate-canister-install --network "$DFX_NETWORK" --release pinned
 dfx-mock-exchange-rate-set --network "$DFX_NETWORK" --base_asset ICP --quote_asset USD --rate_e8s 900_000_000
 
 dfx-software-mock-bitcoin-install --network "$DFX_NETWORK" --ic_commit "$DFX_IC_COMMIT"
 
+set -x
+
 NEW_SNS_CONTROLLER="$(dfx identity get-principal)"
+ADD_CONTROLLER_ARG=()
+if [[ "${USE_POCKET_IC:-}" == "true" ]]; then
+  ADD_CONTROLLER_ARG=(--add_controller "$NEW_SNS_CONTROLLER")
+fi
 
 : Add 1 open SNS project.
-dfx-sns-demo-mksns --network "$DFX_NETWORK" --confirmation_text "I confirm the confirmation text" --config_index 1 --unique_logo "$UNIQUE_LOGO" --add_controller "$NEW_SNS_CONTROLLER"
+dfx-sns-demo-mksns --network "$DFX_NETWORK" --confirmation_text "I confirm the confirmation text" --config_index 1 --unique_logo "$UNIQUE_LOGO" "${ADD_CONTROLLER_ARG[@]}"
 
 : Add some more finalized SNS projects.
 if [ "${PARALLEL_SNS_COUNT:-0}" -gt 0 ]; then
-  dfx-sns-demo-mksns-parallel --network "$DFX_NETWORK" --num_sns "$PARALLEL_SNS_COUNT" --majority snsdemo8 --config_index_offset 2 --unique_logo "$UNIQUE_LOGO" --add_controller "$NEW_SNS_CONTROLLER"
+  dfx-sns-demo-mksns-parallel --network "$DFX_NETWORK" --num_sns "$PARALLEL_SNS_COUNT" --majority snsdemo8 --config_index_offset 2 --unique_logo "$UNIQUE_LOGO" "${ADD_CONTROLLER_ARG[@]}"
 fi
 
 SNS_COUNT="$(dfx canister call nns-sns-wasm list_deployed_snses '(record{})' | idl2json | jq -r '.instances | length')"


### PR DESCRIPTION
# Motivation

When using a PocketIC snapshot on nns-dapp, e2e tests became flaky.
Especially the screenshot tests require a lot more time to settle before we can take a screenshot.
Until this can be fixed we shouldn't use PocketIC on nns-dapp CI yet.

# Changes

1. Add `--pocketic` flag which controls if the snapshot is made with `dfx start --pocketic`.
2. Don't try to add controllers to SNS canisters when not using PocketIC.
3. Wait for a checkpoint to be made if not running with PocketIC.
4. When checking if a snapshot is running, use both `pgrep -x replica` and `pgrep -x pocket-ic`.
5. Use `--pocketic` in `run.yml` to have some test coverage with PocketIC.

# Tested

1. Created snapshots with and without `--pocket`.
2. Used both snapshots.
3. Verified that they were with/without pocket-ic by running `jq .type ~/Library/Application\ Support/org.dfinity.dfx/network/local/replica-effective-config.json`.
