### PR TITLE
chore(test-data): add charlie as ongoing SNS swap

### DIFF
--- a/bin/dfx-sns-propose
+++ b/bin/dfx-sns-propose
@@ -16,7 +16,7 @@ source "$SOURCE_DIR/clap.bash"
 # Define options
 clap.define short=i long=identity desc="The dfx identity to use" variable=DFX_IDENTITY default="$(dfx identity whoami)"
 clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
-clap.define short=N long=neuron desc="The dfx network to use" variable=DFX_NEURON_ID default=""
+clap.define short=N long=neuron desc="The neuronId to use" variable=DFX_NEURON_ID default=""
 clap.define long=save-proposal-id-to desc="Passed to sns propose --save-to" variable=PROPOSAL_ID_FILE default=""
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"

--- a/bin/dfx-stock-deploy
+++ b/bin/dfx-stock-deploy
@@ -39,6 +39,8 @@ POCKET_IC_ARG=()
 if [[ "${USE_POCKET_IC:-}" == "true" ]]; then
   POCKET_IC_ARG=(--pocketic)
 fi
+
+# Creates Alfa
 dfx-sns-demo --network "$DFX_NETWORK" --ic_commit "$DFX_IC_COMMIT" --ic_dir "$IC_REPO_DIR" --nd_dir "$ND_REPO_DIR" --unique_logo "$UNIQUE_LOGO" "${POCKET_IC_ARG[@]}"
 
 dfx-mock-exchange-rate-canister-install --network "$DFX_NETWORK" --release pinned
@@ -52,16 +54,17 @@ if [[ "${USE_POCKET_IC:-}" == "true" ]]; then
   ADD_CONTROLLER_ARG=(--add_controller "$NEW_SNS_CONTROLLER")
 fi
 
-: Add 1 open SNS project.
+: Add 2 open SNS project.
 dfx-sns-demo-mksns --network "$DFX_NETWORK" --confirmation_text "I confirm the confirmation text" --config_index 1 --unique_logo "$UNIQUE_LOGO" "${ADD_CONTROLLER_ARG[@]}"
+dfx-sns-demo-mksns --network "$DFX_NETWORK" --confirmation_text "I confirm the confirmation text" --config_index 2 --unique_logo "$UNIQUE_LOGO" "${ADD_CONTROLLER_ARG[@]}"
 
 : Add some more finalized SNS projects.
 if [ "${PARALLEL_SNS_COUNT:-0}" -gt 0 ]; then
-  dfx-sns-demo-mksns-parallel --network "$DFX_NETWORK" --num_sns "$PARALLEL_SNS_COUNT" --majority snsdemo8 --config_index_offset 2 --unique_logo "$UNIQUE_LOGO" "${ADD_CONTROLLER_ARG[@]}"
+  dfx-sns-demo-mksns-parallel --network "$DFX_NETWORK" --num_sns "$PARALLEL_SNS_COUNT" --majority snsdemo8 --config_index_offset 3 --unique_logo "$UNIQUE_LOGO" "${ADD_CONTROLLER_ARG[@]}"
 fi
 
 SNS_COUNT="$(dfx canister call nns-sns-wasm list_deployed_snses '(record{})' | idl2json | jq -r '.instances | length')"
-EXPECTED_SNS_COUNT="$((2 + PARALLEL_SNS_COUNT))"
+EXPECTED_SNS_COUNT="$((3 + PARALLEL_SNS_COUNT))"
 if [[ "$SNS_COUNT" != "$EXPECTED_SNS_COUNT" ]]; then
   echo "❌ Expected $EXPECTED_SNS_COUNT SNSes. Found $SNS_COUNT"
   exit 1

--- a/bin/dfx-stock-test
+++ b/bin/dfx-stock-test
@@ -48,11 +48,11 @@ export DFX_NETWORK
 )
 
 (
-  print_title "sns_aggregator should have 12 SNSs"
-  # This means the second page should have 2 SNSs.
+  print_title "sns_aggregator should have 13 SNSs"
+  # This means the second page should have 3 SNSs.
   aggregator_url="http://$(dfx canister id sns_aggregator).localhost:8080/v1/sns/list/page/1/slow.json"
-  if [ "$(curl -fsS "$aggregator_url" | jq length)" != "2" ]; then
-    echo "ERROR: The aggragtor should have 12 SNSs." >&2
+  if [ "$(curl -fsS "$aggregator_url" | jq length)" != "3" ]; then
+    echo "ERROR: The aggragtor should have 13 SNSs." >&2
     exit 1
   fi
 )


### PR DESCRIPTION
# Motivation

We want to have a second on-going swap.

![Screenshot 2025-03-12 at 09 07 02](https://github.com/user-attachments/assets/07d301cc-27e2-4730-9305-d85b03bcf47f)

[NNS1-3637](https://dfinity.atlassian.net/browse/NNS1-3637)

## Changes

- Set Charlie as an ongoing swap.
- Updated tests to expect 13 SNSs instead of 12
- Fix typo on `bin/dfx-sns-propose`

[NNS1-3637]: https://dfinity.atlassian.net/browse/NNS1-3637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ