### PR TITLE
feat(scripts): add custom naming to neuron creation utility

### DIFF
--- a/bin/dfx-neuron-create
+++ b/bin/dfx-neuron-create
@@ -9,6 +9,7 @@ clap.define short=s long=icp desc="The amount of ICP to icp" variable=ICP defaul
 clap.define short=i long=DFX_IDENTITY desc="The dfx identity to use" variable=DFX_IDENTITY default="$(dfx identity whoami)"
 clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
 clap.define short=V long=verbose desc="Print progress" variable=DFX_VERBOSE nargs=0
+clap.define short=N long=name desc="The name of the neuron" variable=NEURON_NAME default="1"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 test -z "${DFX_VERBOSE:-}" || set -x
@@ -26,7 +27,7 @@ IC_URL="$("$SOURCE_DIR/dfx-network-url" --network "$DFX_NETWORK")"
 export IC_URL
 # Note: Quill send puts a pile of junk on stdout and has no option to put just the response(s) somewhere safe such as a file.
 
-command=(quill neuron-stake --insecure-local-dev-mode --pem-file "$PEM" --amount "$ICP" --name 1)
+command=(quill neuron-stake --insecure-local-dev-mode --pem-file "$PEM" --amount "$ICP" --name "$NEURON_NAME")
 MESSAGE="$("${command[@]}")"
 test -n "${MESSAGE:-}" || {
   echo "ERROR: Created an empty message."


### PR DESCRIPTION
# Motivation

In the context of testing https://github.com/dfinity/nns-dapp/pull/6590, we needed a method to create new proposals for establishing a new Sns.
These new proposals can be created using a combination of our existing scripts and dfx commands. However, they require a modification to `dfx-neuron-create` to allow for the creation of neurons with different names. This PR introduces a new variable in the script to specify a name. If no name is provided, it will function as it currently does.

These are the required commands: 
```sh
// Fund account
bin/dfx-ledger-get-icp --icp 90000000 --network local

// Create a new neuron
bin/dfx-neuron-create --icp 5000000 --network local --name 2

// List existing neurons and pick the latest
cat ~/.config/dfx/identity/snsdemo8/neurons/local

// Get neuron info - Check current dissolve delay
dfx canister --network=local call rrkah-fqaaa-aaaaa-aaaaq-cai get_neuron_info 

// Manage neuron
dfx canister --network=local call rrkah-fqaaa-aaaaa-aaaaq-cai manage_neuron
  // 1. Configure
  // 2. IncreaseDissolveDelay
  // 3. 31536000

// Open proposal
sns propose --neuron-id <neuronId> --skip-confirmation --network http://localhost:8080 sns.yml
```

[NNS1-3637](https://dfinity.atlassian.net/browse/NNS1-3637)

## Changes

- Exposes new argument `name` in `bin/dfx-neuron-create` to be able to create new neurons.

## Tests

- Tested in [devenv](https://qsgjb-riaaa-aaaaa-aaaga-cai.yhabib-ingress.devenv.dfinity.network/)

[NNS1-3637]: https://dfinity.atlassian.net/browse/NNS1-3637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ