### PR TITLE
chore(deps): update IC version and revert CI changes

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           ./bin/dfx-sns-demo-mksns-parallel -s 10 --config_index_offset 2 -m snsdemo8
   demo_latest:
-    if: false # Claim that snsdemo works with the latest IC repo commit (true) or acknowledge that it doesn't (false).
+    if: true # Claim that snsdemo works with the latest IC repo commit (true) or acknowledge that it doesn't (false).
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/bin/versions.bash
+++ b/bin/versions.bash
@@ -2,7 +2,7 @@
 # shellcheck disable=SC2034 # Variables are expected to be unused in this file
 # Release from 2024-05-02 which includes nervous_system_parameters.
 SNS_AGGREGATOR_RELEASE=proposal-136008-agg
-DFX_IC_COMMIT=5639c29fd72de16d483be7fe6dedc86e9bec3b9e
+DFX_IC_COMMIT=0d2d1e9d8ead709a9ab6523adc7e089aa01282c1
 INTERNET_IDENTITY_RELEASE=release-2023-10-27
 NNS_DAPP_RELEASE=proposal-135420
 DIDC_VERSION=2023-07-25


### PR DESCRIPTION
# Motivation

#491 fixed several related issues stemming from different upgrades of snsdemo. Additionally, it updated the IC version, though not to the latest, as that update was unsuccessful. To be able to merge #491 and unblock developers the demo_latest job was skipped.

The issue was introduced in IC, more info [here](https://dfinity.slack.com/archives/C0527QACNJC/p1748360228527179)

## Changes

- Reverted the change to the latest CI check
- Updated the IC version

## Tests

- Build snapshot in CI.
- Build snapshot locally.