### PR TITLE
ci(workflows): bump linux runners from ubuntu-22.04 to ubuntu-24.04

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 jobs:
   formatting:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       DFX_NETWORK: mainnet
 
@@ -73,7 +73,7 @@ jobs:
   shell-checks:
     needs: formatting
     name: ShellCheck
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Install apt-dependencies
         run: sudo apt-get update && sudo apt-get install moreutils -yy && command -v more
@@ -85,7 +85,7 @@ jobs:
   clap-checks:
     needs: formatting
     name: Clap checks
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Clap works
@@ -93,7 +93,7 @@ jobs:
   sns-aggregator-canister-checks:
     needs: formatting
     name: SNS aggregator tools
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Install apt-dependencies
@@ -121,7 +121,7 @@ jobs:
   ckbtc-checks:
     needs: formatting
     name: CKBTC tools
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Install apt-dependencies
         run: sudo apt-get update && sudo apt-get install moreutils -yy && command -v more
@@ -166,7 +166,7 @@ jobs:
   nns-dapp-canister-checks:
     needs: formatting
     name: NNS dapp tools
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: "Test the nns-dapp version command"
@@ -186,7 +186,7 @@ jobs:
   dfx-canister-url-checks:
     needs: formatting
     name: Canister URL checks
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Install apt-dependencies
         run: sudo apt-get update && sudo apt-get install moreutils -yy && command -v more
@@ -202,7 +202,7 @@ jobs:
           git clean -dfx
   other-tests:
     name: Other tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Install apt-dependencies

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -12,7 +12,7 @@ jobs:
   #    strategy:
   #      fail-fast: false
   #      matrix:
-  #        os: [ macos-14, ubuntu-22.04 ]
+  #        os: [ macos-14, ubuntu-24.04 ]
   #    steps:
   #      - name: Checkout
   #        uses: actions/checkout@v3
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, ubuntu-22.04]
+        os: [macos-14, ubuntu-24.04]
     steps:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
@@ -59,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, ubuntu-22.04]
+        os: [macos-14, ubuntu-24.04]
     steps:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-24.04]
     steps:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0


### PR DESCRIPTION
# Motivation

dfx 0.32.0 is built against glibc 2.38/2.39, but ubuntu-22.04 only ships glibc 2.35, so every linux job in #594 fails with `version 'GLIBC_2.39' not found`. Moving to ubuntu-24.04 (glibc 2.39) unblocks that PR.

# Changes

- Bumped all `runs-on: ubuntu-22.04` entries in `checks.yml` to `ubuntu-24.04`.
- Updated the `os` matrix in `run.yml` (both `demo_current` and `demo_latest`) to use `ubuntu-24.04`.
- Updated the `os` matrix in `snapshot.yml` to use `ubuntu-24.04`.