### PR TITLE
fix(ic): switch mac binary downloads to arm64-darwin, bump pinned IC commit, and fix ckbtc ledger init arg

### DIFF
--- a/bin/dfx-ckbtc-deploy
+++ b/bin/dfx-ckbtc-deploy
@@ -95,6 +95,7 @@ deploy_ckbtc() {
      };
      feature_flags = opt record {
          icrc2 = true;
+         icrc152 = false;
      };
  }
 })" --mode="$DFX_MODE" ${DFX_YES:+--yes} --upgrade-unchanged

--- a/bin/dfx-nns-wasm-download
+++ b/bin/dfx-nns-wasm-download
@@ -87,7 +87,7 @@ get_binary() {
   OS="$(uname)"
   case "$OS" in
   Darwin)
-    curl -fL "https://download.dfinity.systems/ic/${DFX_IC_COMMIT}/binaries/x86_64-darwin/${FILENAME}.gz" | gunzip >"$TMP_FILE"
+    curl -fL "https://download.dfinity.systems/ic/${DFX_IC_COMMIT}/binaries/arm64-darwin/${FILENAME}.gz" | gunzip >"$TMP_FILE"
     ;;
   Linux)
     curl -fL "https://download.dfinity.systems/ic/${DFX_IC_COMMIT}/binaries/x86_64-linux/${FILENAME}.gz" | gunzip >"$TMP_FILE"

--- a/bin/dfx-software-ic-install-executable
+++ b/bin/dfx-software-ic-install-executable
@@ -20,7 +20,7 @@ install_linux() {
   curl -fL "$URL" | gunzip | install -m 755 /dev/stdin "$USER_BIN/$EXEC_NAME"
 }
 install_darwin() {
-  URL="https://download.dfinity.systems/ic/${DFX_IC_COMMIT}/binaries/x86_64-darwin/${EXEC_NAME}.gz"
+  URL="https://download.dfinity.systems/ic/${DFX_IC_COMMIT}/binaries/arm64-darwin/${EXEC_NAME}.gz"
   echo "Downloading $URL"
   curl -fL "$URL" | gunzip >"$USER_BIN/$EXEC_NAME"
   chmod +x "$USER_BIN/$EXEC_NAME"

--- a/bin/dfx-software-ic-latest
+++ b/bin/dfx-software-ic-latest
@@ -16,8 +16,8 @@ function downloads_exist() {
     set -euo pipefail
 
     for file in \
-      "binaries/x86_64-darwin/ic-admin.gz" \
-      "binaries/x86_64-darwin/sns.gz" \
+      "binaries/arm64-darwin/ic-admin.gz" \
+      "binaries/arm64-darwin/sns.gz" \
       "binaries/x86_64-linux/ic-admin.gz" \
       "binaries/x86_64-linux/sns.gz" \
       "canisters/bitcoin-mock-canister.wasm.gz" \

--- a/bin/dfx-token-deploy
+++ b/bin/dfx-token-deploy
@@ -72,6 +72,7 @@ deploy_token() {
      };
      feature_flags = opt record {
          icrc2 = true;
+         icrc152 = false;
      };
  }
 })" --mode="$DFX_MODE" ${DFX_YES:+--yes} --upgrade-unchanged

--- a/bin/versions.bash
+++ b/bin/versions.bash
@@ -2,7 +2,7 @@
 # shellcheck disable=SC2034 # Variables are expected to be unused in this file
 # Release from 2024-05-02 which includes nervous_system_parameters.
 SNS_AGGREGATOR_RELEASE=proposal-138924-agg
-DFX_IC_COMMIT=ddb51a579f34b9843f6347df50b45e9ac20d21d9
+DFX_IC_COMMIT=14382b5abb14b8e7de2bd4a3fb402ba069b82861
 INTERNET_IDENTITY_RELEASE=release-2023-10-27
 NNS_DAPP_RELEASE=proposal-139084
 DIDC_VERSION=2023-07-25


### PR DESCRIPTION
# Motivation

dfinity stopped publishing IC build artifacts under `binaries/x86_64-darwin/` and now ships mac builds only under `binaries/arm64-darwin/`. The scheduled `Update IC` workflow ([example failing run](https://github.com/dfinity/snsdemo/actions/runs/26384070090)) has been failing because `dfx-software-ic-latest` requires `x86_64-darwin/ic-admin.gz` to exist, which 404s for every recent IC revision. The script switch and the pin bump need to land together: the previous pin (`ddb51a579f…`) only has `x86_64-darwin/` artifacts, while every newer IC commit only has `arm64-darwin/`. The newer IC also added a required `icrc152` bool to the ICRC-1 ledger `FeatureFlags` record, so the ckbtc ledger init arg has to set it too.

# Changes

- Switched the publish-existence check in `bin/dfx-software-ic-latest` from `x86_64-darwin` to `arm64-darwin` for `ic-admin.gz` and `sns.gz`.
- Switched the mac install path in `bin/dfx-software-ic-install-executable` from `x86_64-darwin` to `arm64-darwin`.
- Switched the mac download path in `bin/dfx-nns-wasm-download` from `x86_64-darwin` to `arm64-darwin`.
- Bumped `DFX_IC_COMMIT` in `bin/versions.bash` from `ddb51a579f…` to the current `dfinity/ic` master HEAD (`14382b5abb…`), which has all required arm64-darwin + x86_64-linux + canister artifacts.
- Added `icrc152 = false;` to the ckbtc ledger `feature_flags` init arg in `bin/dfx-ckbtc-deploy` to match the new `FeatureFlags` candid type.