### PR TITLE
ci: re-enable demo_latest job

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -53,8 +53,7 @@ jobs:
         run: |
           ./bin/dfx-sns-demo-mksns-parallel -s 10 --config_index_offset 2 -m snsdemo8
   demo_latest:
-    # TODO: Revert after the next IC release with the registry fix.
-    if: false # Claim that snsdemo works with the latest IC repo commit (true) or acknowledge that it doesn't (false).
+    if: true # Claim that snsdemo works with the latest IC repo commit (true) or acknowledge that it doesn't (false).
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
# Motivation

The `demo_latest` job has been gated off with `if: false` since #546 (2025-10-28), waiting on an upstream IC registry-init regression to be reverted. Flipping the gate back on as an experiment to see if the issue is gone with the current IC HEAD. If CI is still red, the PR will be closed and the gate left as-is.

# Changes

- Switched `demo_latest` from `if: false` to `if: true` in `.github/workflows/run.yml`.
- Removed the stale TODO comment about reverting after the IC registry fix.