### PR TITLE
fix(ckbtc): use key_1 ecdsa key name for dfx 0.32.0

### DIFF
--- a/bin/dfx-ckbtc-deploy
+++ b/bin/dfx-ckbtc-deploy
@@ -67,7 +67,7 @@ deploy_ckbtc() {
   Init = record {
        btc_network = variant { Mainnet };
        ledger_id = principal \"$LEDGERID\";
-       ecdsa_key_name = \"dfx_test_key\";
+       ecdsa_key_name = \"key_1\";
        retrieve_btc_min_amount = 13_333;
        max_time_in_queue_nanos = 10_000_000_000;
        min_confirmations = opt 12;


### PR DESCRIPTION
# Motivation

dfx 0.32.0 renamed the local threshold-ECDSA test key from `dfx_test_key` to `key_1`. The ckBTC minter is still deployed with `ecdsa_key_name = "dfx_test_key"`, so `get_btc_address` traps on `ecdsa_public_key` with `ChainKeyError: Requested unknown threshold key ecdsa:Secp256k1:dfx_test_key`. This breaks downstream consumers minting test ckBTC against the snapshot and blocks the nns-dapp dfx 0.32.0 bump (dfinity/nns-dapp#7903).

# Changes

- Switched the ckBTC minter `ecdsa_key_name` from `dfx_test_key` to `key_1` to match the key dfx 0.32.0 provides.

Closes #604