### PR TITLE
fix(sns): pass the network URL to the sns CLI when uploading SNS wasms

### DIFF
--- a/bin/dfx-sns-wasm-upload
+++ b/bin/dfx-sns-wasm-upload
@@ -16,13 +16,18 @@ source "$(clap.build)"
 
 SNS_WASM_CANISTER_ID="${SNS_WASM_CANISTER_ID:-$(dfx canister id nns-sns-wasm --network "$DFX_NETWORK" 2>/dev/null)}"
 
+# The sns CLI no longer resolves the network name "local" to the running
+# replica; it falls back to the dfx project default of 127.0.0.1:8000 whereas we
+# run on 127.0.0.1:8080.  Pass the network URL instead, as dfx-sns-propose does.
+DFX_NNS_URL="$("$SOURCE_DIR/dfx-network-provider" --network "$DFX_NETWORK")"
+
 jq <"$SOURCE_DIR/sns_dfx.json" -r '.canisters | to_entries | map("\(.value.config.nns_sns_wasm_name) \(.value.wasm)") | .[]' | while read -r line; do
   # shellcheck disable=SC2086 # We do actually want to split the line into fields.
   set $line
   UPLOAD_NAME="$1"
   WASM_FILE="wasms/$2"
   set "sns" add-sns-wasm-for-tests \
-    --network "$DFX_NETWORK" \
+    --network "$DFX_NNS_URL" \
     --override-sns-wasm-canister-id-for-tests "${SNS_WASM_CANISTER_ID}" \
     --wasm-file "$WASM_FILE" "$UPLOAD_NAME"
   echo "${@}"


### PR DESCRIPTION
# Motivation

The `sns` CLI shipped with the IC changed how it resolves the network name `local` somewhere between IC commits `cc1287f` (2026-07-06) and `ee35056` (2026-07-13). It no longer reads the shared `~/.config/dfx/networks.json`, where we bind `local` to `127.0.0.1:8080`, and uses the dfx project default `127.0.0.1:8000` instead. So every demo and snapshot job dies at `dfx-sns-wasm-upload` with:

```
Error: Failed to build agent for network `local` and identity `None`
Caused by:
    1: An error happened during communication with the replica: error sending request for url (http://127.0.0.1:8000/api/v2/status)
```

This blocks all the open IC update PRs (#610, #611, #612, #613) and `demo_latest` on main. `dfx-sns-propose` already passes a URL instead of a network name, so it was never affected.

# Changes

- Resolved the network URL with `dfx-network-provider` and passed it to `sns add-sns-wasm-for-tests` instead of the network name.
