### PR TITLE
fix(sns-aggregator): find the latest release by tag instead of a release window

### DIFF
--- a/bin/dfx-software-sns-aggregator-version
+++ b/bin/dfx-software-sns-aggregator-version
@@ -33,7 +33,11 @@ pinned)
   echo "$SNS_AGGREGATOR_RELEASE"
   ;;
 latest)
-  gh release list --exclude-drafts --exclude-pre-releases --limit 300 --repo dfinity/nns-dapp | grep -wEo 'proposal-[0-9]+-agg' | head -1
+  # Aggregator releases happen a couple of times a year but nns-dapp publishes
+  # nightlies, so the aggregator tags fall out of any fixed `gh release list`
+  # window after a few months.  List the matching tags instead and take the
+  # highest proposal number.
+  git ls-remote --tags https://github.com/dfinity/nns-dapp.git 'refs/tags/proposal-*-agg' | grep -wEo 'proposal-[0-9]+-agg' | sort -t- -k2,2n -u | tail -1
   ;;
 *)
   {


### PR DESCRIPTION
# Motivation

`dfx-software-sns-aggregator-version --latest` looked for `proposal-*-agg` in the newest 300 nns-dapp releases. nns-dapp publishes nightlies, so the last aggregator release (`proposal-138924-agg`, 2025-10-21) fell out of that window around mid-July 2026 and the command started returning nothing. That is the "SNS aggregator tools" check failing on #611, #612 and #613, and it has nothing to do with those PRs.

# Changes

- Switched the `latest` lookup to `git ls-remote --tags` filtered on `refs/tags/proposal-*-agg`, taking the highest proposal number, so there is no window to fall out of.
